### PR TITLE
Refactor HybridIntentAgent IntentResult and add tests

### DIFF
--- a/conversation_service/agents/orchestrator_agent.py
+++ b/conversation_service/agents/orchestrator_agent.py
@@ -422,15 +422,18 @@ class OrchestratorAgent(BaseFinancialAgent):
             self._update_workflow_stats(workflow_result, time.perf_counter() - start_time)
             
             return {
-                "content": workflow_result["final_response"],
+                "content": workflow_result.get(
+                    "final_response",
+                    "Je rencontre des difficultés techniques."
+                ),
                 "metadata": {
-                    "workflow_success": workflow_result["success"],
-                    "execution_details": workflow_result["execution_details"],
-                    "performance_summary": workflow_result["performance_summary"],
-                    "conversation_id": conversation_id
+                    "workflow_success": workflow_result.get("success", False),
+                    "execution_details": workflow_result.get("execution_details", {}),
+                    "performance_summary": workflow_result.get("performance_summary", {}),
+                    "conversation_id": conversation_id,
                 },
                 "confidence_score": self._calculate_workflow_confidence(workflow_result),
-                "token_usage": self._aggregate_token_usage(workflow_result)
+                "token_usage": self._aggregate_token_usage(workflow_result),
             }
             
         except Exception as e:

--- a/conversation_service/agents/orchestrator_agent.py
+++ b/conversation_service/agents/orchestrator_agent.py
@@ -78,17 +78,24 @@ class WorkflowExecutor:
         self.search_agent = search_agent
         self.response_agent = response_agent
         
-    async def execute_workflow(self, user_message: str, 
+    async def execute_workflow(self, user_message: str,
                              conversation_id: str) -> Dict[str, Any]:
         """
         Execute the complete 3-agent workflow.
-        
+
         Args:
             user_message: User's input message
             conversation_id: Conversation identifier
-            
+
         Returns:
-            Workflow execution results with all step details
+            Dict with workflow execution results including:
+                - ``success``: Overall workflow success flag
+                - ``final_response``: Final response string (may be fallback)
+                - ``workflow_data``: Intermediate data collected during steps
+                - ``execution_details``: Timing and status for each step
+                - ``performance_summary``: Summary of completed and failed
+                  steps. Always present, even when the workflow fails
+                  entirely.
         """
         workflow_start = time.perf_counter()
         
@@ -250,6 +257,11 @@ class WorkflowExecutor:
                         }
                         for step in steps
                     ]
+                },
+                "performance_summary": {
+                    "completed_steps": len([s for s in steps if s.status == WorkflowStepStatus.COMPLETED]),
+                    "failed_steps": len([s for s in steps if s.status == WorkflowStepStatus.FAILED]),
+                    "total_steps": len(steps)
                 }
             }
     

--- a/conversation_service/api/__init__.py
+++ b/conversation_service/api/__init__.py
@@ -51,7 +51,7 @@ from .routes import (
 )
 
 # API Models for external use
-from ..models.conversation_models import (
+from ..models import (
     ConversationRequest,
     ConversationResponse,
     ConversationTurn,

--- a/conversation_service/api/dependencies.py
+++ b/conversation_service/api/dependencies.py
@@ -28,7 +28,7 @@ from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 
 from ..core.mvp_team_manager import MVPTeamManager
 from ..core.conversation_manager import ConversationManager
-from ..models.conversation_models import ConversationRequest, ConversationResponse
+from ..models import ConversationRequest, ConversationResponse
 from ..utils.metrics import MetricsCollector
 import os
 

--- a/conversation_service/api/dependencies.py
+++ b/conversation_service/api/dependencies.py
@@ -66,7 +66,7 @@ async def get_team_manager() -> MVPTeamManager:
         try:
             logger.info("Initializing MVPTeamManager singleton")
             _team_manager = MVPTeamManager()
-            await _team_manager.initialize()
+            await _team_manager.initialize_agents()
             logger.info("MVPTeamManager initialized successfully")
         except Exception as e:
             logger.error(f"Failed to initialize MVPTeamManager: {e}")

--- a/conversation_service/api/routes.py
+++ b/conversation_service/api/routes.py
@@ -328,7 +328,7 @@ async def get_metrics(
         metrics_summary = metrics.get_summary()
         
         # Get team performance
-        team_performance = await team_manager.get_team_performance()
+        team_performance = team_manager.get_team_performance()
         
         # Compile comprehensive metrics
         comprehensive_metrics = {

--- a/conversation_service/api/routes.py
+++ b/conversation_service/api/routes.py
@@ -113,18 +113,12 @@ async def chat_endpoint(
         
         # Process message through AutoGen team
         try:
-            team_response = await team_manager.process_conversation(
+            team_response = await team_manager.process_user_message(
                 user_message=validated_request.message,
-                conversation_id=conversation_id,
-                context=context,
                 user_id=user_id,
-                metadata={
-                    "user_preferences": user.get("preferences", {}),
-                    "subscription_type": user.get("subscription_type", "standard"),
-                    "language": validated_request.language or "fr"
-                }
+                conversation_id=conversation_id
             )
-            
+
             logger.info(f"AutoGen team processed message successfully")
             
         except Exception as e:
@@ -150,7 +144,7 @@ async def chat_endpoint(
             conversation_manager,
             conversation_id,
             validated_request.message,
-            team_response.message,
+            team_response,
             int((time.time() - start_time) * 1000),
             metrics
         )
@@ -160,18 +154,13 @@ async def chat_endpoint(
         
         # Create response
         response = ConversationResponse(
-            message=team_response.message,
+            message=team_response,
             conversation_id=conversation_id,
             success=True,
             processing_time_ms=processing_time,
-            agent_used=team_response.primary_agent,
-            confidence=team_response.confidence,
-            metadata={
-                "agents_involved": team_response.agents_involved,
-                "search_performed": team_response.search_performed,
-                "entities_detected": team_response.entities_detected,
-                "intent_detected": team_response.intent_detected
-            }
+            agent_used="orchestrator_agent",
+            confidence=1.0,
+            metadata={}
         )
         
         # Record success metrics

--- a/conversation_service/api/routes.py
+++ b/conversation_service/api/routes.py
@@ -32,7 +32,7 @@ from .dependencies import (
 
 from ..core.mvp_team_manager import MVPTeamManager
 from ..core.conversation_manager import ConversationManager
-from ..models.conversation_models import ConversationRequest, ConversationResponse
+from ..models import ConversationRequest, ConversationResponse
 from ..utils.metrics import MetricsCollector
 import os
 

--- a/conversation_service/api/routes.py
+++ b/conversation_service/api/routes.py
@@ -17,8 +17,8 @@ Version: 1.0.0 MVP - FastAPI Routes
 
 import logging
 import time
-from typing import Dict, Any, List, Annotated
-from fastapi import APIRouter, Depends, HTTPException, status, Request, BackgroundTasks
+from typing import Dict, Any, Annotated
+from fastapi import APIRouter, Depends, HTTPException, status, BackgroundTasks
 from fastapi.responses import JSONResponse
 
 from .dependencies import (
@@ -60,7 +60,6 @@ health_router = APIRouter(prefix="/health", tags=["monitoring"])
     }
 )
 async def chat_endpoint(
-    request: ConversationRequest,
     background_tasks: BackgroundTasks,
     team_manager: Annotated[MVPTeamManager, Depends(get_team_manager)],
     conversation_manager: Annotated[ConversationManager, Depends(get_conversation_manager)],
@@ -80,13 +79,12 @@ async def chat_endpoint(
     5. Returns AI response with metadata
     
     Args:
-        request: User conversation request
         background_tasks: FastAPI background tasks
         team_manager: AutoGen team manager dependency
         conversation_manager: Conversation context dependency
         user: Authenticated user context
         metrics: Metrics collector dependency
-        validated_request: Pre-validated request
+        validated_request: Validated conversation request
         
     Returns:
         ConversationResponse: AI response with metadata

--- a/conversation_service/core/__init__.py
+++ b/conversation_service/core/__init__.py
@@ -102,7 +102,8 @@ __all__ = [
     # Utility functions
     "check_core_dependencies",
     "get_available_components",
-    "get_core_config"
+    "get_core_config",
+    "run_core_validation"
 ]
 
 # Configuration par défaut
@@ -264,11 +265,19 @@ logger.info(f"Core package initialized - version {__version__}")
 dependencies_status = check_core_dependencies()
 logger.info(f"Dependencies status: {dependencies_status}")
 
-# Validate setup on import
-validation = validate_core_setup()
-if not validation["valid"]:
-    logger.error(f"Core setup validation failed: {validation['errors']}")
-if validation["warnings"]:
-    logger.warning(f"Core setup warnings: {validation['warnings']}")
+# Deferred validation entrypoint
+def run_core_validation() -> dict:
+    """Execute core setup validation with logging.
 
-logger.info("Core package ready for use")
+    Returns:
+        Validation results dictionary
+    """
+    validation = validate_core_setup()
+
+    if not validation["valid"]:
+        logger.error(f"Core setup validation failed: {validation['errors']}")
+    if validation["warnings"]:
+        logger.warning(f"Core setup warnings: {validation['warnings']}")
+
+    logger.info("Core package ready for use")
+    return validation

--- a/conversation_service/core/deepseek_client.py
+++ b/conversation_service/core/deepseek_client.py
@@ -35,7 +35,7 @@ from openai import AsyncOpenAI
 from openai.types.chat import ChatCompletion
 
 # Imports locaux
-from utils.cache import MultiLevelCache, generate_cache_key
+from ..utils.cache import MultiLevelCache, generate_cache_key
 
 logger = logging.getLogger(__name__)
 

--- a/conversation_service/core/mvp_team_manager.py
+++ b/conversation_service/core/mvp_team_manager.py
@@ -325,7 +325,7 @@ class MVPTeamManager:
             self.deepseek_client = DeepSeekClient(
                 api_key=self.config['DEEPSEEK_API_KEY'],
                 base_url=self.config['DEEPSEEK_BASE_URL'],
-                timeout_seconds=self.config['DEEPSEEK_TIMEOUT']
+                timeout=self.config['DEEPSEEK_TIMEOUT']
             )
             
             # Test connection

--- a/conversation_service/main.py
+++ b/conversation_service/main.py
@@ -295,6 +295,25 @@ async def pre_initialize_dependencies() -> None:
         raise
 
 
+async def initialize_dependencies() -> None:
+    """Initialize and validate core dependencies."""
+    logger.info("🔧 Initializing dependencies")
+
+    try:
+        from .core.mvp_team_manager import MVPTeamManager
+        from .core.conversation_manager import ConversationManager
+
+        # Instantiate core components to ensure availability
+        MVPTeamManager()
+        conversation_manager = ConversationManager()
+        await conversation_manager.initialize()
+
+        logger.info("✅ Dependencies initialized successfully")
+    except Exception as e:
+        logger.error(f"❌ Dependency initialization failed: {e}")
+        raise
+
+
 # Middleware functions
 async def add_process_time_header(request: Request, call_next):
     """Add processing time header to responses."""

--- a/conversation_service/main.py
+++ b/conversation_service/main.py
@@ -36,8 +36,8 @@ from fastapi.exception_handlers import (
 from fastapi.exceptions import RequestValidationError
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
-from api.routes import router as api_router
-from api.dependencies import cleanup_dependencies
+from .api.routes import router as api_router
+from .api.dependencies import cleanup_dependencies
 import os
 
 # Configure logging
@@ -276,9 +276,9 @@ async def pre_initialize_dependencies() -> None:
     
     try:
         # Test import of critical modules
-        from core.mvp_team_manager import MVPTeamManager
-        from core.conversation_manager import ConversationManager
-        from utils.metrics import MetricsCollector
+        from .core.mvp_team_manager import MVPTeamManager
+        from .core.conversation_manager import ConversationManager
+        from .utils.metrics import MetricsCollector
         
         # Test basic initialization without full setup
         logger.info("✅ Core modules loaded successfully")

--- a/conversation_service/main.py
+++ b/conversation_service/main.py
@@ -38,6 +38,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from .api.routes import router as api_router
 from .api.dependencies import cleanup_dependencies
+from .core import run_core_validation
 import os
 
 # Configure logging
@@ -139,6 +140,9 @@ def create_app() -> FastAPI:
     environment = os.getenv("ENVIRONMENT", "development")
     cors_origins = os.getenv("CORS_ORIGINS", "http://localhost:3000,http://localhost:8080").split(",")
     allowed_hosts = ["localhost", "127.0.0.1"] + cors_origins
+
+    # Validate core setup after environment configuration
+    run_core_validation()
     
     # Create FastAPI app with metadata
     app = FastAPI(

--- a/conversation_service/models/__init__.py
+++ b/conversation_service/models/__init__.py
@@ -12,6 +12,8 @@ Exports:
         - TeamWorkflow: Team workflow configuration
     
     Conversation Models:
+        - ConversationRequest: API request model
+        - ConversationResponse: API response model
         - ConversationTurn: Individual conversation turn
         - ConversationContext: Complete conversation context
     
@@ -45,7 +47,9 @@ from .agent_models import (
 # Import conversation models
 from .conversation_models import (
     ConversationTurn,
-    ConversationContext
+    ConversationContext,
+    ConversationRequest,
+    ConversationResponse
 )
 
 # Import financial models
@@ -87,6 +91,8 @@ __all__ = [
     "TeamWorkflow",
     
     # Conversation Models
+    "ConversationRequest",
+    "ConversationResponse",
     "ConversationTurn",
     "ConversationContext",
     

--- a/conversation_service/utils/metrics.py
+++ b/conversation_service/utils/metrics.py
@@ -420,7 +420,28 @@ class MetricsCollector:
                 actual=duration_ms,
                 level=AlertLevel.WARNING
             )
-    
+
+    def record_request(self, endpoint: str, user_id: int) -> None:
+        """Enregistre une requête reçue pour un endpoint."""
+        labels = {"endpoint": endpoint, "user_id": str(user_id)}
+        self.record_counter("requests_total", 1.0, labels)
+
+    def record_response_time(self, endpoint: str, duration_ms: float) -> None:
+        """Enregistre le temps de réponse d'un endpoint."""
+        labels = {"endpoint": endpoint}
+        self.record_timer("response_time_ms", duration_ms, labels)
+
+    def record_success(self, endpoint: str) -> None:
+        """Enregistre un succès pour un endpoint."""
+        labels = {"endpoint": endpoint}
+        self.record_counter("success_total", 1.0, labels)
+
+    def record_error(self, endpoint: str, error_message: str) -> None:
+        """Enregistre une erreur survenue pour un endpoint et loggue le message."""
+        labels = {"endpoint": endpoint}
+        self.record_counter("errors_total", 1.0, labels)
+        logger.error(f"[{endpoint}] {error_message}")
+
     def record_agent_execution(self, agent_name: str, duration_ms: float, success: bool = True, **labels) -> None:
         """
         Enregistre l'exécution d'un agent AutoGen.

--- a/conversation_service/utils/metrics.py
+++ b/conversation_service/utils/metrics.py
@@ -28,6 +28,10 @@ from enum import Enum
 import os
 import uuid
 import statistics
+try:  # pragma: no cover - psutil may not be available in all environments
+    import psutil
+except Exception:  # pragma: no cover
+    psutil = None
 
 logger = logging.getLogger(__name__)
 
@@ -306,7 +310,8 @@ class MetricsCollector:
             collection_interval: Intervalle de collecte en secondes
         """
         self.collection_interval = collection_interval or int(os.getenv('METRICS_COLLECTION_INTERVAL', '60'))
-        self.enabled = os.getenv('ENABLE_METRICS', 'true').lower() == 'true'  
+        self.enabled = os.getenv('ENABLE_METRICS', 'true').lower() == 'true'
+        self.start_time = time.time()
         
         # Stockage des métriques
         self._metrics: List[MetricPoint] = []
@@ -603,6 +608,48 @@ class MetricsCollector:
                     alert.resolved = True
                     return True
         return False
+
+    def get_summary(self) -> Dict[str, Any]:
+        """Retourne un résumé des compteurs, jauges et histogrammes."""
+        with self._lock:
+            counters_summary = dict(self._counters)
+            gauges_summary = dict(self._gauges)
+            histograms_summary: Dict[str, Dict[str, float]] = {}
+            for key, values in self._histograms.items():
+                if values:
+                    histograms_summary[key] = {
+                        "count": len(values),
+                        "min": min(values),
+                        "max": max(values),
+                        "avg": statistics.mean(values)
+                    }
+
+        return {
+            "counters": counters_summary,
+            "gauges": gauges_summary,
+            "histograms": histograms_summary,
+            "total_requests": counters_summary.get("requests_total", 0),
+            "avg_response_time": histograms_summary.get("request_duration_ms", {}).get("avg", 0)
+        }
+
+    def get_memory_usage(self) -> Dict[str, float]:
+        """Retourne l'utilisation mémoire du processus."""
+        if psutil is None:  # pragma: no cover
+            return {}
+
+        process = psutil.Process(os.getpid())
+        mem_info = process.memory_info()
+        return {
+            "rss": mem_info.rss,
+            "vms": mem_info.vms,
+            "percent": psutil.virtual_memory().percent
+        }
+
+    def get_cpu_usage(self) -> float:
+        """Retourne l'utilisation CPU en pourcentage."""
+        if psutil is None:  # pragma: no cover
+            return 0.0
+        return psutil.cpu_percent(interval=None)
     
     def get_performance_report(self) -> Dict[str, Any]:
         """
@@ -809,5 +856,4 @@ def get_default_metrics_collector() -> MetricsCollector:
     
     if _default_metrics_collector is None:
         _default_metrics_collector = MetricsCollector()
-    
     return _default_metrics_collector

--- a/conversation_service/utils/validators.py
+++ b/conversation_service/utils/validators.py
@@ -27,14 +27,14 @@ from pydantic import ValidationError as PydanticValidationError
 
 # Imports locaux des modèles (à ajuster selon structure)
 try:
-    from models.service_contracts import (
+    from ..models.service_contracts import (
         SearchServiceQuery,
         SearchServiceResponse,
         QueryMetadata,
         SearchParameters,
         SearchFilters
     )
-    from models.financial_models import (
+    from ..models.financial_models import (
         IntentResult,
         FinancialEntity,
         EntityType,

--- a/test_conversation_multiple_questions.py
+++ b/test_conversation_multiple_questions.py
@@ -1,0 +1,123 @@
+"""
+Test spécifique pour vérifier le fonctionnement du service de conversation
+avec plusieurs échanges successifs.
+
+Ce script envoie une série de messages au service `/conversation/chat`
+et vérifie que chaque réponse est retournée avec succès et que l'ID de
+conversation reste constant.
+
+Usage:
+    python test_conversation_multiple_questions.py
+    python test_conversation_multiple_questions.py --base-url http://localhost:8000/api/v1
+    python test_conversation_multiple_questions.py --messages "Bonjour" "Comment ça va?" "Merci"
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from typing import List
+
+import requests
+
+DEFAULT_BASE_URL = "http://localhost:8000/api/v1"
+REQUEST_TIMEOUT = 30
+
+
+def _print_step(step: int, message: str) -> None:
+    print("\n" + "=" * 60)
+    print(f"ÉTAPE {step}: {message}")
+    print("=" * 60)
+
+
+def _print_response(response: requests.Response) -> dict:
+    print(f"Status Code: {response.status_code}")
+    try:
+        data = response.json()
+        print("Réponse JSON:")
+        print(json.dumps(data, indent=2, ensure_ascii=False))
+        return data
+    except json.JSONDecodeError:
+        print("❌ Réponse non JSON:")
+        print(response.text[:500])
+        return {}
+
+
+def run_conversation_test(base_url: str, conversation_id: str, messages: List[str]) -> bool:
+    print("🚀 DÉBUT DU TEST MULTI-CONVERSATION HARENA")
+    print(f"Base URL: {base_url}")
+    print(f"Conversation ID: {conversation_id}")
+    print(f"Timestamp: {datetime.now().isoformat()}")
+
+    session = requests.Session()
+    session.timeout = REQUEST_TIMEOUT
+
+    successes = 0
+    for idx, msg in enumerate(messages, start=1):
+        _print_step(idx, f"ENVOI DU MESSAGE: {msg}")
+        payload = {"conversation_id": conversation_id, "message": msg}
+        try:
+            response = session.post(
+                f"{base_url.rstrip('/')}/conversation/chat",
+                json=payload,
+                timeout=REQUEST_TIMEOUT,
+            )
+        except requests.exceptions.RequestException as e:
+            print(f"❌ Erreur de requête: {e}")
+            continue
+
+        data = _print_response(response)
+        if (
+            response.status_code == 200
+            and data.get("success") is True
+            and data.get("conversation_id") == conversation_id
+        ):
+            print("✅ Message traité avec succès")
+            successes += 1
+        else:
+            print("❌ Échec du traitement du message")
+
+    print("\n" + "=" * 60)
+    print("📊 RÉSUMÉ DU TEST")
+    print("=" * 60)
+    print(f"Messages réussis: {successes}/{len(messages)}")
+
+    if successes == len(messages):
+        print("✅ TOUS LES MESSAGES ONT ÉTÉ TRAITÉS AVEC SUCCÈS")
+        return True
+
+    print("❌ Des messages n'ont pas été traités correctement")
+    return False
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Test de conversation multi-messages")
+    parser.add_argument(
+        "--base-url",
+        default=DEFAULT_BASE_URL,
+        help="URL de base de l'API Harena",
+    )
+    parser.add_argument(
+        "--conversation-id",
+        default="test-conversation-multi",
+        help="Identifiant de conversation à utiliser",
+    )
+    parser.add_argument(
+        "--messages",
+        nargs="*",
+        default=[
+            "Bonjour",
+            "Peux-tu me donner ton nom ?",
+            "Merci et au revoir",
+        ],
+        help="Liste de messages à envoyer",
+    )
+    args = parser.parse_args()
+
+    success = run_conversation_test(args.base_url, args.conversation_id, args.messages)
+    if not success:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/test_harena_nominal.py
+++ b/test_harena_nominal.py
@@ -71,8 +71,8 @@ class HarenaTestClient:
     def _print_response(self, response: Optional[requests.Response], expected_status: int = 200):
         """Affiche les détails de la réponse.
 
-        Retourne un tuple (success, json_data)."""
-        if not response:
+        Retourne toujours un tuple (success, json_data)."""
+        if response is None:
             print("❌ Pas de réponse reçue")
             return False, None
         
@@ -85,7 +85,7 @@ class HarenaTestClient:
         
         try:
             json_response = response.json()
-            print(f"Réponse JSON:")
+            print("Réponse JSON:")
             print(json.dumps(json_response, indent=2, ensure_ascii=False))
             return response.status_code == expected_status, json_response
         except json.JSONDecodeError:
@@ -103,8 +103,7 @@ class HarenaTestClient:
         }
         
         response = self._make_request("POST", "/users/auth/login", headers=headers, data=payload)
-        result = self._print_response(response)
-        success, json_data = result if isinstance(result, tuple) else (result, None)
+        success, json_data = self._print_response(response)
         
         if success and json_data and 'access_token' in json_data:
             self.token = json_data['access_token']
@@ -123,8 +122,7 @@ class HarenaTestClient:
             return False
         
         response = self._make_request("GET", "/users/me")
-        result = self._print_response(response)
-        success, json_data = result if isinstance(result, tuple) else (result, None)
+        success, json_data = self._print_response(response)
         
         if success and json_data and 'id' in json_data:
             self.user_id = json_data['id']
@@ -145,8 +143,7 @@ class HarenaTestClient:
             return False
         
         response = self._make_request("POST", f"/enrichment/elasticsearch/sync-user/{self.user_id}")
-        result = self._print_response(response)
-        success, json_data = result if isinstance(result, tuple) else (result, None)
+        success, json_data = self._print_response(response)
         
         if success and json_data:
             total_tx = json_data.get('total_transactions', 0)
@@ -174,8 +171,7 @@ class HarenaTestClient:
         self._print_step(4, "HEALTH CHECK ENRICHMENT SERVICE")
         
         response = self._make_request("GET", "/enrichment/elasticsearch/health")
-        result = self._print_response(response)
-        success, json_data = result if isinstance(result, tuple) else (result, None)
+        success, json_data = self._print_response(response)
         
         if success and json_data:
             service_status = json_data.get('status', 'unknown')
@@ -245,8 +241,7 @@ class HarenaTestClient:
                                     headers=headers,
                                     data=json.dumps(search_payload))
 
-        result = self._print_response(response)
-        success, json_data = result if isinstance(result, tuple) else (result, None)
+        success, json_data = self._print_response(response)
         
         if success and json_data:
             total_hits = json_data.get('total_hits', 0)
@@ -284,8 +279,7 @@ class HarenaTestClient:
         self._print_step(6, "HEALTH CHECK CONVERSATION SERVICE")
 
         response = self._make_request("GET", "/conversation/health")
-        result = self._print_response(response)
-        success, json_data = result if isinstance(result, tuple) else (result, None)
+        success, json_data = self._print_response(response)
 
         if success and json_data:
             status = json_data.get('status', 'unknown')
@@ -305,8 +299,7 @@ class HarenaTestClient:
         self._print_step(7, "STATUS CONVERSATION SERVICE")
 
         response = self._make_request("GET", "/conversation/status")
-        result = self._print_response(response)
-        success, json_data = result if isinstance(result, tuple) else (result, None)
+        success, json_data = self._print_response(response)
 
         if success and json_data:
             service = json_data.get('service')
@@ -333,8 +326,7 @@ class HarenaTestClient:
                                       headers=headers,
                                       data=json.dumps(payload))
 
-        result = self._print_response(response)
-        success, json_data = result if isinstance(result, tuple) else (result, None)
+        success, json_data = self._print_response(response)
 
         if success and json_data:
             if json_data.get('success') is True:

--- a/test_harena_nominal.py
+++ b/test_harena_nominal.py
@@ -68,11 +68,13 @@ class HarenaTestClient:
             print(f"Status: {status}")
         print('='*60)
     
-    def _print_response(self, response: requests.Response, expected_status: int = 200):
-        """Affiche les détails de la réponse."""
+    def _print_response(self, response: Optional[requests.Response], expected_status: int = 200):
+        """Affiche les détails de la réponse.
+
+        Retourne un tuple (success, json_data)."""
         if not response:
             print("❌ Pas de réponse reçue")
-            return False
+            return False, None
         
         print(f"Status Code: {response.status_code}")
         
@@ -101,7 +103,8 @@ class HarenaTestClient:
         }
         
         response = self._make_request("POST", "/users/auth/login", headers=headers, data=payload)
-        success, json_data = self._print_response(response)
+        result = self._print_response(response)
+        success, json_data = result if isinstance(result, tuple) else (result, None)
         
         if success and json_data and 'access_token' in json_data:
             self.token = json_data['access_token']
@@ -120,7 +123,8 @@ class HarenaTestClient:
             return False
         
         response = self._make_request("GET", "/users/me")
-        success, json_data = self._print_response(response)
+        result = self._print_response(response)
+        success, json_data = result if isinstance(result, tuple) else (result, None)
         
         if success and json_data and 'id' in json_data:
             self.user_id = json_data['id']
@@ -141,7 +145,8 @@ class HarenaTestClient:
             return False
         
         response = self._make_request("POST", f"/enrichment/elasticsearch/sync-user/{self.user_id}")
-        success, json_data = self._print_response(response)
+        result = self._print_response(response)
+        success, json_data = result if isinstance(result, tuple) else (result, None)
         
         if success and json_data:
             total_tx = json_data.get('total_transactions', 0)
@@ -169,7 +174,8 @@ class HarenaTestClient:
         self._print_step(4, "HEALTH CHECK ENRICHMENT SERVICE")
         
         response = self._make_request("GET", "/enrichment/elasticsearch/health")
-        success, json_data = self._print_response(response)
+        result = self._print_response(response)
+        success, json_data = result if isinstance(result, tuple) else (result, None)
         
         if success and json_data:
             service_status = json_data.get('status', 'unknown')
@@ -235,11 +241,12 @@ class HarenaTestClient:
         }
         
         headers = {'Content-Type': 'application/json'}
-        response = self._make_request("POST", "/search/search", 
-                                    headers=headers, 
+        response = self._make_request("POST", "/search/search",
+                                    headers=headers,
                                     data=json.dumps(search_payload))
-        
-        success, json_data = self._print_response(response)
+
+        result = self._print_response(response)
+        success, json_data = result if isinstance(result, tuple) else (result, None)
         
         if success and json_data:
             total_hits = json_data.get('total_hits', 0)
@@ -277,7 +284,8 @@ class HarenaTestClient:
         self._print_step(6, "HEALTH CHECK CONVERSATION SERVICE")
 
         response = self._make_request("GET", "/conversation/health")
-        success, json_data = self._print_response(response)
+        result = self._print_response(response)
+        success, json_data = result if isinstance(result, tuple) else (result, None)
 
         if success and json_data:
             status = json_data.get('status', 'unknown')
@@ -297,7 +305,8 @@ class HarenaTestClient:
         self._print_step(7, "STATUS CONVERSATION SERVICE")
 
         response = self._make_request("GET", "/conversation/status")
-        success, json_data = self._print_response(response)
+        result = self._print_response(response)
+        success, json_data = result if isinstance(result, tuple) else (result, None)
 
         if success and json_data:
             service = json_data.get('service')
@@ -324,7 +333,8 @@ class HarenaTestClient:
                                       headers=headers,
                                       data=json.dumps(payload))
 
-        success, json_data = self._print_response(response)
+        result = self._print_response(response)
+        success, json_data = result if isinstance(result, tuple) else (result, None)
 
         if success and json_data:
             if json_data.get('success') is True:

--- a/test_hybrid_intent_agent.py
+++ b/test_hybrid_intent_agent.py
@@ -1,0 +1,76 @@
+import pytest
+import sys
+import types
+import asyncio
+
+# Stub autogen so BaseFinancialAgent can import
+autogen_stub = types.ModuleType("autogen")
+class AssistantAgent:
+    def __init__(self, *args, **kwargs):
+        pass
+autogen_stub.AssistantAgent = AssistantAgent
+sys.modules["autogen"] = autogen_stub
+
+# Stub httpx to satisfy indirect imports
+sys.modules["httpx"] = types.ModuleType("httpx")
+
+# Stub DeepSeekClient module to avoid heavy dependencies
+deepseek_stub = types.ModuleType("deepseek_client")
+class _StubDeepSeekClient:
+    pass
+deepseek_stub.DeepSeekClient = _StubDeepSeekClient
+sys.modules["conversation_service.core.deepseek_client"] = deepseek_stub
+
+from conversation_service.agents.hybrid_intent_agent import HybridIntentAgent
+from conversation_service.models.financial_models import (
+    IntentResult,
+    IntentCategory,
+    FinancialEntity,
+)
+
+
+class DummyDeepSeekClient:
+    api_key = "test"
+    base_url = "http://test"
+
+    async def generate_response(self, *args, **kwargs):
+        class Resp:
+            content = "Intention: GENERAL\nConfiance: 0.5\n"
+        return Resp()
+
+
+def test_rule_based_detection_returns_intent_result():
+    agent = HybridIntentAgent(deepseek_client=DummyDeepSeekClient())
+    result = asyncio.run(agent.detect_intent("bonjour"))
+    intent_result = result["metadata"]["intent_result"]
+    assert isinstance(intent_result, IntentResult)
+    assert isinstance(intent_result.intent_category, IntentCategory)
+    assert isinstance(intent_result.entities, list)
+    assert all(isinstance(e, FinancialEntity) for e in intent_result.entities)
+    assert result["metadata"]["detection_method"] == "rules"
+
+
+def test_ai_fallback_returns_intent_result():
+    agent = HybridIntentAgent(deepseek_client=DummyDeepSeekClient())
+    result = asyncio.run(agent.detect_intent("message sans correspondance"))
+    intent_result = result["metadata"]["intent_result"]
+    assert result["metadata"]["detection_method"] == "ai_fallback"
+    assert isinstance(intent_result, IntentResult)
+    assert isinstance(intent_result.intent_category, IntentCategory)
+    assert isinstance(intent_result.entities, list)
+
+
+def test_error_handling_returns_fallback(monkeypatch):
+    agent = HybridIntentAgent(deepseek_client=DummyDeepSeekClient())
+
+    async def broken_rule(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(agent, "_try_rule_based_detection", broken_rule)
+
+    result = asyncio.run(agent.detect_intent("bonjour"))
+    intent_result = result["metadata"]["intent_result"]
+    assert result["metadata"]["detection_method"] == "fallback"
+    assert isinstance(intent_result, IntentResult)
+    assert intent_result.intent_type == "GENERAL"
+    assert isinstance(intent_result.entities, list)

--- a/test_metrics_endpoint.py
+++ b/test_metrics_endpoint.py
@@ -1,0 +1,20 @@
+import asyncio
+
+from conversation_service.api.routes import get_metrics
+from conversation_service.utils.metrics import MetricsCollector
+
+
+class DummyTeamManager:
+    def get_team_performance(self):
+        return {}
+
+
+def test_metrics_endpoint_returns_json():
+    metrics = MetricsCollector()
+    user = {"permissions": ["view_metrics"]}
+    result = asyncio.run(get_metrics(metrics=metrics, team_manager=DummyTeamManager(), user=user))
+    assert "service_metrics" in result
+    assert "system_info" in result
+    assert "memory_usage" in result["system_info"]
+    assert "cpu_usage" in result["system_info"]
+

--- a/test_orchestrator_agent_failure.py
+++ b/test_orchestrator_agent_failure.py
@@ -1,0 +1,84 @@
+import asyncio
+import sys
+import types
+
+# Stub external dependencies that are not available in the test environment
+sys.modules.setdefault("httpx", types.ModuleType("httpx"))
+
+openai_module = types.ModuleType("openai")
+openai_module.AsyncOpenAI = type("AsyncOpenAI", (), {})
+openai_types = types.ModuleType("openai.types")
+openai_chat = types.ModuleType("openai.types.chat")
+openai_chat.ChatCompletion = type("ChatCompletion", (), {})
+openai_types.chat = openai_chat
+sys.modules["openai"] = openai_module
+sys.modules["openai.types"] = openai_types
+sys.modules["openai.types.chat"] = openai_chat
+
+pydantic_module = types.ModuleType("pydantic")
+class BaseModel:
+    def __init__(self, **data):
+        for k, v in data.items():
+            setattr(self, k, v)
+
+def Field(default=None, *args, **kwargs):
+    return default
+
+def field_validator(*args, **kwargs):
+    def decorator(func):
+        return func
+    return decorator
+
+def model_validator(*args, **kwargs):
+    def decorator(func):
+        return func
+    return decorator
+
+class ValidationError(Exception):
+    pass
+
+pydantic_module.BaseModel = BaseModel
+pydantic_module.Field = Field
+pydantic_module.field_validator = field_validator
+pydantic_module.model_validator = model_validator
+pydantic_module.ValidationError = ValidationError
+sys.modules["pydantic"] = pydantic_module
+
+from conversation_service.agents.orchestrator_agent import OrchestratorAgent
+import conversation_service.agents.base_financial_agent as base_financial_agent
+
+# Ensure BaseFinancialAgent does not require the real AutoGen package
+base_financial_agent.AUTOGEN_AVAILABLE = True
+
+
+class DummyDeepSeekClient:
+    api_key = "test"
+    base_url = "http://test"
+
+
+class DummyAgent:
+    def __init__(self, name: str):
+        self.name = name
+        self.deepseek_client = DummyDeepSeekClient()
+
+
+class FailingOrchestratorAgent(OrchestratorAgent):
+    async def _execute_workflow(self, user_message: str, conversation_id: str):
+        # Simulate a workflow result missing performance_summary and execution_details
+        return {
+            "success": False,
+            "final_response": "Workflow failed",
+        }
+
+
+def test_failed_workflow_does_not_raise_performance_summary_error():
+    agent = FailingOrchestratorAgent(
+        DummyAgent("intent"), DummyAgent("search"), DummyAgent("response")
+    )
+    result = asyncio.run(agent.process_conversation("hello", "conv1"))
+
+    assert result["content"] == "Workflow failed"
+    assert "performance_summary" not in result["content"]
+    assert result["metadata"]["performance_summary"] == {}
+    assert result["metadata"]["execution_details"] == {}
+    assert result["metadata"]["workflow_success"] is False

--- a/test_workflow_executor.py
+++ b/test_workflow_executor.py
@@ -1,0 +1,100 @@
+import sys
+import types
+import asyncio
+import pytest
+
+# Stub external dependencies to allow importing WorkflowExecutor
+pydantic_stub = types.ModuleType("pydantic")
+class BaseModel: ...
+def Field(*args, **kwargs): return None
+
+def field_validator(*args, **kwargs):
+    def decorator(func):
+        return func
+    return decorator
+
+def model_validator(*args, **kwargs):
+    def decorator(func):
+        return func
+    return decorator
+
+pydantic_stub.BaseModel = BaseModel
+pydantic_stub.Field = Field
+pydantic_stub.field_validator = field_validator
+pydantic_stub.model_validator = model_validator
+sys.modules.setdefault("pydantic", pydantic_stub)
+
+# Stub httpx dependency
+sys.modules.setdefault("httpx", types.ModuleType("httpx"))
+
+# Stub internal modules required for import
+base_module = types.ModuleType("conversation_service.agents.base_financial_agent")
+class BaseFinancialAgent: ...
+base_module.BaseFinancialAgent = BaseFinancialAgent
+sys.modules["conversation_service.agents.base_financial_agent"] = base_module
+
+for mod_name in [
+    "conversation_service.agents.hybrid_intent_agent",
+    "conversation_service.agents.search_query_agent",
+    "conversation_service.agents.response_agent",
+]:
+    mod = types.ModuleType(mod_name)
+    cls_name = mod_name.split('.')[-1].title().replace('_', '')
+    setattr(mod, cls_name, type(cls_name, (), {}))
+    sys.modules[mod_name] = mod
+
+models_agent = types.ModuleType("conversation_service.models.agent_models")
+class AgentConfig: ...
+class AgentResponse: ...
+models_agent.AgentConfig = AgentConfig
+models_agent.AgentResponse = AgentResponse
+sys.modules["conversation_service.models.agent_models"] = models_agent
+
+models_conv = types.ModuleType("conversation_service.models.conversation_models")
+class ConversationContext: ...
+models_conv.ConversationContext = ConversationContext
+sys.modules["conversation_service.models.conversation_models"] = models_conv
+
+core_ds = types.ModuleType("conversation_service.core.deepseek_client")
+class DeepSeekClient: ...
+core_ds.DeepSeekClient = DeepSeekClient
+sys.modules["conversation_service.core.deepseek_client"] = core_ds
+
+from conversation_service.agents.orchestrator_agent import WorkflowExecutor
+
+
+class DummyIntentAgent:
+    name = "intent_agent"
+
+    async def execute_with_metrics(self, data):
+        raise RuntimeError("intent failure")
+
+
+class DummySearchAgent:
+    name = "search_agent"
+
+    async def execute_with_metrics(self, data):
+        return type("Response", (), {"success": True, "metadata": {}, "error_message": None})()
+
+
+class DummyResponseAgent:
+    name = "response_agent"
+
+    async def execute_with_metrics(self, data):
+        return type("Response", (), {"success": True, "content": "ok", "error_message": None})()
+
+
+def test_performance_summary_in_failure(monkeypatch):
+    """Workflow should return performance_summary even on catastrophic failure."""
+    executor = WorkflowExecutor(DummyIntentAgent(), DummySearchAgent(), DummyResponseAgent())
+
+    def failing_fallback_intent(self):
+        raise RuntimeError("no fallback")
+
+    monkeypatch.setattr(WorkflowExecutor, "_create_fallback_intent", failing_fallback_intent)
+
+    result = asyncio.run(executor.execute_workflow("hello", "conv1"))
+
+    assert "performance_summary" in result
+    summary = result["performance_summary"]
+    assert {"completed_steps", "failed_steps", "total_steps"} <= summary.keys()


### PR DESCRIPTION
## Summary
- migrate HybridIntentAgent to new IntentResult signature with intent_type, intent_category, FinancialEntity list and processing_time_ms
- add helper mapping and entity conversion utilities
- add tests covering rule-based detection, AI fallback and error fallback

## Testing
- `pytest -q test_hybrid_intent_agent.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6898f2e571dc8320a727d4af5fbd906c