### PR TITLE
refactor: lazy-load team manager

### DIFF
--- a/conversation_service/api/routes.py
+++ b/conversation_service/api/routes.py
@@ -18,7 +18,7 @@ Version: 1.0.0 MVP - FastAPI Routes
 import logging
 import time
 import asyncio
-from typing import Dict, Any, Annotated
+from typing import Dict, Any, Annotated, TYPE_CHECKING
 from fastapi import APIRouter, Depends, HTTPException, status, BackgroundTasks
 from fastapi.responses import JSONResponse
 
@@ -30,12 +30,15 @@ from .dependencies import (
     validate_request_rate_limit,
     get_metrics_collector
 )
-
-from ..core.mvp_team_manager import MVPTeamManager
 from ..core.conversation_manager import ConversationManager
 from ..models import ConversationRequest, ConversationResponse
 from ..utils.metrics import MetricsCollector
 import os
+
+if TYPE_CHECKING:
+    from ..core.mvp_team_manager import MVPTeamManager
+else:
+    MVPTeamManager = Any
 
 # Configure logging
 logger = logging.getLogger(__name__)

--- a/conversation_service/core/__init__.py
+++ b/conversation_service/core/__init__.py
@@ -283,13 +283,11 @@ def validate_core_setup() -> dict:
     results["info"].append(f"Core package version: {__version__}")
     results["info"].append(f"Available components: {len(get_available_components())}")
     results["info"].append(f"Configuration loaded with {len(config)} parameters")
-    
+
     return results
 
 # Log core package initialization
 logger.info(f"Core package initialized - version {__version__}")
-dependencies_status = check_core_dependencies()
-logger.info(f"Dependencies status: {dependencies_status}")
 
 # Deferred validation entrypoint
 def run_core_validation() -> dict:

--- a/conversation_service/main.py
+++ b/conversation_service/main.py
@@ -280,10 +280,14 @@ async def pre_initialize_dependencies() -> None:
     
     try:
         # Test import of critical modules
-        from .core.mvp_team_manager import MVPTeamManager
+        from .core import load_team_manager
         from .core.conversation_manager import ConversationManager
         from .utils.metrics import MetricsCollector
-        
+
+        MVPTeamManager, _ = load_team_manager()
+        if MVPTeamManager is None:
+            raise ImportError("MVPTeamManager not available")
+
         # Test basic initialization without full setup
         logger.info("✅ Core modules loaded successfully")
         
@@ -304,10 +308,13 @@ async def initialize_dependencies() -> None:
     logger.info("🔧 Initializing dependencies")
 
     try:
-        from .core.mvp_team_manager import MVPTeamManager
+        from .core import load_team_manager
         from .core.conversation_manager import ConversationManager
 
         # Instantiate core components to ensure availability
+        MVPTeamManager, _ = load_team_manager()
+        if MVPTeamManager is None:
+            raise ImportError("MVPTeamManager not available")
         MVPTeamManager()
         conversation_manager = ConversationManager()
         await conversation_manager.initialize()


### PR DESCRIPTION
## Summary
- avoid eager MVPTeamManager import by adding load_team_manager and dropping startup dependency checks
- lazily load MVPTeamManager in API dependencies, routes, and startup routines

## Testing
- `pytest tests/test_search_query_user_id.py`

------
https://chatgpt.com/codex/tasks/task_e_6899cbb3e3f48320bdf77941b54166c9