### PR TITLE
Use health_check for team manager status

### DIFF
--- a/conversation_service/core/mvp_team_manager.py
+++ b/conversation_service/core/mvp_team_manager.py
@@ -490,17 +490,26 @@ class MVPTeamManager:
     async def health_check(self) -> Dict[str, Any]:
         """
         Perform and return current health status.
-        
+
         Returns:
             Dictionary containing current health status
         """
         await self._perform_health_check()
-        
+
         return {
             "healthy": self.team_health.overall_healthy if self.team_health else False,
             "timestamp": datetime.utcnow().isoformat(),
             "details": self.team_health.__dict__ if self.team_health else None
         }
+
+    async def get_health_status(self) -> Dict[str, Any]:
+        """
+        Backward compatible wrapper for :meth:`health_check`.
+
+        Returns:
+            Current health status information.
+        """
+        return await self.health_check()
     
     def is_healthy(self) -> bool:
         """


### PR DESCRIPTION
## Summary
- Replace deprecated `get_health_status` call with `health_check` in conversation routes
- Expose `get_health_status` wrapper in `MVPTeamManager`

## Testing
- `pytest` *(fails: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_689a078ccd4883209cf99587610688e1