### PR TITLE
Refactor intent tests for new intent schema

### DIFF
--- a/test_fallback_intent.py
+++ b/test_fallback_intent.py
@@ -74,7 +74,11 @@ core_ds.DeepSeekClient = DeepSeekClient
 sys.modules["conversation_service.core.deepseek_client"] = core_ds
 
 from conversation_service.agents.orchestrator_agent import WorkflowExecutor
-from conversation_service.models.financial_models import IntentResult, DetectionMethod
+from conversation_service.models.financial_models import (
+    IntentResult,
+    DetectionMethod,
+    FinancialEntity,
+)
 
 
 class FailingIntentAgent:
@@ -104,3 +108,5 @@ def test_fallback_intent_valid():
     intent_result = result["workflow_data"]["intent_result"]
     assert isinstance(intent_result, IntentResult)
     assert intent_result.method == DetectionMethod.FALLBACK
+    assert isinstance(intent_result.entities, list)
+    assert all(isinstance(e, FinancialEntity) for e in intent_result.entities)


### PR DESCRIPTION
## Summary
- update tests to use `intent_type`, `intent_category`, and list-based entities
- validate fallback detection returns a list of `FinancialEntity`

## Testing
- `pytest test_fallback_intent.py -q`
- `pytest test_fallback_intent.py test_intent_detection.py test_orchestrator_agent_failure.py test_workflow_executor.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Could not find a version that satisfies the requirement requests)*
- `pytest test_fallback_intent.py test_orchestrator_agent_failure.py test_workflow_executor.py -q` *(fails: AgentConfig() takes no arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6898f789b934832090e5c7db4e0717b3