### PR TITLE
Remove await in metrics team performance call

### DIFF
--- a/conversation_service/api/routes.py
+++ b/conversation_service/api/routes.py
@@ -328,7 +328,7 @@ async def get_metrics(
         metrics_summary = metrics.get_summary()
         
         # Get team performance
-        team_performance = await team_manager.get_team_performance()
+        team_performance = team_manager.get_team_performance()
         
         # Compile comprehensive metrics
         comprehensive_metrics = {


### PR DESCRIPTION
## Summary
- call `MVPTeamManager.get_team_performance` synchronously in metrics endpoint

## Testing
- `flake8 conversation_service/api/routes.py` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests'; attempted `pip install requests` but proxy blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6898690aeb508320b11f19246821f14c