### PR TITLE
Map user_id to user field in DeepSeek agents

### DIFF
--- a/conversation_service/agents/hybrid_intent_agent.py
+++ b/conversation_service/agents/hybrid_intent_agent.py
@@ -325,8 +325,9 @@ class HybridIntentAgent(BaseFinancialAgent):
         try:
             # Prepare context for AI
             context = self._prepare_ai_context(message, rule_backup)
-            
+
             # Call DeepSeek for intent detection
+            logger.debug("DeepSeek intent detection for user_id=%s", user_id)
             response = await self.deepseek_client.generate_response(
                 messages=[
                     {"role": "system", "content": self._get_ai_detection_prompt()},
@@ -334,7 +335,7 @@ class HybridIntentAgent(BaseFinancialAgent):
                 ],
                 temperature=self.config.temperature,
                 max_tokens=self.config.max_tokens,
-                user_id=user_id,
+                user=str(user_id),
             )
             
             # Parse AI response into structured result

--- a/conversation_service/agents/response_agent.py
+++ b/conversation_service/agents/response_agent.py
@@ -349,6 +349,7 @@ class ResponseAgent(BaseFinancialAgent):
         prompt = self._build_response_prompt(user_message, formatted_results, conversation_context)
 
         try:
+            logger.debug("Generating AI response for user_id=%s", user_id)
             response = await self.deepseek_client.generate_response(
                 messages=[
                     {"role": "system", "content": self._get_response_generation_prompt()},
@@ -356,7 +357,7 @@ class ResponseAgent(BaseFinancialAgent):
                 ],
                 temperature=self.config.temperature,
                 max_tokens=self.config.max_tokens,
-                user_id=user_id,
+                user=str(user_id),
             )
 
             return response.content.strip()

--- a/conversation_service/agents/search_query_agent.py
+++ b/conversation_service/agents/search_query_agent.py
@@ -432,8 +432,9 @@ class SearchQueryAgent(BaseFinancialAgent):
             # Prepare context for entity extraction
             existing_entities = intent_result.entities if intent_result.entities else []
             context = self._prepare_entity_extraction_context(message, existing_entities)
-            
+
             # Call DeepSeek for entity extraction
+            logger.debug("Extracting additional entities for user_id=%s", user_id)
             response = await self.deepseek_client.generate_response(
                 messages=[
                     {"role": "system", "content": self._get_entity_extraction_prompt()},
@@ -441,7 +442,7 @@ class SearchQueryAgent(BaseFinancialAgent):
                 ],
                 temperature=0.1,
                 max_tokens=200,
-                user_id=user_id,
+                user=str(user_id),
             )
             
             # Parse AI response


### PR DESCRIPTION
## Summary
- map deprecated `user_id` parameter to DeepSeek's supported `user` field when calling `generate_response`
- log `user_id` before invoking DeepSeek to preserve downstream traceability

## Testing
- `pytest -q` *(fails: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_689b616ee97483208ed58c7fd9b98c38