### PR TITLE
Respect intent search requirement in orchestrator

### DIFF
--- a/test_conversation_multiple_questions.py
+++ b/test_conversation_multiple_questions.py
@@ -165,7 +165,7 @@ def main() -> None:
         sys.exit(1)
 
 
-def test_greeting_skips_search():
+def test_skips_search_when_not_required():
     from types import SimpleNamespace
     import asyncio
     import conversation_service.agents.base_financial_agent as base_financial_agent
@@ -180,13 +180,13 @@ def test_greeting_skips_search():
 
         async def execute_with_metrics(self, data):
             ir = IntentResult(
-                intent_type="GREETING",
-                intent_category=IntentCategory.GREETING,
+                intent_type="TEST_INTENT",
+                intent_category=IntentCategory.GENERAL_QUESTION,
                 confidence=0.99,
                 entities=[],
                 method=DetectionMethod.RULE_BASED,
                 processing_time_ms=1.0,
-                suggested_actions=["Bonjour ! Comment puis-je vous aider ?"],
+                suggested_actions=["No search needed"],
                 search_required=False,
             )
             return SimpleNamespace(success=True, metadata={"intent_result": ir})
@@ -205,7 +205,7 @@ def test_greeting_skips_search():
 
     agent = OrchestratorAgent(DummyIntentAgent(), DummySearchAgent(), DummyResponseAgent())
     result = asyncio.run(agent.process_conversation("Bonjour", "conv1"))
-    assert "bonjour" in result["content"].lower()
+    assert result["content"] == "No search needed"
     steps = {s["name"]: s["status"] for s in result["metadata"]["execution_details"]["steps"]}
     assert steps.get("search_query") == "skipped"
     assert steps.get("response_generation") == "skipped"

--- a/test_orchestrator_agent_performance.py
+++ b/test_orchestrator_agent_performance.py
@@ -59,7 +59,16 @@ for mod_name in [
 models_conv = types.ModuleType("conversation_service.models.conversation_models")
 class ConversationContext:
     pass
+class ConversationTurn:
+    pass
+class ConversationRequest:
+    pass
+class ConversationResponse:
+    pass
 models_conv.ConversationContext = ConversationContext
+models_conv.ConversationTurn = ConversationTurn
+models_conv.ConversationRequest = ConversationRequest
+models_conv.ConversationResponse = ConversationResponse
 sys.modules["conversation_service.models.conversation_models"] = models_conv
 
 from conversation_service.agents.orchestrator_agent import OrchestratorAgent

--- a/test_workflow_executor.py
+++ b/test_workflow_executor.py
@@ -52,7 +52,13 @@ sys.modules["conversation_service.models.agent_models"] = models_agent
 
 models_conv = types.ModuleType("conversation_service.models.conversation_models")
 class ConversationContext: ...
+class ConversationTurn: ...
+class ConversationRequest: ...
+class ConversationResponse: ...
 models_conv.ConversationContext = ConversationContext
+models_conv.ConversationTurn = ConversationTurn
+models_conv.ConversationRequest = ConversationRequest
+models_conv.ConversationResponse = ConversationResponse
 sys.modules["conversation_service.models.conversation_models"] = models_conv
 
 core_ds = types.ModuleType("conversation_service.core.deepseek_client")


### PR DESCRIPTION
## Summary
- Remove intent-type checks and rely solely on `search_required` to decide search execution
- Skip search and response stages when search isn't required, returning suggested actions or a default greeting
- Track skipped steps in workflow metrics and ignore them for step success rates
- Update tests and stubs to match new behavior

## Testing
- `pytest test_conversation_multiple_questions.py::test_skips_search_when_not_required test_orchestrator_agent_performance.py::test_workflow_completes_under_threshold test_orchestrator_agent_failure.py test_workflow_executor.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68990e99662c8320a4dd6f1adad8d29b