### PR TITLE
feat: update search service default URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,9 @@ python test_metrics_endpoint.py
 The conversation service now performs a full agent health check during
 startup. If any agent reports an unhealthy status, initialization fails and
 the process exits instead of running in a degraded state.
+
+## Environment Variables
+
+`SEARCH_SERVICE_URL` sets the base URL for the Search Service. It defaults to
+`http://localhost:8000/api/v1/search` and the service automatically appends
+`/search` when issuing queries.

--- a/conversation_service/core/mvp_team_manager.py
+++ b/conversation_service/core/mvp_team_manager.py
@@ -88,7 +88,7 @@ class MVPTeamManager:
         # Load configuration from environment variables
         self.config = config or self._load_config_from_env()
         self.team_config = team_config or TeamConfiguration(
-            search_service_url=self.config.get('SEARCH_SERVICE_URL', 'http://localhost:8000')
+            search_service_url=self.config.get('SEARCH_SERVICE_URL', 'http://localhost:8000/api/v1/search')
         )
         
         # Core components
@@ -370,7 +370,7 @@ class MVPTeamManager:
             'DEEPSEEK_API_KEY': os.getenv('DEEPSEEK_API_KEY', ''),
             'DEEPSEEK_BASE_URL': os.getenv('DEEPSEEK_BASE_URL', 'https://api.deepseek.com'),
             'DEEPSEEK_TIMEOUT': int(os.getenv('DEEPSEEK_TIMEOUT', '30')),
-            'SEARCH_SERVICE_URL': os.getenv('SEARCH_SERVICE_URL', 'http://localhost:8000'),
+            'SEARCH_SERVICE_URL': os.getenv('SEARCH_SERVICE_URL', 'http://localhost:8000/api/v1/search'),
             'MAX_CONVERSATION_HISTORY': int(os.getenv('MAX_CONVERSATION_HISTORY', '100')),
             'WORKFLOW_TIMEOUT_SECONDS': int(os.getenv('WORKFLOW_TIMEOUT_SECONDS', '60')),
             'HEALTH_CHECK_INTERVAL_SECONDS': int(os.getenv('HEALTH_CHECK_INTERVAL_SECONDS', '300')),


### PR DESCRIPTION
## Summary
- default SEARCH_SERVICE_URL to `http://localhost:8000/api/v1/search`
- document new SEARCH_SERVICE_URL default and note that SearchQueryAgent appends `/search`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install fastapi requests` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_689b5b1305c88320a3ea76574ed9c455