### PR TITLE
Use initialize_agents in team manager dependency

### DIFF
--- a/conversation_service/api/dependencies.py
+++ b/conversation_service/api/dependencies.py
@@ -61,7 +61,7 @@ async def get_team_manager() -> MVPTeamManager:
         try:
             logger.info("Initializing MVPTeamManager singleton")
             _team_manager = MVPTeamManager()
-            await _team_manager.initialize()
+            await _team_manager.initialize_agents()
             logger.info("MVPTeamManager initialized successfully")
         except Exception as e:
             logger.error(f"Failed to initialize MVPTeamManager: {e}")


### PR DESCRIPTION
## Summary
- fix MVPTeamManager initialization call to use `initialize_agents`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68985c8156f08320b55e9717b230c07b