### PR TITLE
refactor: unify db dependency and oauth2 scheme

### DIFF
--- a/conversation_service/api/dependencies.py
+++ b/conversation_service/api/dependencies.py
@@ -30,7 +30,6 @@ from sqlalchemy.orm import Session
 import httpx
 
 from db_service.session import SessionLocal
-from db_service.session import get_db
 from ..core import load_team_manager
 from ..core.conversation_manager import ConversationManager
 from ..models import ConversationRequest, ConversationResponse
@@ -38,10 +37,6 @@ from ..utils.metrics import MetricsCollector
 from ..utils.logging import log_unauthorized_access
 from ..services.conversation_db import ConversationService
 from config_service.config import settings
-
-oauth2_scheme = OAuth2PasswordBearer(
-    tokenUrl=f"{settings.API_V1_STR}/users/auth/login"
-)
 
 if TYPE_CHECKING:
     from ..core.mvp_team_manager import MVPTeamManager
@@ -51,7 +46,7 @@ logger = logging.getLogger(__name__)
 
 # Global instances (singleton pattern)
 _team_manager: Optional["MVPTeamManager"] = None
-_conversation_manager: Optional[ConversationManager] = None  
+_conversation_manager: Optional[ConversationManager] = None
 _metrics_collector: Optional[MetricsCollector] = None
 
 # Rate limiting storage (in-memory for MVP; use Redis or another shared backend in production)


### PR DESCRIPTION
## Summary
- remove duplicate database dependency import and rely on local session helper
- consolidate OAuth2PasswordBearer initialization to a single auth login endpoint

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_e_689a1985ec388320896349dd583ce18b