### PR TITLE
Handle missing responses in nominal tests

### DIFF
--- a/test_harena_nominal.py
+++ b/test_harena_nominal.py
@@ -68,11 +68,13 @@ class HarenaTestClient:
             print(f"Status: {status}")
         print('='*60)
     
-    def _print_response(self, response: requests.Response, expected_status: int = 200):
-        """Affiche les détails de la réponse."""
+    def _print_response(self, response: Optional[requests.Response], expected_status: int = 200):
+        """Affiche les détails de la réponse.
+
+        Retourne un tuple (success, json_data)."""
         if not response:
             print("❌ Pas de réponse reçue")
-            return False
+            return False, None
         
         print(f"Status Code: {response.status_code}")
         
@@ -101,7 +103,8 @@ class HarenaTestClient:
         }
         
         response = self._make_request("POST", "/users/auth/login", headers=headers, data=payload)
-        success, json_data = self._print_response(response)
+        result = self._print_response(response)
+        success, json_data = result if isinstance(result, tuple) else (result, None)
         
         if success and json_data and 'access_token' in json_data:
             self.token = json_data['access_token']
@@ -120,7 +123,8 @@ class HarenaTestClient:
             return False
         
         response = self._make_request("GET", "/users/me")
-        success, json_data = self._print_response(response)
+        result = self._print_response(response)
+        success, json_data = result if isinstance(result, tuple) else (result, None)
         
         if success and json_data and 'id' in json_data:
             self.user_id = json_data['id']
@@ -141,7 +145,8 @@ class HarenaTestClient:
             return False
         
         response = self._make_request("POST", f"/enrichment/elasticsearch/sync-user/{self.user_id}")
-        success, json_data = self._print_response(response)
+        result = self._print_response(response)
+        success, json_data = result if isinstance(result, tuple) else (result, None)
         
         if success and json_data:
             total_tx = json_data.get('total_transactions', 0)
@@ -169,7 +174,8 @@ class HarenaTestClient:
         self._print_step(4, "HEALTH CHECK ENRICHMENT SERVICE")
         
         response = self._make_request("GET", "/enrichment/elasticsearch/health")
-        success, json_data = self._print_response(response)
+        result = self._print_response(response)
+        success, json_data = result if isinstance(result, tuple) else (result, None)
         
         if success and json_data:
             service_status = json_data.get('status', 'unknown')
@@ -235,11 +241,12 @@ class HarenaTestClient:
         }
         
         headers = {'Content-Type': 'application/json'}
-        response = self._make_request("POST", "/search/search", 
-                                    headers=headers, 
+        response = self._make_request("POST", "/search/search",
+                                    headers=headers,
                                     data=json.dumps(search_payload))
-        
-        success, json_data = self._print_response(response)
+
+        result = self._print_response(response)
+        success, json_data = result if isinstance(result, tuple) else (result, None)
         
         if success and json_data:
             total_hits = json_data.get('total_hits', 0)
@@ -277,7 +284,8 @@ class HarenaTestClient:
         self._print_step(6, "HEALTH CHECK CONVERSATION SERVICE")
 
         response = self._make_request("GET", "/conversation/health")
-        success, json_data = self._print_response(response)
+        result = self._print_response(response)
+        success, json_data = result if isinstance(result, tuple) else (result, None)
 
         if success and json_data:
             status = json_data.get('status', 'unknown')
@@ -297,7 +305,8 @@ class HarenaTestClient:
         self._print_step(7, "STATUS CONVERSATION SERVICE")
 
         response = self._make_request("GET", "/conversation/status")
-        success, json_data = self._print_response(response)
+        result = self._print_response(response)
+        success, json_data = result if isinstance(result, tuple) else (result, None)
 
         if success and json_data:
             service = json_data.get('service')
@@ -324,7 +333,8 @@ class HarenaTestClient:
                                       headers=headers,
                                       data=json.dumps(payload))
 
-        success, json_data = self._print_response(response)
+        result = self._print_response(response)
+        success, json_data = result if isinstance(result, tuple) else (result, None)
 
         if success and json_data:
             if json_data.get('success') is True:


### PR DESCRIPTION
## Summary
- ensure `_print_response` always returns a `(success, json_data)` tuple
- protect test steps from unpacking errors when responses are missing or invalid

## Testing
- `python test_harena_nominal.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_e_68987ceda8ac8320977fdc58a5ba6674