### PR TITLE
fix: remove duplicate Session import

### DIFF
--- a/conversation_service/api/dependencies.py
+++ b/conversation_service/api/dependencies.py
@@ -28,7 +28,6 @@ from fastapi import Depends, HTTPException, status, Request
 from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy.orm import Session
 import httpx
-from sqlalchemy.orm import Session
 
 from db_service.session import SessionLocal
 from db_service.session import get_db


### PR DESCRIPTION
## Summary
- remove redundant SQLAlchemy `Session` import from `dependencies`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Could not find a version that satisfies the requirement requests (proxy 403 Forbidden))*

------
https://chatgpt.com/codex/tasks/task_e_689a137960108320bd54350c92f9d905