### PR TITLE
Use package-relative imports in conversation service

### DIFF
--- a/conversation_service/main.py
+++ b/conversation_service/main.py
@@ -36,8 +36,8 @@ from fastapi.exception_handlers import (
 from fastapi.exceptions import RequestValidationError
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
-from api.routes import router as api_router
-from api.dependencies import cleanup_dependencies
+from .api.routes import router as api_router
+from .api.dependencies import cleanup_dependencies
 import os
 
 # Configure logging
@@ -276,9 +276,9 @@ async def pre_initialize_dependencies() -> None:
     
     try:
         # Test import of critical modules
-        from core.mvp_team_manager import MVPTeamManager
-        from core.conversation_manager import ConversationManager
-        from utils.metrics import MetricsCollector
+        from .core.mvp_team_manager import MVPTeamManager
+        from .core.conversation_manager import ConversationManager
+        from .utils.metrics import MetricsCollector
         
         # Test basic initialization without full setup
         logger.info("✅ Core modules loaded successfully")


### PR DESCRIPTION
## Summary
- Convert conversation service imports to package-relative paths
- Update dependency pre-initialization to use relative imports for core modules

## Testing
- `python local_app.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_689875d5c9448320a79cb42d624851a3