### PR TITLE
Handle unknown entity types

### DIFF
--- a/conversation_service/agents/hybrid_intent_agent.py
+++ b/conversation_service/agents/hybrid_intent_agent.py
@@ -223,9 +223,14 @@ class HybridIntentAgent(BaseFinancialAgent):
         for entity_list in entities.values():
             for e in entity_list:
                 try:
+                    entity_type = EntityType(e.entity_type.upper())
+                except ValueError:
+                    logger.warning(f"Skipping unknown entity type: {e.entity_type}")
+                    continue
+                try:
                     financial_entities.append(
                         FinancialEntity(
-                            entity_type=EntityType(e.entity_type),
+                            entity_type=entity_type,
                             raw_value=e.raw_value,
                             normalized_value=e.normalized_value,
                             confidence=e.confidence,


### PR DESCRIPTION
## Summary
- Normalize rule engine entity types to uppercase before Enum conversion
- Skip unknown entity types gracefully during conversion

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi'; ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_689b5b2381bc8320918170c0593de0f3