### PR TITLE
Add database session dependency and integrate across endpoints

### DIFF
--- a/enrichment_service/api/routes.py
+++ b/enrichment_service/api/routes.py
@@ -19,7 +19,7 @@ from fastapi import APIRouter, Depends, HTTPException, status, Query
 from sqlalchemy.orm import Session
 from datetime import datetime
 
-from db_service.session import get_db
+from conversation_service.api.dependencies import get_db
 from user_service.api.deps import get_current_active_user
 from db_service.models.user import User
 from db_service.models.sync import RawTransaction

--- a/sync_service/api/endpoints/accounts.py
+++ b/sync_service/api/endpoints/accounts.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, status, Query
 from sqlalchemy.orm import Session
 from typing import Dict, Any, List, Optional
 
-from db_service.session import get_db
+from conversation_service.api.dependencies import get_db
 from user_service.api.deps import get_current_active_user
 from db_service.models.user import User
 from db_service.models.sync import SyncAccount, LoanDetail, RawStock, AccountInformation

--- a/sync_service/api/endpoints/categories.py
+++ b/sync_service/api/endpoints/categories.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 from typing import Dict, Any, List, Optional
 
-from db_service.session import get_db
+from conversation_service.api.dependencies import get_db
 from user_service.api.deps import get_current_active_user, get_current_active_superuser
 from db_service.models.user import User
 from db_service.models.sync import BridgeCategory

--- a/sync_service/api/endpoints/insights.py
+++ b/sync_service/api/endpoints/insights.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 from typing import Dict, Any, Optional
 
-from db_service.session import get_db
+from conversation_service.api.dependencies import get_db
 from user_service.api.deps import get_current_active_user
 from db_service.models.user import User
 from db_service.models.sync import BridgeInsight

--- a/sync_service/api/endpoints/items.py
+++ b/sync_service/api/endpoints/items.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, status, BackgroundTasks
 from sqlalchemy.orm import Session
 from typing import Dict, Any, List, Optional
 
-from db_service.session import get_db
+from conversation_service.api.dependencies import get_db
 from user_service.api.deps import get_current_active_user
 from db_service.models.user import User
 from db_service.models.sync import SyncItem

--- a/sync_service/api/endpoints/stocks.py
+++ b/sync_service/api/endpoints/stocks.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 from typing import Dict, Any, List, Optional
 from datetime import datetime
 
-from db_service.session import get_db
+from conversation_service.api.dependencies import get_db
 from user_service.api.deps import get_current_active_user
 from db_service.models.user import User
 from db_service.models.sync import RawStock, SyncAccount

--- a/sync_service/api/endpoints/sync.py
+++ b/sync_service/api/endpoints/sync.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 from typing import Dict, Any, List
 from datetime import datetime
 
-from db_service.session import get_db
+from conversation_service.api.dependencies import get_db
 from user_service.api.deps import get_current_active_user
 from db_service.models.user import User
 from db_service.models.sync import SyncItem

--- a/sync_service/api/endpoints/transactions.py
+++ b/sync_service/api/endpoints/transactions.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 from typing import Dict, Any, List, Optional
 from datetime import datetime, date
 
-from db_service.session import get_db
+from conversation_service.api.dependencies import get_db
 from user_service.api.deps import get_current_active_user
 from db_service.models.user import User
 from db_service.models.sync import RawTransaction, SyncAccount, BridgeCategory

--- a/sync_service/api/endpoints/webhooks.py
+++ b/sync_service/api/endpoints/webhooks.py
@@ -11,7 +11,7 @@ from typing import Dict, Any, Optional
 # Configuration du logger
 logger = logging.getLogger(__name__)
 
-from db_service.session import get_db
+from conversation_service.api.dependencies import get_db
 from config_service.config import settings
 from sync_service.webhook_handler.processor import process_webhook, validate_webhook
 

--- a/user_service/api/deps.py
+++ b/user_service/api/deps.py
@@ -5,7 +5,7 @@ from jose import jwt, JWTError
 from sqlalchemy.orm import Session
 from typing import Optional
 
-from db_service.session import get_db
+from conversation_service.api.dependencies import get_db
 from db_service.models.user import User
 from user_service.services.users import get_user_by_id
 from config_service.config import settings


### PR DESCRIPTION
## Summary
- add database `get_db` dependency with commit/rollback handling
- use shared `get_db` across enrichment, sync, and user service endpoints

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6899db6d5ebc8320a3e607d13c62f356