### PR TITLE
Use separate read/write conversation services

### DIFF
--- a/conversation_service/api/dependencies.py
+++ b/conversation_service/api/dependencies.py
@@ -36,7 +36,12 @@ from ..core.conversation_manager import ConversationManager
 from ..models import ConversationRequest, ConversationResponse
 from ..utils.metrics import MetricsCollector
 from ..utils.logging import log_unauthorized_access
-from ..services.conversation_db import ConversationService
+from ..services.conversation_db import (
+    ConversationService as ConversationWriteService,
+)
+from ..services.conversation_service import (
+    ConversationService as ConversationReadService,
+)
 from config_service.config import settings
 
 oauth2_scheme = OAuth2PasswordBearer(
@@ -156,17 +161,26 @@ async def get_metrics_collector() -> MetricsCollector:
 
 def get_conversation_service(
     db: Annotated[Session, Depends(get_db)]
-) -> ConversationService:
+) -> ConversationWriteService:
     """
-    Dependency to provide ConversationService instance bound to a database session.
-    
+    Dependency to provide ConversationWriteService instance bound to a database
+    session.
+
     Args:
         db: Database session from FastAPI dependency injection
-        
+
     Returns:
-        ConversationService: Service instance for conversation operations
+        ConversationWriteService: Service instance for conversation write
+        operations
     """
-    return ConversationService(db)
+    return ConversationWriteService(db)
+
+
+def get_conversation_read_service(
+    db: Annotated[Session, Depends(get_db)]
+) -> ConversationReadService:
+    """Dependency to provide ConversationReadService for read-only operations."""
+    return ConversationReadService(db)
 
 
 async def get_current_user(

--- a/conversation_service/api/routes.py
+++ b/conversation_service/api/routes.py
@@ -32,6 +32,7 @@ from .dependencies import (
     validate_request_rate_limit,
     get_metrics_collector,
     get_conversation_service,
+    get_conversation_read_service,
 )
 from ..core.conversation_manager import ConversationManager
 from ..models import (
@@ -44,8 +45,8 @@ import os
 
 from ..utils.logging import log_unauthorized_access
 from ..services.conversation_db import ConversationService as ConversationDBService
+from ..services.conversation_service import ConversationService
 from ..utils.metrics import MetricsCollector
-from ..services.conversation_db import ConversationService
 from db_service.session import get_db
 
 try:
@@ -454,7 +455,7 @@ async def get_metrics(
 )
 async def list_conversations(
     user: Annotated[Dict[str, Any], Depends(get_current_user)],
-    service: Annotated[ConversationDBService, Depends(get_conversation_service)],
+    service: Annotated[ConversationService, Depends(get_conversation_read_service)],
     limit: int = Query(10, ge=1, le=100),
     offset: int = Query(0, ge=0),
 ) -> List[ConversationOut]:
@@ -486,7 +487,7 @@ async def list_conversations(
 async def get_conversation_turns(
     conversation_id: str,
     user: Annotated[Dict[str, Any], Depends(get_current_user)],
-    service: Annotated[ConversationDBService, Depends(get_conversation_service)],
+    service: Annotated[ConversationService, Depends(get_conversation_read_service)],
 ) -> List[ConversationTurn]:
     """Return the turns for a specific conversation."""
     conversation = service.get_conversation(conversation_id)


### PR DESCRIPTION
## Summary
- remove duplicate ConversationService import in routes
- introduce read-only ConversationService and alias legacy write service
- provide new dependency for read operations

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_689a194b1b608320886787c7655fa67d