### PR TITLE
Propagate chat permission in user JWTs

### DIFF
--- a/user_service/api/endpoints/users.py
+++ b/user_service/api/endpoints/users.py
@@ -55,10 +55,13 @@ async def login_access_token(
         )
     
     access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    access_token = create_access_token(
+        user.id,
+        permissions=["chat:write"],
+        expires_delta=access_token_expires,
+    )
     return {
-        "access_token": create_access_token(
-            user.id, expires_delta=access_token_expires
-        ),
+        "access_token": access_token,
         "token_type": "bearer"
     }
 

--- a/user_service/core/security.py
+++ b/user_service/core/security.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import Any, Union, Optional
+from typing import Any, Union, Optional, List
 import logging
 
 from jose import jwt
@@ -51,7 +51,9 @@ ALGORITHM = "HS256"
 
 
 def create_access_token(
-    subject: Union[str, Any], expires_delta: Optional[timedelta] = None
+    subject: Union[str, Any],
+    permissions: Optional[List[str]] = None,
+    expires_delta: Optional[timedelta] = None,
 ) -> str:
     if expires_delta:
         expire = datetime.utcnow() + expires_delta
@@ -59,7 +61,11 @@ def create_access_token(
         expire = datetime.utcnow() + timedelta(
             minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES
         )
-    to_encode = {"exp": expire, "sub": str(subject)}
+    to_encode = {
+        "exp": expire,
+        "sub": str(subject),
+        "permissions": permissions or ["chat:write"],
+    }
     encoded_jwt = jwt.encode(to_encode, settings.SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt
 


### PR DESCRIPTION
## Summary
- include permissions claim (defaulting to `chat:write`) in access tokens
- pass chat permission when issuing tokens from user login endpoint

## Testing
- `pytest` *(fails: No module named 'fastapi'; No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_689b4ffe7bb0832098faba6333eae4c2