### PR TITLE
feat: defer core validation to application startup

### DIFF
--- a/conversation_service/core/__init__.py
+++ b/conversation_service/core/__init__.py
@@ -102,7 +102,8 @@ __all__ = [
     # Utility functions
     "check_core_dependencies",
     "get_available_components",
-    "get_core_config"
+    "get_core_config",
+    "run_core_validation"
 ]
 
 # Configuration par défaut
@@ -264,11 +265,19 @@ logger.info(f"Core package initialized - version {__version__}")
 dependencies_status = check_core_dependencies()
 logger.info(f"Dependencies status: {dependencies_status}")
 
-# Validate setup on import
-validation = validate_core_setup()
-if not validation["valid"]:
-    logger.error(f"Core setup validation failed: {validation['errors']}")
-if validation["warnings"]:
-    logger.warning(f"Core setup warnings: {validation['warnings']}")
+# Deferred validation entrypoint
+def run_core_validation() -> dict:
+    """Execute core setup validation with logging.
 
-logger.info("Core package ready for use")
+    Returns:
+        Validation results dictionary
+    """
+    validation = validate_core_setup()
+
+    if not validation["valid"]:
+        logger.error(f"Core setup validation failed: {validation['errors']}")
+    if validation["warnings"]:
+        logger.warning(f"Core setup warnings: {validation['warnings']}")
+
+    logger.info("Core package ready for use")
+    return validation

--- a/conversation_service/main.py
+++ b/conversation_service/main.py
@@ -38,6 +38,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from .api.routes import router as api_router
 from .api.dependencies import cleanup_dependencies
+from .core import run_core_validation
 import os
 
 # Configure logging
@@ -139,6 +140,9 @@ def create_app() -> FastAPI:
     environment = os.getenv("ENVIRONMENT", "development")
     cors_origins = os.getenv("CORS_ORIGINS", "http://localhost:3000,http://localhost:8080").split(",")
     allowed_hosts = ["localhost", "127.0.0.1"] + cors_origins
+
+    # Validate core setup after environment configuration
+    run_core_validation()
     
     # Create FastAPI app with metadata
     app = FastAPI(


### PR DESCRIPTION
## Summary
- add `run_core_validation` to the Conversation Service core and export it
- remove eager validation on import
- trigger core validation from Conversation Service's main entry after env setup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests'; No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6898ed9323848320b8167578d3dcb164