### PR TITLE
Add search text to search parameters and query contract

### DIFF
--- a/conversation_service/agents/search_query_agent.py
+++ b/conversation_service/agents/search_query_agent.py
@@ -317,7 +317,7 @@ class SearchQueryAgent(BaseFinancialAgent):
         # Create search parameters based on intent
         search_params = SearchParameters(
             search_text=search_text,
-            size=20 if intent_result.intent_type == "TRANSACTION_SEARCH" else 10,
+            max_results=20 if intent_result.intent_type == "TRANSACTION_SEARCH" else 10,
             include_highlights=True,
             boost_recent=intent_result.intent_type in [
                 "BALANCE_CHECK",

--- a/conversation_service/models/service_contracts.py
+++ b/conversation_service/models/service_contracts.py
@@ -116,6 +116,11 @@ class SearchParameters(BaseModel):
     result limits, sorting, and search strategy preferences.
     """
     
+    search_text: Optional[str] = Field(
+        default=None,
+        description="Text to search for in the Search Service",
+    )
+
     max_results: int = Field(
         default=50,
         description="Maximum number of results to return",
@@ -174,6 +179,7 @@ class SearchParameters(BaseModel):
     model_config = {
         "json_schema_extra": {
             "example": {
+                "search_text": "restaurant paris",
                 "max_results": 20,
                 "offset": 0,
                 "sort_by": "date",
@@ -413,10 +419,10 @@ class SearchServiceQuery(BaseModel):
         filters_dict = self.filters.dict(exclude_none=True) if self.filters else {}
         return {
             "user_id": self.query_metadata.user_id,
-            "query": getattr(self.search_parameters, "search_text", ""),
+            "query": self.search_parameters.search_text or "",
             "filters": filters_dict,
-            "limit": getattr(self.search_parameters, "size", getattr(self.search_parameters, "max_results", 20)),
-            "offset": getattr(self.search_parameters, "offset", 0),
+            "limit": self.search_parameters.max_results,
+            "offset": self.search_parameters.offset,
             "metadata": {
                 "conversation_id": self.query_metadata.conversation_id,
                 "intent_type": self.query_metadata.intent_type,


### PR DESCRIPTION
## Summary
- add optional `search_text` to `SearchParameters`
- forward `search_text` and `max_results` in search contract generation and request builder

## Testing
- `pytest` *(fails: No module named 'fastapi')*
- `pip install fastapi requests` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_689b6f5f29b08320a96815e6c4fc3e88