### PR TITLE
Expose conversation metrics on main router

### DIFF
--- a/conversation_service/api/__init__.py
+++ b/conversation_service/api/__init__.py
@@ -16,7 +16,7 @@ Exports:
     
     Router:
         - chat_router: Main conversation endpoints router
-        - health_router: Health check and metrics endpoints
+        - health_router: Health check endpoints
     
     Models:
         - ConversationRequest: API request model

--- a/conversation_service/api/routes.py
+++ b/conversation_service/api/routes.py
@@ -404,14 +404,15 @@ async def health_check(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             content=error_response
         )
-@health_router.get(
+@router.get(
     "/metrics",
     summary="Service performance metrics",
     description="Detailed performance metrics and agent statistics",
     responses={
         200: {"description": "Metrics retrieved successfully"},
         503: {"description": "Metrics service unavailable"}
-    }
+    },
+    tags=["monitoring"],
 )
 async def get_metrics(
     metrics: Annotated[MetricsCollector, Depends(get_metrics_collector)],

--- a/conversation_service/api/test_health_route.py
+++ b/conversation_service/api/test_health_route.py
@@ -19,6 +19,9 @@ class StubTeamManager:
             }
         }
 
+    def get_team_performance(self):
+        return {}
+
 
 class StubConversationManager:
     async def get_stats(self):
@@ -26,13 +29,21 @@ class StubConversationManager:
 
 
 class StubMetricsCollector:
+    start_time = 0
+
     def get_summary(self):
         return {"total_requests": 0, "avg_response_time": 0}
+
+    def get_memory_usage(self):
+        return 0
+
+    def get_cpu_usage(self):
+        return 0
 
 
 def create_test_app():
     app = FastAPI()
-    app.include_router(router, prefix="/conversation")
+    app.include_router(router, prefix="/api/v1/conversation")
 
     async def override_team_manager():
         return StubTeamManager()
@@ -52,9 +63,18 @@ def create_test_app():
 def test_health_route_serializes_last_activity():
     app = create_test_app()
     client = TestClient(app)
-    response = client.get("/conversation/health")
+    response = client.get("/api/v1/conversation/health")
     assert response.status_code == 200
     data = response.json()
     last_activity = data["components"]["team_manager"]["last_activity"]
     assert last_activity == "2025-01-01T00:00:00"
+
+
+def test_metrics_route_available():
+    app = create_test_app()
+    client = TestClient(app)
+    response = client.get("/api/v1/conversation/metrics")
+    assert response.status_code == 200
+    data = response.json()
+    assert "service_metrics" in data
 


### PR DESCRIPTION
## Summary
- serve `/metrics` on main router instead of `/health/metrics`
- update API package docs
- cover new `/api/v1/conversation/metrics` path with tests

## Testing
- `pytest -q` *(fails: No module named 'fastapi'; No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_689b5b2ad98c83208281531a7a86ce0c