### PR TITLE
feat: add conversation request and response models

### DIFF
--- a/conversation_service/api/__init__.py
+++ b/conversation_service/api/__init__.py
@@ -51,7 +51,7 @@ from .routes import (
 )
 
 # API Models for external use
-from ..models.conversation_models import (
+from ..models import (
     ConversationRequest,
     ConversationResponse,
     ConversationTurn,

--- a/conversation_service/api/dependencies.py
+++ b/conversation_service/api/dependencies.py
@@ -26,7 +26,7 @@ from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 
 from ..core.mvp_team_manager import MVPTeamManager
 from ..core.conversation_manager import ConversationManager
-from ..models.conversation_models import ConversationRequest, ConversationResponse
+from ..models import ConversationRequest, ConversationResponse
 from ..utils.metrics import MetricsCollector
 import os
 

--- a/conversation_service/api/routes.py
+++ b/conversation_service/api/routes.py
@@ -32,7 +32,7 @@ from .dependencies import (
 
 from ..core.mvp_team_manager import MVPTeamManager
 from ..core.conversation_manager import ConversationManager
-from ..models.conversation_models import ConversationRequest, ConversationResponse
+from ..models import ConversationRequest, ConversationResponse
 from ..utils.metrics import MetricsCollector
 import os
 

--- a/conversation_service/models/__init__.py
+++ b/conversation_service/models/__init__.py
@@ -12,6 +12,8 @@ Exports:
         - TeamWorkflow: Team workflow configuration
     
     Conversation Models:
+        - ConversationRequest: API request model
+        - ConversationResponse: API response model
         - ConversationTurn: Individual conversation turn
         - ConversationContext: Complete conversation context
     
@@ -45,7 +47,9 @@ from .agent_models import (
 # Import conversation models
 from .conversation_models import (
     ConversationTurn,
-    ConversationContext
+    ConversationContext,
+    ConversationRequest,
+    ConversationResponse
 )
 
 # Import financial models
@@ -87,6 +91,8 @@ __all__ = [
     "TeamWorkflow",
     
     # Conversation Models
+    "ConversationRequest",
+    "ConversationResponse",
     "ConversationTurn",
     "ConversationContext",
     


### PR DESCRIPTION
## Summary
- add `ConversationRequest` and `ConversationResponse` Pydantic models for chat API
- export new models through `conversation_service.models`
- update API modules to import models from package root

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_689856c116bc83208e3e1e22890a2289