### PR TITLE
Use correct timeout parameter for DeepSeekClient

### DIFF
--- a/conversation_service/core/mvp_team_manager.py
+++ b/conversation_service/core/mvp_team_manager.py
@@ -325,7 +325,7 @@ class MVPTeamManager:
             self.deepseek_client = DeepSeekClient(
                 api_key=self.config['DEEPSEEK_API_KEY'],
                 base_url=self.config['DEEPSEEK_BASE_URL'],
-                timeout_seconds=self.config['DEEPSEEK_TIMEOUT']
+                timeout=self.config['DEEPSEEK_TIMEOUT']
             )
             
             # Test connection


### PR DESCRIPTION
## Summary
- Fix DeepSeek client initialization to use `timeout` parameter instead of deprecated `timeout_seconds`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `python - <<'PYTHON' ...` *(initialization and health check return healthy status)*

------
https://chatgpt.com/codex/tasks/task_e_68988a6de2d88320841169b067d3ae94