### PR TITLE
Switch to ModuleType for pydantic test stub

### DIFF
--- a/tests/test_conversation_context_user_id.py
+++ b/tests/test_conversation_context_user_id.py
@@ -23,14 +23,14 @@ class _BaseModel:
         return result
 
 
-pydantic_stub = types.SimpleNamespace(
-    BaseModel=_BaseModel,
-    Field=lambda *args, **kwargs: None,
-    field_validator=lambda *args, **kwargs: (lambda f: f),
-    model_validator=lambda *args, **kwargs: (lambda f: f),
-    ValidationError=Exception,
-)
+pydantic_stub = types.ModuleType("pydantic")
+pydantic_stub.BaseModel = _BaseModel
+pydantic_stub.Field = lambda *args, **kwargs: None
+pydantic_stub.field_validator = lambda *args, **kwargs: (lambda f: f)
+pydantic_stub.model_validator = lambda *args, **kwargs: (lambda f: f)
+pydantic_stub.ValidationError = Exception
 sys.modules.setdefault("pydantic", pydantic_stub)
+sys.modules.setdefault("pydantic.generics", types.ModuleType("generics"))
 
 from conversation_service.core.conversation_manager import ConversationManager
 

--- a/tests/test_search_query_user_id.py
+++ b/tests/test_search_query_user_id.py
@@ -34,14 +34,14 @@ class _BaseModel:
         return result
 
 
-pydantic_stub = types.SimpleNamespace(
-    BaseModel=_BaseModel,
-    Field=lambda *args, **kwargs: None,
-    field_validator=lambda *args, **kwargs: (lambda f: f),
-    model_validator=lambda *args, **kwargs: (lambda f: f),
-    ValidationError=Exception,
-)
+pydantic_stub = types.ModuleType("pydantic")
+pydantic_stub.BaseModel = _BaseModel
+pydantic_stub.Field = lambda *args, **kwargs: None
+pydantic_stub.field_validator = lambda *args, **kwargs: (lambda f: f)
+pydantic_stub.model_validator = lambda *args, **kwargs: (lambda f: f)
+pydantic_stub.ValidationError = Exception
 sys.modules.setdefault("pydantic", pydantic_stub)
+sys.modules.setdefault("pydantic.generics", types.ModuleType("generics"))
 
 # Stub for openai client used in DeepSeekClient
 openai_types_chat_stub = types.SimpleNamespace(ChatCompletion=SimpleNamespace)


### PR DESCRIPTION
## Summary
- replace SimpleNamespace pydantic stub with ModuleType and expose `pydantic.generics`

## Testing
- `pytest tests/test_search_query_user_id.py tests/test_conversation_context_user_id.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_6899cbadf7588320a9cc886d6225b970