### PR TITLE
Extend intent rules with response metadata

### DIFF
--- a/conversation_service/intent_rules/rule_engine.py
+++ b/conversation_service/intent_rules/rule_engine.py
@@ -31,13 +31,15 @@ class RuleMatch(NamedTuple):
     """Résultat d'un match de règle avec entités"""
     intent: str
     intent_category: str
-    confidence: float 
+    confidence: float
     entities: Dict[str, List[EntityMatch]]
     method: str  # "exact_match" | "pattern_match"
     execution_time_ms: float
     pattern_matched: str
     rule_priority: int
     entity_count: int
+    no_search_needed: bool
+    suggested_responses: Optional[List[str]]
     
     def to_dict(self) -> Dict[str, Any]:
         """Convertit le match en dictionnaire pour sérialisation"""
@@ -63,7 +65,9 @@ class RuleMatch(NamedTuple):
             "execution_time_ms": self.execution_time_ms,
             "pattern_matched": self.pattern_matched,
             "rule_priority": self.rule_priority,
-            "entity_count": self.entity_count
+            "entity_count": self.entity_count,
+            "no_search_needed": self.no_search_needed,
+            "suggested_responses": self.suggested_responses
         }
 
 
@@ -158,7 +162,9 @@ class ExactMatcher:
                 execution_time_ms=execution_time,
                 pattern_matched=f"exact:{context.normalized_text}",
                 rule_priority=rule.priority,
-                entity_count=0
+                entity_count=0,
+                no_search_needed=rule.no_search_needed,
+                suggested_responses=rule.suggested_responses
             )
         
         return None
@@ -411,7 +417,9 @@ class RulePatternMatcher:
             execution_time_ms=0.0,  # Sera mis à jour par le caller
             pattern_matched=";".join(matched_patterns),
             rule_priority=rule.priority,
-            entity_count=entity_count
+            entity_count=entity_count,
+            no_search_needed=rule.no_search_needed,
+            suggested_responses=rule.suggested_responses
         )
     
     def get_stats(self) -> Dict[str, Any]:

--- a/conversation_service/intent_rules/rule_loader.py
+++ b/conversation_service/intent_rules/rule_loader.py
@@ -56,6 +56,8 @@ class IntentRule:
     search_parameters: Optional[Dict] = None
     default_filters: Optional[List[Dict]] = None
     examples: Optional[List[str]] = None
+    no_search_needed: bool = False
+    suggested_responses: Optional[List[str]] = None
     
     def __post_init__(self):
         """Validation post-initialisation"""
@@ -236,7 +238,9 @@ class RuleLoader:
                 exact_matches=set(config.get('exact_matches', [])),
                 search_parameters=config.get('search_parameters'),
                 default_filters=config.get('default_filters'),
-                examples=config.get('examples')
+                examples=config.get('examples'),
+                no_search_needed=config.get('no_search_needed', False),
+                suggested_responses=config.get('suggested_responses')
             )
             
             return rule

--- a/test_intent_rule_new_fields.py
+++ b/test_intent_rule_new_fields.py
@@ -1,0 +1,21 @@
+from conversation_service.intent_rules.rule_loader import RuleLoader
+from conversation_service.intent_rules.rule_engine import create_rule_engine
+
+
+def test_loader_parses_new_fields():
+    loader = RuleLoader()
+    greeting_rule = loader.get_conversational_rules().get("GREETING")
+    assert greeting_rule is not None
+    assert greeting_rule.no_search_needed is True
+    assert greeting_rule.suggested_responses
+    assert isinstance(greeting_rule.suggested_responses, list)
+
+
+def test_rule_match_includes_new_fields():
+    loader = RuleLoader()
+    engine = create_rule_engine(loader)
+    match = engine.match_intent("bonjour")
+    assert match is not None
+    greeting_rule = loader.get_conversational_rules()["GREETING"]
+    assert match.no_search_needed == greeting_rule.no_search_needed
+    assert match.suggested_responses == greeting_rule.suggested_responses


### PR DESCRIPTION
## Summary
- add `no_search_needed` and `suggested_responses` fields to `IntentRule`
- propagate new fields through `RuleMatch` for downstream access
- test rule loader and engine for suggested responses

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pytest test_intent_rule_new_fields.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689907a2ad988320ac8b34d94fd6043b