### PR TITLE
Fix missing parenthesis in search query audit log

### DIFF
--- a/conversation_service/agents/search_query_agent.py
+++ b/conversation_service/agents/search_query_agent.py
@@ -371,6 +371,7 @@ class SearchQueryAgent(BaseFinancialAgent):
                 metadata.conversation_id,
                 metadata.query_id,
                 metadata.intent_type,
+            )
             logger.info(
                 (
                     "Sending search request to Search Service: user_id=%s, "


### PR DESCRIPTION
## Summary
- close audit logger call in search query agent

## Testing
- `python -m py_compile conversation_service/agents/search_query_agent.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_e_689b2e726fe083209e52ff629e9edb50