### PR TITLE
fix: correct cache import path

### DIFF
--- a/conversation_service/core/deepseek_client.py
+++ b/conversation_service/core/deepseek_client.py
@@ -35,7 +35,7 @@ from openai import AsyncOpenAI
 from openai.types.chat import ChatCompletion
 
 # Imports locaux
-from utils.cache import MultiLevelCache, generate_cache_key
+from ..utils.cache import MultiLevelCache, generate_cache_key
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- fix relative import for cache utilities in DeepSeek client

## Testing
- `python - <<'PY' ...` *(fails: No module named 'httpx')*
- `pytest` *(fails: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_689875dced7c8320a00a2651c3397e34