### PR TITLE
Use returned_results from search metadata

### DIFF
--- a/conversation_service/agents/search_query_agent.py
+++ b/conversation_service/agents/search_query_agent.py
@@ -219,12 +219,12 @@ class SearchQueryAgent(BaseFinancialAgent):
             
             execution_time = (time.perf_counter() - start_time) * 1000
             
-            returned_hits = getattr(getattr(search_response, "response_metadata", {}), "returned_hits", 0)
+            returned_results = getattr(getattr(search_response, "response_metadata", {}), "returned_results", 0)
             if isinstance(getattr(search_response, "response_metadata", None), dict):
-                returned_hits = search_response.response_metadata.get("returned_hits", 0)
+                returned_results = search_response.response_metadata.get("returned_results", 0)
 
             return {
-                "content": f"Search completed: {returned_hits} results",
+                "content": f"Search completed: {returned_results} results",
                 "metadata": {
                     "search_query": search_query.dict(),
                     "search_response": search_response.dict(),
@@ -232,7 +232,7 @@ class SearchQueryAgent(BaseFinancialAgent):
                         e.dict() for e in enhanced_entities
                     ] if enhanced_entities else [],
                     "execution_time_ms": execution_time,
-                    "search_results_count": returned_hits,
+                    "search_results_count": returned_results,
                 },
                 "confidence_score": min(intent_result.confidence + 0.1, 1.0),  # Boost confidence slightly
                 "token_usage": {
@@ -395,14 +395,14 @@ class SearchQueryAgent(BaseFinancialAgent):
             response_data = response.json()
             search_response = SearchServiceResponse(**response_data)
 
-            returned_hits = getattr(getattr(search_response, "response_metadata", {}), "returned_hits", 0)
+            returned_results = getattr(getattr(search_response, "response_metadata", {}), "returned_results", 0)
             if isinstance(getattr(search_response, "response_metadata", None), dict):
-                returned_hits = search_response.response_metadata.get("returned_hits", 0)
+                returned_results = search_response.response_metadata.get("returned_results", 0)
 
             logger.info(
-                f"Search query executed successfully: {returned_hits} results"
+                f"Search query executed successfully: {returned_results} results"
             )
-            
+
             return search_response
             
         except httpx.HTTPStatusError as e:


### PR DESCRIPTION
## Summary
- use `returned_results` for search statistics
- log `returned_results` after executing search queries

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi'; ModuleNotFoundError: No module named 'requests')*
- `pip install fastapi requests` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_689b7af2aa88832094bb784a5c3afb44