### PR TITLE
Add audit logging for search queries

### DIFF
--- a/conversation_service/agents/search_query_agent.py
+++ b/conversation_service/agents/search_query_agent.py
@@ -33,6 +33,8 @@ from ..core.deepseek_client import DeepSeekClient
 from ..utils.validators import ContractValidator
 
 logger = logging.getLogger(__name__)
+# Dedicated logger for security/audit events
+audit_logger = logging.getLogger("audit")
 
 
 class QueryOptimizer:
@@ -362,6 +364,16 @@ class SearchQueryAgent(BaseFinancialAgent):
             }
 
             request_payload = query.to_search_request() if hasattr(query, "to_search_request") else query.dict()
+
+            # Audit logging for search execution
+            metadata = query.query_metadata
+            audit_logger.info(
+                "search query execution: user_id=%s conversation_id=%s query_id=%s intent_type=%s",
+                metadata.user_id,
+                metadata.conversation_id,
+                metadata.query_id,
+                metadata.intent_type,
+            )
 
             # Execute HTTP request
             response = await self.http_client.post(


### PR DESCRIPTION
## Summary
- add audit logger to search query agent
- log user and intent details when executing search queries

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6899db73868883208b414d677563a79c