### PR TITLE
feat: expose conversation read endpoints

### DIFF
--- a/conversation_service/api/dependencies.py
+++ b/conversation_service/api/dependencies.py
@@ -26,6 +26,10 @@ from typing import Dict, Optional, Any, Annotated, Deque, TYPE_CHECKING
 from fastapi import Depends, HTTPException, status, Request
 from fastapi.security import OAuth2PasswordBearer
 import httpx
+from sqlalchemy.orm import Session
+
+from db_service.session import get_db
+from conversation_service.services.conversation_service import ConversationService
 
 from ..core import load_team_manager
 from ..core.conversation_manager import ConversationManager
@@ -128,6 +132,13 @@ async def get_metrics_collector() -> MetricsCollector:
         _metrics_collector = MetricsCollector()
     
     return _metrics_collector
+
+
+def get_conversation_service(
+    db: Annotated[Session, Depends(get_db)]
+) -> ConversationService:
+    """Dependency to provide ConversationService instance."""
+    return ConversationService(db)
 
 
 async def get_current_user(

--- a/conversation_service/api/routes.py
+++ b/conversation_service/api/routes.py
@@ -18,8 +18,8 @@ Version: 1.0.0 MVP - FastAPI Routes
 import logging
 import time
 import asyncio
-from typing import Dict, Any, Annotated, TYPE_CHECKING
-from fastapi import APIRouter, Depends, HTTPException, status, BackgroundTasks
+from typing import Dict, Any, Annotated, TYPE_CHECKING, List
+from fastapi import APIRouter, Depends, HTTPException, status, BackgroundTasks, Query
 from fastapi.responses import JSONResponse
 
 from .dependencies import (
@@ -28,11 +28,18 @@ from .dependencies import (
     validate_conversation_request,
     get_conversation_manager,
     validate_request_rate_limit,
-    get_metrics_collector
+    get_metrics_collector,
+    get_conversation_service
 )
 from ..core.conversation_manager import ConversationManager
-from ..models import ConversationRequest, ConversationResponse
+from ..models import (
+    ConversationRequest,
+    ConversationResponse,
+    ConversationOut,
+    ConversationTurn,
+)
 from ..utils.metrics import MetricsCollector
+from ..services.conversation_service import ConversationService
 import os
 
 if TYPE_CHECKING:
@@ -49,6 +56,7 @@ router = APIRouter()
 # Create specialized routers
 chat_router = APIRouter(prefix="/chat", tags=["conversation"])
 health_router = APIRouter(prefix="/health", tags=["monitoring"])
+conversations_router = APIRouter(prefix="/conversations", tags=["conversation"])
 
 
 @chat_router.post(
@@ -351,6 +359,78 @@ async def get_metrics(
         )
 
 
+@conversations_router.get(
+    "",
+    response_model=List[ConversationOut],
+    summary="List user conversations",
+    description="Return conversations for the authenticated user",
+    responses={
+        200: {"description": "Conversations retrieved successfully"},
+        401: {"description": "Unauthorized"},
+    },
+)
+async def list_conversations(
+    user: Annotated[Dict[str, Any], Depends(get_current_user)],
+    service: Annotated[ConversationService, Depends(get_conversation_service)],
+    limit: int = Query(10, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+) -> List[ConversationOut]:
+    """List conversations belonging to the current user."""
+    conversations = service.get_conversations(user["user_id"], limit=limit, offset=offset)
+    return [
+        ConversationOut(
+            conversation_id=c.conversation_id,
+            title=c.title,
+            status=c.status,
+            total_turns=c.total_turns,
+            last_activity_at=c.last_activity_at,
+        )
+        for c in conversations
+    ]
+
+
+@conversations_router.get(
+    "/{conversation_id}/turns",
+    response_model=List[ConversationTurn],
+    summary="Get conversation turns",
+    description="Return turns of a conversation if it belongs to the user",
+    responses={
+        200: {"description": "Conversation turns retrieved"},
+        404: {"description": "Conversation not found"},
+        401: {"description": "Unauthorized"},
+    },
+)
+async def get_conversation_turns(
+    conversation_id: str,
+    user: Annotated[Dict[str, Any], Depends(get_current_user)],
+    service: Annotated[ConversationService, Depends(get_conversation_service)],
+) -> List[ConversationTurn]:
+    """Return the turns for a specific conversation."""
+    conversation = service.get_conversation(conversation_id)
+    if conversation is None or conversation.user_id != user["user_id"]:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Conversation not found")
+
+    turns: List[ConversationTurn] = []
+    for t in conversation.turns:
+        turns.append(
+            ConversationTurn(
+                turn_id=t.turn_id,
+                user_message=t.user_message,
+                assistant_response=t.assistant_response,
+                timestamp=t.created_at,
+                metadata=t.turn_metadata or {},
+                turn_number=t.turn_number,
+                processing_time_ms=t.processing_time_ms or 0.0,
+                intent_detected=t.intent_detected,
+                entities_extracted=t.entities_extracted,
+                confidence_score=t.confidence_score,
+                error_occurred=t.error_occurred,
+                agent_chain=t.agent_chain,
+            )
+        )
+    return turns
+
+
 @router.get(
     "/status",
     summary="Service status information",
@@ -426,3 +506,4 @@ async def store_conversation_turn(
 # Include routers in main router
 router.include_router(chat_router)
 router.include_router(health_router)
+router.include_router(conversations_router)

--- a/conversation_service/models/__init__.py
+++ b/conversation_service/models/__init__.py
@@ -49,7 +49,8 @@ from .conversation_models import (
     ConversationTurn,
     ConversationContext,
     ConversationRequest,
-    ConversationResponse
+    ConversationResponse,
+    ConversationOut
 )
 
 # Import financial models
@@ -95,6 +96,7 @@ __all__ = [
     "ConversationResponse",
     "ConversationTurn",
     "ConversationContext",
+    "ConversationOut",
     
     # Financial Models
     "FinancialEntity",

--- a/conversation_service/models/conversation_models.py
+++ b/conversation_service/models/conversation_models.py
@@ -260,6 +260,26 @@ class ConversationTurn(BaseModel):
     }
 
 
+class ConversationOut(BaseModel):
+    """Lightweight conversation representation for API responses."""
+
+    conversation_id: str = Field(
+        ..., description="Unique identifier for the conversation"
+    )
+    title: Optional[str] = Field(
+        default=None, description="Optional conversation title"
+    )
+    status: str = Field(
+        ..., description="Current status of the conversation"
+    )
+    total_turns: int = Field(
+        ..., description="Total number of turns in the conversation", ge=0
+    )
+    last_activity_at: datetime = Field(
+        ..., description="Timestamp of the last activity"
+    )
+
+
 class ConversationContext(BaseModel):
     """
     Complete conversation context with all turns and state management.

--- a/conversation_service/services/conversation_service.py
+++ b/conversation_service/services/conversation_service.py
@@ -1,0 +1,36 @@
+from typing import List, Optional
+from sqlalchemy.orm import Session, joinedload
+
+from db_service.models.conversation import Conversation, ConversationTurn
+
+
+class ConversationService:
+    """Service layer for conversation read operations."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    def get_conversations(self, user_id: int, limit: int = 10, offset: int = 0) -> List[Conversation]:
+        """Return conversations for a given user."""
+        return (
+            self.db.query(Conversation)
+            .filter(Conversation.user_id == user_id)
+            .order_by(Conversation.last_activity_at.desc())
+            .offset(offset)
+            .limit(limit)
+            .all()
+        )
+
+    def get_conversation(self, conversation_id: str) -> Optional[Conversation]:
+        """Return a conversation with its turns."""
+        return (
+            self.db.query(Conversation)
+            .options(joinedload(Conversation.turns))
+            .filter(Conversation.conversation_id == conversation_id)
+            .first()
+        )
+
+    def get_conversation_turns(self, conversation_id: str) -> List[ConversationTurn]:
+        """Return turns for a conversation."""
+        conversation = self.get_conversation(conversation_id)
+        return conversation.turns if conversation else []


### PR DESCRIPTION
## Summary
- add ConversationService to fetch conversations and turns from DB
- expose `/conversations` and `/conversations/{conversation_id}/turns` with auth
- wire up dependency for ConversationService

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6899db58129c8320af0929bce9b36d5e