### PR TITLE
Add DeepSeek errors to OpenAI stub

### DIFF
--- a/tests/conversation_service/core/test_core_components.py
+++ b/tests/conversation_service/core/test_core_components.py
@@ -81,6 +81,14 @@ for module_name, class_name in [
 # Stub openai module used by DeepSeekClient
 openai_mod = types.ModuleType("openai")
 
+
+class DeepSeekError(Exception):
+    pass
+
+
+class DeepSeekTimeoutError(DeepSeekError):
+    pass
+
 class _DummyOpenAI:
     handler = None  # set per test
 
@@ -93,7 +101,8 @@ class _DummyOpenAI:
         if _DummyOpenAI.handler is None:
             raise NotImplementedError("No handler set for AsyncOpenAI")
         return await _DummyOpenAI.handler(*args, **kwargs)
-
+openai_mod.DeepSeekError = DeepSeekError
+openai_mod.DeepSeekTimeoutError = DeepSeekTimeoutError
 openai_mod.AsyncOpenAI = _DummyOpenAI
 
 openai_types = types.ModuleType("openai.types")


### PR DESCRIPTION
## Summary
- Define DeepSeekError and DeepSeekTimeoutError in test module
- Expose these error classes in the OpenAI stub to mimic real DeepSeek client behavior

## Testing
- `pytest tests/conversation_service/core/test_core_components.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689ba5934ec483208f561870931a5ec6