### PR TITLE
Allow direct execution of tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Harena
+
+## Tests unitaires
+
+Les tests peuvent être exécutés avec `pytest` :
+
+```bash
+pytest
+```
+
+Chaque fichier de test peut également être lancé directement :
+
+```bash
+python test_metrics_endpoint.py
+```

--- a/test_metrics_endpoint.py
+++ b/test_metrics_endpoint.py
@@ -18,3 +18,8 @@ def test_metrics_endpoint_returns_json():
     assert "memory_usage" in result["system_info"]
     assert "cpu_usage" in result["system_info"]
 
+
+if __name__ == "__main__":
+    import pytest, sys
+
+    sys.exit(pytest.main([__file__]))

--- a/test_orchestrator_agent_failure.py
+++ b/test_orchestrator_agent_failure.py
@@ -82,3 +82,9 @@ def test_failed_workflow_does_not_raise_performance_summary_error():
     assert result["metadata"]["performance_summary"] == {}
     assert result["metadata"]["execution_details"] == {}
     assert result["metadata"]["workflow_success"] is False
+
+
+if __name__ == "__main__":
+    import pytest, sys
+
+    sys.exit(pytest.main([__file__]))

--- a/test_workflow_executor.py
+++ b/test_workflow_executor.py
@@ -98,3 +98,9 @@ def test_performance_summary_in_failure(monkeypatch):
     assert "performance_summary" in result
     summary = result["performance_summary"]
     assert {"completed_steps", "failed_steps", "total_steps"} <= summary.keys()
+
+
+if __name__ == "__main__":
+    import pytest, sys
+
+    sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
## Summary
- add `__main__` blocks to test files for direct execution
- document in README how to run tests via `pytest` or directly

## Testing
- `pytest test_orchestrator_agent_failure.py test_workflow_executor.py` (passes)
- `pytest test_orchestrator_agent_failure.py test_workflow_executor.py test_metrics_endpoint.py` (fails: No module named 'fastapi')

------
https://chatgpt.com/codex/tasks/task_e_6898f2ed53c4832091a883f003c6d045