### PR TITLE
Align search metadata fields with ResponseMetadata

### DIFF
--- a/conversation_service/agents/orchestrator_agent.py
+++ b/conversation_service/agents/orchestrator_agent.py
@@ -301,10 +301,10 @@ class WorkflowExecutor:
         empty_search_response = {
             "response_metadata": {
                 "query_id": f"fallback_{int(time.time())}",
-                "execution_time_ms": 0,
-                "returned_hits": 0,
-                "total_hits": 0,
-                "has_more": False,
+                "processing_time_ms": 0,
+                "returned_results": 0,
+                "total_results": 0,
+                "has_more_results": False,
                 "cache_hit": False,
                 "search_strategy_used": "none",
             },
@@ -534,7 +534,7 @@ class OrchestratorAgent(BaseFinancialAgent):
             if search_results_count is None:
                 sr_meta = metadata.get("search_response", {}) if isinstance(metadata, dict) else {}
                 rm = sr_meta.get("response_metadata", {}) if isinstance(sr_meta, dict) else {}
-                search_results_count = rm.get("returned_hits", 0)
+                search_results_count = rm.get("returned_results", 0)
 
             entities_extracted = []
             intent_detected = None

--- a/conversation_service/agents/response_agent.py
+++ b/conversation_service/agents/response_agent.py
@@ -242,8 +242,8 @@ class ResponseAgent(BaseFinancialAgent):
                 "metadata": {
                     "formatted_results": formatted_results,
                     "search_stats": {
-                        "total_results": search_response.response_metadata.returned_hits,
-                        "execution_time_ms": search_response.response_metadata.execution_time_ms
+                        "total_results": search_response.response_metadata.returned_results,
+                        "processing_time_ms": search_response.response_metadata.processing_time_ms
                     },
                     "response_generation_time_ms": execution_time,
                     "conversation_updated": context is not None

--- a/conversation_service/agents/search_query_agent.py
+++ b/conversation_service/agents/search_query_agent.py
@@ -219,12 +219,12 @@ class SearchQueryAgent(BaseFinancialAgent):
             
             execution_time = (time.perf_counter() - start_time) * 1000
             
-            returned_hits = getattr(getattr(search_response, "response_metadata", {}), "returned_hits", 0)
+            returned_results = getattr(getattr(search_response, "response_metadata", {}), "returned_results", 0)
             if isinstance(getattr(search_response, "response_metadata", None), dict):
-                returned_hits = search_response.response_metadata.get("returned_hits", 0)
+                returned_results = search_response.response_metadata.get("returned_results", 0)
 
             return {
-                "content": f"Search completed: {returned_hits} results",
+                "content": f"Search completed: {returned_results} results",
                 "metadata": {
                     "search_query": search_query.dict(),
                     "search_response": search_response.dict(),
@@ -232,7 +232,7 @@ class SearchQueryAgent(BaseFinancialAgent):
                         e.dict() for e in enhanced_entities
                     ] if enhanced_entities else [],
                     "execution_time_ms": execution_time,
-                    "search_results_count": returned_hits,
+                    "search_results_count": returned_results,
                 },
                 "confidence_score": min(intent_result.confidence + 0.1, 1.0),  # Boost confidence slightly
                 "token_usage": {
@@ -395,12 +395,12 @@ class SearchQueryAgent(BaseFinancialAgent):
             response_data = response.json()
             search_response = SearchServiceResponse(**response_data)
 
-            returned_hits = getattr(getattr(search_response, "response_metadata", {}), "returned_hits", 0)
+            returned_results = getattr(getattr(search_response, "response_metadata", {}), "returned_results", 0)
             if isinstance(getattr(search_response, "response_metadata", None), dict):
-                returned_hits = search_response.response_metadata.get("returned_hits", 0)
+                returned_results = search_response.response_metadata.get("returned_results", 0)
 
             logger.info(
-                f"Search query executed successfully: {returned_hits} results"
+                f"Search query executed successfully: {returned_results} results"
             )
             
             return search_response

--- a/conversation_service/prompts/response_prompts.py
+++ b/conversation_service/prompts/response_prompts.py
@@ -104,9 +104,9 @@ def format_response_prompt(
     results_formatted = format_search_results_for_prompt(search_results)
     
     metadata = search_results.get("response_metadata", {})
-    total_results = metadata.get("total_count", "inconnu")
-    execution_time = metadata.get("execution_time_ms", "inconnu")
-    query_type = metadata.get("query_type", "inconnu")
+    total_results = metadata.get("total_results", "inconnu")
+    processing_time = metadata.get("processing_time_ms", "inconnu")
+    query_type = metadata.get("search_strategy_used", "inconnu")
     
     context_section = ""
     if context and context.strip():
@@ -116,7 +116,7 @@ def format_response_prompt(
         user_message=user_message.strip(),
         search_results=results_formatted,
         total_results=total_results,
-        execution_time=execution_time,
+        execution_time=processing_time,
         query_type=query_type,
         context_section=context_section
     )

--- a/conversation_service/utils/validators.py
+++ b/conversation_service/utils/validators.py
@@ -248,8 +248,10 @@ class ContractValidator:
             else:
                 if "total_results" not in metadata:
                     errors.append("response_metadata missing: total_results")
-                if "execution_time_ms" not in metadata:
-                    errors.append("response_metadata missing: execution_time_ms")
+                if "returned_results" not in metadata:
+                    errors.append("response_metadata missing: returned_results")
+                if "processing_time_ms" not in metadata:
+                    errors.append("response_metadata missing: processing_time_ms")
         
         # Validation results
         if "results" in response:

--- a/search_service/core/search_engine.py
+++ b/search_service/core/search_engine.py
@@ -55,8 +55,8 @@ class SearchEngine:
             # Calcul temps d'exécution
             execution_time = int((time.time() - start_time) * 1000)
 
-            total_hits = self._get_total_hits(es_response)
-            returned_hits = len(results)
+            total_results = self._get_total_hits(es_response)
+            returned_results = len(results)
 
             response = {
                 "results": [r.model_dump() for r in results],
@@ -67,9 +67,9 @@ class SearchEngine:
                     "query_id": (request.metadata or {}).get("query_id", "unknown"),
                     "response_timestamp": datetime.utcnow().isoformat(),
                     "processing_time_ms": execution_time,
-                    "total_results": total_hits,
-                    "returned_results": returned_hits,
-                    "has_more_results": total_hits > (returned_hits + request.offset),
+                    "total_results": total_results,
+                    "returned_results": returned_results,
+                    "has_more_results": total_results > (returned_results + request.offset),
                     "search_strategy_used": (request.metadata or {}).get(
                         "search_strategy", "standard"
                     ),
@@ -84,7 +84,7 @@ class SearchEngine:
                 )
 
             logger.info(
-                f"Search completed: {returned_hits}/{total_hits} results in {execution_time}ms"
+                f"Search completed: {returned_results}/{total_results} results in {execution_time}ms"
             )
             return response
 
@@ -356,8 +356,8 @@ class SearchEngine:
             # Calcul temps d'exécution
             execution_time = int((time.time() - start_time) * 1000)
 
-            total_hits = self._get_total_hits(es_response)
-            returned_hits = len(results)
+            total_results = self._get_total_hits(es_response)
+            returned_results = len(results)
 
             response = {
                 "results": [r.model_dump() for r in results],
@@ -368,9 +368,9 @@ class SearchEngine:
                     "query_id": (request.metadata or {}).get("query_id", "unknown"),
                     "response_timestamp": datetime.utcnow().isoformat(),
                     "processing_time_ms": execution_time,
-                    "total_results": total_hits,
-                    "returned_results": returned_hits,
-                    "has_more_results": total_hits > (returned_hits + request.offset),
+                    "total_results": total_results,
+                    "returned_results": returned_results,
+                    "has_more_results": total_results > (returned_results + request.offset),
                     "search_strategy_used": (request.metadata or {}).get(
                         "search_strategy", "standard"
                     ),
@@ -385,7 +385,7 @@ class SearchEngine:
                 )
 
             logger.info(
-                f"Search completed: {returned_hits}/{total_hits} results in {execution_time}ms"
+                f"Search completed: {returned_results}/{total_results} results in {execution_time}ms"
             )
             return response
 

--- a/search_service/models/response.py
+++ b/search_service/models/response.py
@@ -37,9 +37,9 @@ class SearchResponse(BaseModel):
     results: List[SearchResult] = Field(default_factory=list, description="Liste des résultats")
     
     # Métadonnées de la recherche
-    total_hits: int = Field(..., description="Nombre total de résultats")
-    returned_hits: int = Field(..., description="Nombre de résultats retournés")
-    execution_time_ms: int = Field(..., description="Temps d'exécution en ms")
+    total_results: int = Field(..., description="Nombre total de résultats")
+    returned_results: int = Field(..., description="Nombre de résultats retournés")
+    processing_time_ms: int = Field(..., description="Temps de traitement en ms")
     
     # Informations Elasticsearch
     elasticsearch_took: Optional[int] = Field(None, description="Temps Elasticsearch en ms")
@@ -73,9 +73,9 @@ class SearchResponse(BaseModel):
                         "score": 1.0
                     }
                 ],
-                "total_hits": 156,
-                "returned_hits": 1,
-                "execution_time_ms": 45,
+                "total_results": 156,
+                "returned_results": 1,
+                "processing_time_ms": 45,
                 "elasticsearch_took": 23,
                 "cache_hit": False
             }

--- a/test_harena_nominal.py
+++ b/test_harena_nominal.py
@@ -248,13 +248,13 @@ class HarenaTestClient:
 
         if success and json_data:
             metadata = json_data.get("response_metadata", {})
-            total_hits = metadata.get("total_results", 0)
-            returned_hits = metadata.get("returned_results", 0)
+            total_results = metadata.get("total_results", 0)
+            returned_results = metadata.get("returned_results", 0)
             processing_time = metadata.get("processing_time_ms", 0)
             es_took = metadata.get("elasticsearch_took", 0)
 
-            print(f"✅ Résultats trouvés: {total_hits}")
-            print(f"✅ Résultats retournés: {returned_hits}")
+            print(f"✅ Résultats trouvés: {total_results}")
+            print(f"✅ Résultats retournés: {returned_results}")
             print(f"✅ Temps de traitement: {processing_time}ms")
             print(f"✅ Temps Elasticsearch: {es_took}ms")
 


### PR DESCRIPTION
## Summary
- replace legacy `returned_hits` and `execution_time_ms` with `returned_results` and `processing_time_ms` in response agent search stats
- propagate updated `ResponseMetadata` fields across agents, prompts and validators
- update search service models and engine to emit new field names and adjust tests

## Testing
- `pytest -q` *(fails: No module named 'fastapi'; missing dependencies)*
- `pip install fastapi requests -q` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_689b7ad9d2948320abf3efa5ff3f448d