### PR TITLE
Fix duplicate get_conversation_service import

### DIFF
--- a/conversation_service/api/routes.py
+++ b/conversation_service/api/routes.py
@@ -32,7 +32,6 @@ from .dependencies import (
     get_conversation_manager,
     validate_request_rate_limit,
     get_metrics_collector,
-    get_conversation_service
     get_conversation_service,
 
 )


### PR DESCRIPTION
## Summary
- remove duplicate `get_conversation_service` entry from API dependencies

## Testing
- `python -m py_compile conversation_service/api/routes.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_689a0782d92c8320959d2b01e3844d50