### PR TITLE
Leverage rule metadata for search skipping and suggestions

### DIFF
--- a/conversation_service/intent_rules/rule_loader.py
+++ b/conversation_service/intent_rules/rule_loader.py
@@ -56,6 +56,8 @@ class IntentRule:
     search_parameters: Optional[Dict] = None
     default_filters: Optional[List[Dict]] = None
     examples: Optional[List[str]] = None
+    no_search_needed: bool = False
+    suggested_responses: Optional[List[str]] = None
     
     def __post_init__(self):
         """Validation post-initialisation"""
@@ -236,7 +238,9 @@ class RuleLoader:
                 exact_matches=set(config.get('exact_matches', [])),
                 search_parameters=config.get('search_parameters'),
                 default_filters=config.get('default_filters'),
-                examples=config.get('examples')
+                examples=config.get('examples'),
+                no_search_needed=config.get('no_search_needed', False),
+                suggested_responses=config.get('suggested_responses')
             )
             
             return rule


### PR DESCRIPTION
## Summary
- remove hard-coded intent lists in HybridIntentAgent
- derive search requirement and suggested responses from rule metadata
- add test ensuring GRATITUDE intent skips search and proposes response

## Testing
- `pytest test_conversation_multiple_questions.py::test_gratitude_skips_search -q`
- `pytest test_conversation_multiple_questions.py::test_greeting_skips_search -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install fastapi -q` *(fails: Could not find a version that satisfies the requirement fastapi (403))*

------
https://chatgpt.com/codex/tasks/task_e_689907a80d408320a19c26a1416cc052