### PR TITLE
Handle None values in search filters

### DIFF
--- a/conversation_service/models/service_contracts.py
+++ b/conversation_service/models/service_contracts.py
@@ -410,7 +410,7 @@ class SearchServiceQuery(BaseModel):
 
     def to_search_request(self) -> Dict[str, Any]:
         """Convert this query to the simplified SearchRequest schema."""
-        filters_dict = self.filters.dict() if self.filters else {}
+        filters_dict = self.filters.dict(exclude_none=True) if self.filters else {}
         return {
             "user_id": self.query_metadata.user_id,
             "query": getattr(self.search_parameters, "search_text", ""),

--- a/search_service/core/query_builder.py
+++ b/search_service/core/query_builder.py
@@ -66,8 +66,10 @@ class QueryBuilder:
     def _build_additional_filters(self, filters: Dict[str, Any]) -> List[Dict[str, Any]]:
         """Construction des filtres additionnels"""
         filter_list = []
-        
+
         for field, value in filters.items():
+            if value is None:
+                continue
             if isinstance(value, dict):
                 # Filtre range (ex: {"amount": {"gte": -100, "lte": 0}})
                 filter_list.append({"range": {field: value}})
@@ -152,5 +154,5 @@ class QueryBuilder:
             base_query["aggs"] = aggregations
             # Limiter les résultats si on fait surtout des agrégations
             base_query["size"] = min(request.limit, 10)
-        
+
         return base_query


### PR DESCRIPTION
## Summary
- Drop `None` filter entries when generating search requests in Conversation Service
- Ignore `None` values when building additional filters for Search Service queries

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install fastapi requests` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_689b61756da88320851ce5929398bcfb