### PR TITLE
Make team performance retrieval asynchronous

### DIFF
--- a/conversation_service/api/routes.py
+++ b/conversation_service/api/routes.py
@@ -430,7 +430,7 @@ async def get_metrics(
         metrics_summary = metrics.get_summary()
         
         # Get team performance
-        team_performance = team_manager.get_team_performance()
+        team_performance = await team_manager.get_team_performance()
         
         # Compile comprehensive metrics
         comprehensive_metrics = {

--- a/conversation_service/api/test_health_route.py
+++ b/conversation_service/api/test_health_route.py
@@ -19,7 +19,7 @@ class StubTeamManager:
             }
         }
 
-    def get_team_performance(self):
+    async def get_team_performance(self):
         return {}
 
 

--- a/conversation_service/core/mvp_team_manager.py
+++ b/conversation_service/core/mvp_team_manager.py
@@ -268,7 +268,7 @@ class MVPTeamManager:
             },
         }
     
-    def get_team_performance(self) -> Dict[str, Any]:
+    async def get_team_performance(self) -> Dict[str, Any]:
         """
         Get comprehensive team performance metrics.
         
@@ -298,7 +298,7 @@ class MVPTeamManager:
         conversation_metrics = {}
         if self.conversation_manager:
             try:
-                conversation_metrics = self.conversation_manager.get_stats()
+                conversation_metrics = await self.conversation_manager.get_stats()
             except Exception as e:
                 conversation_metrics = {"error": str(e)}
         


### PR DESCRIPTION
## Summary
- convert `get_team_performance` to async and await conversation manager stats
- update metrics route to await the new async API
- adjust test stubs for async performance method

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install fastapi==0.115.12 requests==2.32.3` *(fails: Could not find a version that satisfies the requirement fastapi==0.115.12; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689b61b045c483208d1b56b66ef1b752