### PR TITLE
Fix conversation turns endpoint parameter order

### DIFF
--- a/conversation_service/api/routes.py
+++ b/conversation_service/api/routes.py
@@ -514,11 +514,12 @@ async def list_conversations(
 async def get_conversation_turns(
     conversation_id: str,
     user: Annotated[Dict[str, Any], Depends(get_current_user)],
-    service: Annotated[ConversationDBService, Depends(get_conversation_service)],
-    limit: int = Query(10, ge=1, le=50),
+    db_service: Annotated[ConversationDBService, Depends(get_conversation_service)],
     service: Annotated[ConversationService, Depends(get_conversation_read_service)],
+    limit: int = Query(10, ge=1, le=50),
 ) -> List[ConversationTurn]:
     """Return the turns for a specific conversation."""
+    _ = db_service  # dependency for potential future use
     conversation = service.get_conversation(conversation_id)
     if conversation is None:
         raise HTTPException(


### PR DESCRIPTION
## Summary
- reorder parameters in `get_conversation_turns` to accept `db_service` before `service` and place `limit` last
- reference db service dependency for future use

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_689a2f3b425483209d86c0e2109b18df