### PR TITLE
feat: expand metrics with runtime summary and system stats

### DIFF
--- a/test_metrics_endpoint.py
+++ b/test_metrics_endpoint.py
@@ -1,0 +1,20 @@
+import asyncio
+
+from conversation_service.api.routes import get_metrics
+from conversation_service.utils.metrics import MetricsCollector
+
+
+class DummyTeamManager:
+    def get_team_performance(self):
+        return {}
+
+
+def test_metrics_endpoint_returns_json():
+    metrics = MetricsCollector()
+    user = {"permissions": ["view_metrics"]}
+    result = asyncio.run(get_metrics(metrics=metrics, team_manager=DummyTeamManager(), user=user))
+    assert "service_metrics" in result
+    assert "system_info" in result
+    assert "memory_usage" in result["system_info"]
+    assert "cpu_usage" in result["system_info"]
+


### PR DESCRIPTION
## Summary
- track collector start time
- provide metrics summary with counters, gauges and histograms
- expose memory and CPU usage helpers for monitoring
- add test covering /metrics endpoint response

## Testing
- `pytest test_metrics_endpoint.py -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68988a8595d483208ef138285c78a494