### PR TITLE
Serialize health check timestamps

### DIFF
--- a/conversation_service/api/routes.py
+++ b/conversation_service/api/routes.py
@@ -328,10 +328,11 @@ async def health_check(
                 team_manager.health_check(), timeout=component_timeout
             )
             details = team_health.get("details", {})
+            last_health_check = details.get("last_health_check")
             health_status["components"]["team_manager"] = {
                 "status": "healthy" if team_health.get("healthy") else "unhealthy",
                 "agents_loaded": len(details.get("agent_statuses", {})),
-                "last_activity": details.get("last_health_check")
+                "last_activity": last_health_check.isoformat() if last_health_check else None
             }
             if not team_health.get("healthy"):
                 health_status["status"] = "degraded"

--- a/conversation_service/core/mvp_team_manager.py
+++ b/conversation_service/core/mvp_team_manager.py
@@ -565,10 +565,14 @@ class MVPTeamManager:
         """
         await self._perform_health_check()
 
+        details = self.team_health.__dict__.copy() if self.team_health else None
+        if details and details.get("last_health_check"):
+            details["last_health_check"] = details["last_health_check"].isoformat()
+
         return {
             "healthy": self.team_health.overall_healthy if self.team_health else False,
             "timestamp": datetime.utcnow().isoformat(),
-            "details": self.team_health.__dict__ if self.team_health else None
+            "details": details
         }
 
     async def get_health_status(self) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- Ensure team manager health check `last_activity` uses ISO timestamp.
- Convert `last_health_check` to ISO string before returning team manager details.

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_e_689b41a26e1083209dffd53a6713ca7b