### PR TITLE
Handle missing workflow summary in conversation service

### DIFF
--- a/conversation_service/agents/orchestrator_agent.py
+++ b/conversation_service/agents/orchestrator_agent.py
@@ -422,15 +422,18 @@ class OrchestratorAgent(BaseFinancialAgent):
             self._update_workflow_stats(workflow_result, time.perf_counter() - start_time)
             
             return {
-                "content": workflow_result["final_response"],
+                "content": workflow_result.get(
+                    "final_response",
+                    "Je rencontre des difficultés techniques."
+                ),
                 "metadata": {
-                    "workflow_success": workflow_result["success"],
-                    "execution_details": workflow_result["execution_details"],
-                    "performance_summary": workflow_result["performance_summary"],
-                    "conversation_id": conversation_id
+                    "workflow_success": workflow_result.get("success", False),
+                    "execution_details": workflow_result.get("execution_details", {}),
+                    "performance_summary": workflow_result.get("performance_summary", {}),
+                    "conversation_id": conversation_id,
                 },
                 "confidence_score": self._calculate_workflow_confidence(workflow_result),
-                "token_usage": self._aggregate_token_usage(workflow_result)
+                "token_usage": self._aggregate_token_usage(workflow_result),
             }
             
         except Exception as e:

--- a/test_orchestrator_agent_failure.py
+++ b/test_orchestrator_agent_failure.py
@@ -1,0 +1,84 @@
+import asyncio
+import sys
+import types
+
+# Stub external dependencies that are not available in the test environment
+sys.modules.setdefault("httpx", types.ModuleType("httpx"))
+
+openai_module = types.ModuleType("openai")
+openai_module.AsyncOpenAI = type("AsyncOpenAI", (), {})
+openai_types = types.ModuleType("openai.types")
+openai_chat = types.ModuleType("openai.types.chat")
+openai_chat.ChatCompletion = type("ChatCompletion", (), {})
+openai_types.chat = openai_chat
+sys.modules["openai"] = openai_module
+sys.modules["openai.types"] = openai_types
+sys.modules["openai.types.chat"] = openai_chat
+
+pydantic_module = types.ModuleType("pydantic")
+class BaseModel:
+    def __init__(self, **data):
+        for k, v in data.items():
+            setattr(self, k, v)
+
+def Field(default=None, *args, **kwargs):
+    return default
+
+def field_validator(*args, **kwargs):
+    def decorator(func):
+        return func
+    return decorator
+
+def model_validator(*args, **kwargs):
+    def decorator(func):
+        return func
+    return decorator
+
+class ValidationError(Exception):
+    pass
+
+pydantic_module.BaseModel = BaseModel
+pydantic_module.Field = Field
+pydantic_module.field_validator = field_validator
+pydantic_module.model_validator = model_validator
+pydantic_module.ValidationError = ValidationError
+sys.modules["pydantic"] = pydantic_module
+
+from conversation_service.agents.orchestrator_agent import OrchestratorAgent
+import conversation_service.agents.base_financial_agent as base_financial_agent
+
+# Ensure BaseFinancialAgent does not require the real AutoGen package
+base_financial_agent.AUTOGEN_AVAILABLE = True
+
+
+class DummyDeepSeekClient:
+    api_key = "test"
+    base_url = "http://test"
+
+
+class DummyAgent:
+    def __init__(self, name: str):
+        self.name = name
+        self.deepseek_client = DummyDeepSeekClient()
+
+
+class FailingOrchestratorAgent(OrchestratorAgent):
+    async def _execute_workflow(self, user_message: str, conversation_id: str):
+        # Simulate a workflow result missing performance_summary and execution_details
+        return {
+            "success": False,
+            "final_response": "Workflow failed",
+        }
+
+
+def test_failed_workflow_does_not_raise_performance_summary_error():
+    agent = FailingOrchestratorAgent(
+        DummyAgent("intent"), DummyAgent("search"), DummyAgent("response")
+    )
+    result = asyncio.run(agent.process_conversation("hello", "conv1"))
+
+    assert result["content"] == "Workflow failed"
+    assert "performance_summary" not in result["content"]
+    assert result["metadata"]["performance_summary"] == {}
+    assert result["metadata"]["execution_details"] == {}
+    assert result["metadata"]["workflow_success"] is False


### PR DESCRIPTION
## Summary
- Avoid KeyErrors in `process_conversation` by using `workflow_result.get(...)` for workflow metadata
- Add regression test for failed workflows to ensure missing performance data doesn't break responses

## Testing
- `pytest test_orchestrator_agent_failure.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6898e7b799f08320b266e85207ee4406