### PR TITLE
Align search test with updated metadata fields

### DIFF
--- a/test_harena_nominal.py
+++ b/test_harena_nominal.py
@@ -250,15 +250,15 @@ class HarenaTestClient:
             metadata = json_data.get("response_metadata", {})
             total_results = metadata.get("total_results", 0)
             returned_results = metadata.get("returned_results", 0)
-            processing_time = metadata.get("processing_time_ms", 0)
-            es_took = metadata.get("elasticsearch_took", 0)
+            processing_time_ms = metadata.get("processing_time_ms", 0)
+            elasticsearch_took = metadata.get("elasticsearch_took", 0)
 
             print(f"✅ Résultats trouvés: {total_results}")
             print(f"✅ Résultats retournés: {returned_results}")
-            print(f"✅ Temps de traitement: {processing_time}ms")
-            print(f"✅ Temps Elasticsearch: {es_took}ms")
+            print(f"✅ Temps de traitement: {processing_time_ms}ms")
+            print(f"✅ Temps Elasticsearch: {elasticsearch_took}ms")
 
-            if total_hits > 0:
+            if total_results > 0:
                 print("✅ Recherche fonctionnelle - Résultats trouvés")
                 
                 # Afficher quelques détails des résultats


### PR DESCRIPTION
## Summary
- Replace legacy hit fields with `total_results` and `returned_results`
- Report search timing using `processing_time_ms` and `elasticsearch_took`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_689b805f81148320be3871d9eea4a3c3