### PR TITLE
Remove duplicate orchestrator call in MVPTeamManager

### DIFF
--- a/conversation_service/core/mvp_team_manager.py
+++ b/conversation_service/core/mvp_team_manager.py
@@ -182,12 +182,6 @@ class MVPTeamManager:
                 },
                 user_id,
             )
-            
-            response_data = await self.orchestrator.execute_with_metrics({
-                "user_message": user_message,
-                "conversation_id": conversation_id,
-                "user_id": user_id,
-            })
 
             execution_time = (asyncio.get_event_loop().time() - start_time) * 1000
             if response_data.success:


### PR DESCRIPTION
## Summary
- Ensure process_user_message only invokes orchestrator once and passes user_id explicitly

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_689a198574208320ba45ea364858fa7f