### PR TITLE
Validate user_id and log Search Service requests

### DIFF
--- a/conversation_service/agents/search_query_agent.py
+++ b/conversation_service/agents/search_query_agent.py
@@ -363,6 +363,16 @@ class SearchQueryAgent(BaseFinancialAgent):
 
             request_payload = query.to_search_request() if hasattr(query, "to_search_request") else query.dict()
 
+            logger.info(
+                (
+                    "Sending search request to Search Service: user_id=%s, "
+                    "conversation_id=%s, query_id=%s"
+                ),
+                query.query_metadata.user_id,
+                query.query_metadata.conversation_id,
+                query.query_metadata.query_id,
+            )
+
             # Execute HTTP request
             response = await self.http_client.post(
                 url=url,

--- a/conversation_service/models/service_contracts.py
+++ b/conversation_service/models/service_contracts.py
@@ -99,6 +99,14 @@ class QueryMetadata(BaseModel):
         }
     }
 
+    @field_validator("user_id")
+    @classmethod
+    def validate_user_id(cls, v: int) -> int:
+        """Ensure user_id is provided and positive."""
+        if v is None or v <= 0:
+            raise ValueError("user_id must be greater than 0")
+        return v
+
 
 class SearchParameters(BaseModel):
     """


### PR DESCRIPTION
## Summary
- enforce positive `user_id` with a field validator in `QueryMetadata`
- add detailed logging of Search Service requests including user and query identifiers

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6899db64d5f88320a5957914d190dd6a