### PR TITLE
Ensure conversation context starts at zero

### DIFF
--- a/conversation_service/agents/orchestrator_agent.py
+++ b/conversation_service/agents/orchestrator_agent.py
@@ -336,11 +336,12 @@ class WorkflowExecutor:
             from ..models.conversation_models import ConversationContext
             
             turns = []
+            current_turn = 0 if not turns else len(turns)
             return ConversationContext(
                 conversation_id=conversation_id,
                 user_id=user_id,
                 turns=turns,
-                current_turn=len(turns),
+                current_turn=current_turn,
                 status="active",
                 language="fr",
             )


### PR DESCRIPTION
## Summary
- ensure `_create_conversation_context` initializes `current_turn` to 0 when no conversation turns are present

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi'; attempted installation but network blocked)*
- `pytest test_create_conversation_context.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b760bf25483209e75f75edd7be613