### PR TITLE
Alias conversation DB service import

### DIFF
--- a/conversation_service/api/routes.py
+++ b/conversation_service/api/routes.py
@@ -32,9 +32,7 @@ from .dependencies import (
     get_conversation_manager,
     validate_request_rate_limit,
     get_metrics_collector,
-    get_conversation_service
     get_conversation_service,
-
 )
 from ..core.conversation_manager import ConversationManager
 from ..models import (
@@ -45,8 +43,7 @@ from ..models import (
 )
 from ..utils.metrics import MetricsCollector
 from ..utils.logging import log_unauthorized_access
-from ..services.conversation_service import ConversationService
-from ..services.conversation_db import ConversationService
+from ..services.conversation_db import ConversationService as ConversationDBService
 from db_service.session import get_db
 import os
 
@@ -86,7 +83,7 @@ async def chat_endpoint(
     user: Annotated[Dict[str, Any], Depends(get_current_user)],
     metrics: Annotated[MetricsCollector, Depends(get_metrics_collector)],
     conversation_service: Annotated[
-        ConversationService, Depends(get_conversation_service)
+        ConversationDBService, Depends(get_conversation_service)
     ],
     db: Annotated[Session, Depends(get_db)],
     _: Annotated[None, Depends(validate_request_rate_limit)],
@@ -445,7 +442,7 @@ async def get_metrics(
 )
 async def list_conversations(
     user: Annotated[Dict[str, Any], Depends(get_current_user)],
-    service: Annotated[ConversationService, Depends(get_conversation_service)],
+    service: Annotated[ConversationDBService, Depends(get_conversation_service)],
     limit: int = Query(10, ge=1, le=100),
     offset: int = Query(0, ge=0),
 ) -> List[ConversationOut]:
@@ -477,7 +474,7 @@ async def list_conversations(
 async def get_conversation_turns(
     conversation_id: str,
     user: Annotated[Dict[str, Any], Depends(get_current_user)],
-    service: Annotated[ConversationService, Depends(get_conversation_service)],
+    service: Annotated[ConversationDBService, Depends(get_conversation_service)],
 ) -> List[ConversationTurn]:
     """Return the turns for a specific conversation."""
     conversation = service.get_conversation(conversation_id)


### PR DESCRIPTION
## Summary
- alias conversation database service to `ConversationDBService`
- update route signatures to use the aliased service

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_689a078550f88320b4f3775e2ea14467