### PR TITLE
Include request parameter in conversation auth dependency

### DIFF
--- a/conversation_service/api/dependencies.py
+++ b/conversation_service/api/dependencies.py
@@ -149,7 +149,6 @@ async def get_metrics_collector() -> MetricsCollector:
     return _metrics_collector
 
 
-async def get_current_user(request: Request) -> Dict[str, Any]:
 def get_conversation_service(
     db: Annotated[Session, Depends(get_db)]
 ) -> ConversationService:
@@ -166,6 +165,7 @@ def get_conversation_service(
 
 
 async def get_current_user(
+    request: Request,
     token: Annotated[str, Depends(oauth2_scheme)]
 ) -> Dict[str, Any]:
     """


### PR DESCRIPTION
## Summary
- accept Request object in conversation service `get_current_user`
- use `oauth2_scheme` token while preserving header-based authorization logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_689a1375997483208b606203a57ae123