### PR TITLE
Ensure performance summary returned on workflow failure

### DIFF
--- a/conversation_service/agents/orchestrator_agent.py
+++ b/conversation_service/agents/orchestrator_agent.py
@@ -78,17 +78,24 @@ class WorkflowExecutor:
         self.search_agent = search_agent
         self.response_agent = response_agent
         
-    async def execute_workflow(self, user_message: str, 
+    async def execute_workflow(self, user_message: str,
                              conversation_id: str) -> Dict[str, Any]:
         """
         Execute the complete 3-agent workflow.
-        
+
         Args:
             user_message: User's input message
             conversation_id: Conversation identifier
-            
+
         Returns:
-            Workflow execution results with all step details
+            Dict with workflow execution results including:
+                - ``success``: Overall workflow success flag
+                - ``final_response``: Final response string (may be fallback)
+                - ``workflow_data``: Intermediate data collected during steps
+                - ``execution_details``: Timing and status for each step
+                - ``performance_summary``: Summary of completed and failed
+                  steps. Always present, even when the workflow fails
+                  entirely.
         """
         workflow_start = time.perf_counter()
         
@@ -250,6 +257,11 @@ class WorkflowExecutor:
                         }
                         for step in steps
                     ]
+                },
+                "performance_summary": {
+                    "completed_steps": len([s for s in steps if s.status == WorkflowStepStatus.COMPLETED]),
+                    "failed_steps": len([s for s in steps if s.status == WorkflowStepStatus.FAILED]),
+                    "total_steps": len(steps)
                 }
             }
     

--- a/test_workflow_executor.py
+++ b/test_workflow_executor.py
@@ -1,0 +1,100 @@
+import sys
+import types
+import asyncio
+import pytest
+
+# Stub external dependencies to allow importing WorkflowExecutor
+pydantic_stub = types.ModuleType("pydantic")
+class BaseModel: ...
+def Field(*args, **kwargs): return None
+
+def field_validator(*args, **kwargs):
+    def decorator(func):
+        return func
+    return decorator
+
+def model_validator(*args, **kwargs):
+    def decorator(func):
+        return func
+    return decorator
+
+pydantic_stub.BaseModel = BaseModel
+pydantic_stub.Field = Field
+pydantic_stub.field_validator = field_validator
+pydantic_stub.model_validator = model_validator
+sys.modules.setdefault("pydantic", pydantic_stub)
+
+# Stub httpx dependency
+sys.modules.setdefault("httpx", types.ModuleType("httpx"))
+
+# Stub internal modules required for import
+base_module = types.ModuleType("conversation_service.agents.base_financial_agent")
+class BaseFinancialAgent: ...
+base_module.BaseFinancialAgent = BaseFinancialAgent
+sys.modules["conversation_service.agents.base_financial_agent"] = base_module
+
+for mod_name in [
+    "conversation_service.agents.hybrid_intent_agent",
+    "conversation_service.agents.search_query_agent",
+    "conversation_service.agents.response_agent",
+]:
+    mod = types.ModuleType(mod_name)
+    cls_name = mod_name.split('.')[-1].title().replace('_', '')
+    setattr(mod, cls_name, type(cls_name, (), {}))
+    sys.modules[mod_name] = mod
+
+models_agent = types.ModuleType("conversation_service.models.agent_models")
+class AgentConfig: ...
+class AgentResponse: ...
+models_agent.AgentConfig = AgentConfig
+models_agent.AgentResponse = AgentResponse
+sys.modules["conversation_service.models.agent_models"] = models_agent
+
+models_conv = types.ModuleType("conversation_service.models.conversation_models")
+class ConversationContext: ...
+models_conv.ConversationContext = ConversationContext
+sys.modules["conversation_service.models.conversation_models"] = models_conv
+
+core_ds = types.ModuleType("conversation_service.core.deepseek_client")
+class DeepSeekClient: ...
+core_ds.DeepSeekClient = DeepSeekClient
+sys.modules["conversation_service.core.deepseek_client"] = core_ds
+
+from conversation_service.agents.orchestrator_agent import WorkflowExecutor
+
+
+class DummyIntentAgent:
+    name = "intent_agent"
+
+    async def execute_with_metrics(self, data):
+        raise RuntimeError("intent failure")
+
+
+class DummySearchAgent:
+    name = "search_agent"
+
+    async def execute_with_metrics(self, data):
+        return type("Response", (), {"success": True, "metadata": {}, "error_message": None})()
+
+
+class DummyResponseAgent:
+    name = "response_agent"
+
+    async def execute_with_metrics(self, data):
+        return type("Response", (), {"success": True, "content": "ok", "error_message": None})()
+
+
+def test_performance_summary_in_failure(monkeypatch):
+    """Workflow should return performance_summary even on catastrophic failure."""
+    executor = WorkflowExecutor(DummyIntentAgent(), DummySearchAgent(), DummyResponseAgent())
+
+    def failing_fallback_intent(self):
+        raise RuntimeError("no fallback")
+
+    monkeypatch.setattr(WorkflowExecutor, "_create_fallback_intent", failing_fallback_intent)
+
+    result = asyncio.run(executor.execute_workflow("hello", "conv1"))
+
+    assert "performance_summary" in result
+    summary = result["performance_summary"]
+    assert {"completed_steps", "failed_steps", "total_steps"} <= summary.keys()


### PR DESCRIPTION
## Summary
- guarantee `performance_summary` is returned by `execute_workflow` even when the workflow crashes
- document the return structure including `performance_summary`
- test that `performance_summary` exists during catastrophic workflow failure

## Testing
- `pytest test_workflow_executor.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6898e7cce27083208e8c63efcd2e3db4