### PR TITLE
refactor: use team_result in add_turn

### DIFF
--- a/conversation_service/api/routes.py
+++ b/conversation_service/api/routes.py
@@ -231,30 +231,19 @@ async def chat_endpoint(
 
         try:
             conversation_service.add_turn(
-                conversation,
-                validated_request.message,
-                team_result["content"],
-                processing_time,
-                intent_detected=team_result["metadata"].get("intent_detected"),
-                entities_extracted=team_result["metadata"].get("entities_extracted"),
-                agent_chain=team_result["metadata"].get("agent_chain"),
-                search_results_count=team_result["metadata"].get("search_results_count"),
-                confidence_score=team_result.get("confidence_score"),
-                conversation_id=conversation_id,
                 conversation_id=conversation.conversation_id,
                 user_id=user_id,
                 user_message=validated_request.message,
-                assistant_response=team_response.content,
+                assistant_response=team_result["content"],
                 processing_time_ms=processing_time,
-                intent_detected=team_response.metadata.get("intent_detected"),
-                entities_extracted=team_response.metadata.get("entities_extracted"),
-                confidence_score=team_response.confidence_score,
-                agent_chain=team_response.metadata.get("agent_chain"),
-                search_results_count=team_response.metadata.get("search_results_count"),
-                search_results_count=team_response.metadata.get(
+                intent_detected=team_result["metadata"].get("intent_detected"),
+                entities_extracted=team_result["metadata"].get("entities_extracted"),
+                confidence_score=team_result.get("confidence_score"),
+                agent_chain=team_result["metadata"].get("agent_chain"),
+                search_results_count=team_result["metadata"].get(
                     "search_results_count", 0
                 ),
-                search_execution_time_ms=team_response.metadata.get(
+                search_execution_time_ms=team_result["metadata"].get(
                     "search_execution_time_ms"
                 ),
             )


### PR DESCRIPTION
## Summary
- use `team_result` instead of `team_response` when adding conversation turns
- remove duplicate `conversation_id` and `search_results_count` kwargs

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_689a2f4284d88320a942fdf2e7dc3e5d