### PR TITLE
Propagate user ID through conversation context

### DIFF
--- a/conversation_service/api/routes.py
+++ b/conversation_service/api/routes.py
@@ -142,6 +142,7 @@ async def chat_endpoint(
             store_conversation_turn,
             conversation_manager,
             conversation_id,
+            user_id,
             validated_request.message,
             team_response,
             int((time.time() - start_time) * 1000),
@@ -383,6 +384,7 @@ async def get_status() -> Dict[str, Any]:
 async def store_conversation_turn(
     conversation_manager: ConversationManager,
     conversation_id: str,
+    user_id: int,
     user_message: str,
     assistant_message: str,
     processing_time_ms: int,
@@ -394,6 +396,7 @@ async def store_conversation_turn(
     Args:
         conversation_manager: Conversation manager instance
         conversation_id: Conversation identifier
+        user_id: User identifier
         user_message: User's message
         assistant_message: Assistant's response
         processing_time_ms: Processing time in milliseconds
@@ -402,6 +405,7 @@ async def store_conversation_turn(
     try:
         await conversation_manager.add_turn(
             conversation_id=conversation_id,
+            user_id=user_id,
             user_msg=user_message,
             assistant_msg=assistant_message,
             processing_time_ms=float(processing_time_ms)

--- a/conversation_service/core/mvp_team_manager.py
+++ b/conversation_service/core/mvp_team_manager.py
@@ -185,7 +185,10 @@ class MVPTeamManager:
                 
                 # Update conversation history
                 await self.conversation_manager.add_turn(
-                    conversation_id, user_message, final_response
+                    conversation_id,
+                    user_id,
+                    user_message,
+                    final_response
                 )
                 
                 # Update team statistics

--- a/tests/test_conversation_context_user_id.py
+++ b/tests/test_conversation_context_user_id.py
@@ -1,0 +1,52 @@
+import sys
+from pathlib import Path
+import types
+
+# Ensure project root is on sys.path for module imports
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# Minimal pydantic stub for tests
+class _BaseModel:
+    def __init__(self, **data):
+        for k, v in data.items():
+            setattr(self, k, v)
+
+    def dict(self):
+        result = {}
+        for k, v in self.__dict__.items():
+            if hasattr(v, "dict"):
+                result[k] = v.dict()
+            elif isinstance(v, list):
+                result[k] = [item.dict() if hasattr(item, "dict") else item for item in v]
+            else:
+                result[k] = v
+        return result
+
+
+pydantic_stub = types.SimpleNamespace(
+    BaseModel=_BaseModel,
+    Field=lambda *args, **kwargs: None,
+    field_validator=lambda *args, **kwargs: (lambda f: f),
+    model_validator=lambda *args, **kwargs: (lambda f: f),
+    ValidationError=Exception,
+)
+sys.modules.setdefault("pydantic", pydantic_stub)
+
+from conversation_service.core.conversation_manager import ConversationManager
+
+
+def test_add_turn_sets_user_id_in_context():
+    async def run_test():
+        manager = ConversationManager()
+        await manager.add_turn(
+            conversation_id="conv1",
+            user_id=123,
+            user_msg="hello",
+            assistant_msg="hi",
+        )
+        context = await manager.get_context("conv1")
+        assert context.user_id == 123
+
+    import asyncio
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- Pass authenticated `user_id` to conversation manager when storing chat turns
- Extend conversation manager to create contexts with provided `user_id`
- Add regression test ensuring contexts retain the correct `user_id`

## Testing
- `pytest tests/test_conversation_context_user_id.py tests/test_search_query_user_id.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6899a2b8854483209c62fefc21d3428e