### PR TITLE
Allow service usage before first health check

### DIFF
--- a/conversation_service/core/mvp_team_manager.py
+++ b/conversation_service/core/mvp_team_manager.py
@@ -588,7 +588,9 @@ class MVPTeamManager:
             True if team is healthy, False otherwise
         """
         return (
-            self.is_initialized and 
-            self.team_health is not None and 
-            self.team_health.overall_healthy
+            self.is_initialized and
+            (
+                self.team_health is None or
+                self.team_health.overall_healthy
+            )
         )


### PR DESCRIPTION
## Summary
- Treat team as healthy when no health data has been gathered yet

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Could not find a version that satisfies the requirement requests; proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_689b3ae907c4832083d07c73cbdf3fb0