### PR TITLE
Fix validators import paths

### DIFF
--- a/conversation_service/utils/validators.py
+++ b/conversation_service/utils/validators.py
@@ -27,14 +27,14 @@ from pydantic import ValidationError as PydanticValidationError
 
 # Imports locaux des modèles (à ajuster selon structure)
 try:
-    from models.service_contracts import (
+    from ..models.service_contracts import (
         SearchServiceQuery,
         SearchServiceResponse,
         QueryMetadata,
         SearchParameters,
         SearchFilters
     )
-    from models.financial_models import (
+    from ..models.financial_models import (
         IntentResult,
         FinancialEntity,
         EntityType,


### PR DESCRIPTION
## Summary
- use relative imports for conversation service validators dependencies

## Testing
- `python local_app.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_689875e1e82883208c9ec2afa85c5a99