### PR TITLE
Expose conversation monitoring endpoints without auth

### DIFF
--- a/conversation_service/api/routes.py
+++ b/conversation_service/api/routes.py
@@ -302,8 +302,7 @@ async def chat_endpoint(
 async def health_check(
     team_manager: Annotated[MVPTeamManager, Depends(get_team_manager)],
     conversation_manager: Annotated[ConversationManager, Depends(get_conversation_manager)],
-    metrics: Annotated[MetricsCollector, Depends(get_metrics_collector)],
-    user: Annotated[Dict[str, Any], Depends(get_current_user)]
+    metrics: Annotated[MetricsCollector, Depends(get_metrics_collector)]
 ) -> Dict[str, Any]:
     """
     Comprehensive health check for all service components.
@@ -412,8 +411,7 @@ async def health_check(
 )
 async def get_metrics(
     metrics: Annotated[MetricsCollector, Depends(get_metrics_collector)],
-    team_manager: Annotated[MVPTeamManager, Depends(get_team_manager)],
-    user: Annotated[Dict[str, Any], Depends(get_current_user)]
+    team_manager: Annotated[MVPTeamManager, Depends(get_team_manager)]
 ) -> Dict[str, Any]:
     """
     Get detailed performance metrics and statistics.
@@ -422,13 +420,6 @@ async def get_metrics(
         Dict containing comprehensive service metrics
     """
     try:
-        # Check if user has metrics permission
-        if "view_metrics" not in user.get("permissions", []):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Insufficient permissions to view metrics"
-            )
-        
         # Get metrics summary
         metrics_summary = metrics.get_summary()
         
@@ -550,9 +541,7 @@ async def get_conversation_turns(
     description="Basic service status and configuration",
     tags=["monitoring"]
 )
-async def get_status(
-    user: Annotated[Dict[str, Any], Depends(get_current_user)]
-) -> Dict[str, Any]:
+async def get_status() -> Dict[str, Any]:
     """
     Get basic service status and configuration information.
     

--- a/test_harena_nominal.py
+++ b/test_harena_nominal.py
@@ -276,7 +276,7 @@ class HarenaTestClient:
         """Test 6: Health check conversation service."""
         self._print_step(6, "HEALTH CHECK CONVERSATION SERVICE")
 
-        response = self._make_request("GET", "/conversation/health")
+        response = self._make_request("GET", "/conversation/health", use_auth=False)
         success, json_data = self._print_response(response)
 
         if success and json_data:
@@ -296,7 +296,7 @@ class HarenaTestClient:
         """Test 7: Status conversation service."""
         self._print_step(7, "STATUS CONVERSATION SERVICE")
 
-        response = self._make_request("GET", "/conversation/status")
+        response = self._make_request("GET", "/conversation/status", use_auth=False)
         success, json_data = self._print_response(response)
 
         if success and json_data:
@@ -352,7 +352,7 @@ class HarenaTestClient:
             print("❌ user_id non disponible")
             return False
 
-        metrics_resp = self._make_request("GET", "/conversation/metrics")
+        metrics_resp = self._make_request("GET", "/conversation/metrics", use_auth=False)
         metrics_ok, metrics_json = self._print_response(metrics_resp)
         if metrics_ok and metrics_json:
             counters = metrics_json.get("service_metrics", {}).get("counters", {})


### PR DESCRIPTION
## Summary
- Remove user auth dependency from health, metrics, and status endpoints
- Drop metrics permission check to avoid calling user service
- Adjust tests to call monitoring endpoints without authentication

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `python -m py_compile conversation_service/api/routes.py test_harena_nominal.py`


------
https://chatgpt.com/codex/tasks/task_e_689b31ef5c9083208cbc15176a540f89