### PR TITLE
Return conversation id with turns

### DIFF
--- a/conversation_service/api/routes.py
+++ b/conversation_service/api/routes.py
@@ -40,6 +40,7 @@ from ..models import (
     ConversationResponse,
     ConversationOut,
     ConversationTurn,
+    ConversationTurnsResponse,
 )
 import os
 
@@ -486,7 +487,7 @@ async def list_conversations(
 
 @conversations_router.get(
     "/{conversation_id}/turns",
-    response_model=List[ConversationTurn],
+    response_model=ConversationTurnsResponse,
     summary="Get conversation turns",
     description="Return turns of a conversation if it belongs to the user",
     responses={
@@ -501,7 +502,7 @@ async def get_conversation_turns(
     db_service: Annotated[ConversationDBService, Depends(get_conversation_service)],
     service: Annotated[ConversationService, Depends(get_conversation_read_service)],
     limit: int = Query(10, ge=1, le=50),
-) -> List[ConversationTurn]:
+) -> ConversationTurnsResponse:
     """Return the turns for a specific conversation."""
     _ = db_service  # dependency for potential future use
     conversation = service.get_conversation(conversation_id)
@@ -536,7 +537,7 @@ async def get_conversation_turns(
                 agent_chain=t.agent_chain,
             )
         )
-    return turns
+    return {"conversation_id": conversation_id, "turns": turns}
 
 
 @router.get(

--- a/conversation_service/models/__init__.py
+++ b/conversation_service/models/__init__.py
@@ -50,7 +50,8 @@ from .conversation_models import (
     ConversationContext,
     ConversationRequest,
     ConversationResponse,
-    ConversationOut
+    ConversationOut,
+    ConversationTurnsResponse
 )
 
 # Import financial models
@@ -97,6 +98,7 @@ __all__ = [
     "ConversationTurn",
     "ConversationContext",
     "ConversationOut",
+    "ConversationTurnsResponse",
     
     # Financial Models
     "FinancialEntity",

--- a/conversation_service/models/conversation_models.py
+++ b/conversation_service/models/conversation_models.py
@@ -280,6 +280,17 @@ class ConversationOut(BaseModel):
     )
 
 
+class ConversationTurnsResponse(BaseModel):
+    """Response model for conversation turns retrieval."""
+
+    conversation_id: str = Field(
+        ..., description="Identifier of the conversation"
+    )
+    turns: List[ConversationTurn] = Field(
+        ..., description="List of conversation turns"
+    )
+
+
 class ConversationContext(BaseModel):
     """
     Complete conversation context with all turns and state management.

--- a/test_harena_nominal.py
+++ b/test_harena_nominal.py
@@ -424,7 +424,12 @@ class HarenaTestClient:
         # Contrôle persistance
         resp = self._make_request("GET", turns_endpoint)
         success, json_data = self._print_response(resp)
-        if not (success and json_data and isinstance(json_data.get("turns"), list)):
+        if not (
+            success
+            and json_data
+            and json_data.get("conversation_id") == conversation_id
+            and isinstance(json_data.get("turns"), list)
+        ):
             print("❌ Échec récupération des turns")
             return False
 


### PR DESCRIPTION
## Summary
- include conversation ID alongside turn list in conversation turns endpoint
- define ConversationTurnsResponse Pydantic schema and export through models package
- adjust integration test to check for conversation ID in returned data

## Testing
- `python -m py_compile conversation_service/api/routes.py conversation_service/models/conversation_models.py conversation_service/models/__init__.py test_harena_nominal.py`
- `pytest conversation_service/api/test_health_route.py -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install fastapi==0.115.12 -q` *(fails: Could not find a version that satisfies the requirement fastapi==0.115.12)*

------
https://chatgpt.com/codex/tasks/task_e_689b5b309690832083803b0c2d5c9a63