### PR TITLE
test: isolate httpx stubs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,53 @@
+import sys
+import types
+import pytest
+
+
+@pytest.fixture
+def httpx_stub(monkeypatch):
+    httpx = types.ModuleType("httpx")
+
+    class Response:
+        def __init__(self, *args, **kwargs):
+            self._json = kwargs.get("json", {})
+
+        def json(self):
+            return self._json
+
+        def raise_for_status(self):
+            pass
+
+    class AsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def post(self, *args, **kwargs):
+            return Response()
+
+        async def aclose(self):
+            pass
+
+    class HTTPStatusError(Exception):
+        pass
+
+    class TimeoutException(Exception):
+        pass
+
+    class RequestError(Exception):
+        pass
+
+    httpx.Response = Response
+    httpx.AsyncClient = AsyncClient
+    httpx.HTTPStatusError = HTTPStatusError
+    httpx.TimeoutException = TimeoutException
+    httpx.RequestError = RequestError
+
+    monkeypatch.setitem(sys.modules, "httpx", httpx)
+    yield httpx
+

--- a/tests/conversation_service/core/test_core_components.py
+++ b/tests/conversation_service/core/test_core_components.py
@@ -119,28 +119,13 @@ sys.modules['openai.types'] = openai_types
 sys.modules['openai.types.chat'] = openai_chat
 
 # Stub httpx module required by deepseek_client
-httpx_mod = types.ModuleType("httpx")
-class HTTPStatusError(Exception):
-    pass
-class TimeoutException(Exception):
-    pass
-httpx_mod.HTTPStatusError = HTTPStatusError
-httpx_mod.TimeoutException = TimeoutException
-httpx_mod.RequestError = Exception
-sys.modules['httpx'] = httpx_mod
 
-# ---- Import the modules under test ---------------------------------------------
-from conversation_service.core.conversation_manager import ConversationManager
-from conversation_service.core.mvp_team_manager import MVPTeamManager, TeamConfiguration
-from conversation_service.core.deepseek_client import (
-    DeepSeekClient,
-    DeepSeekError,
-    DeepSeekTimeoutError,
-)
 
 # ---- Tests ---------------------------------------------------------------------
 
-def test_conversation_manager_creates_and_updates_context():
+def test_conversation_manager_creates_and_updates_context(httpx_stub):
+    from conversation_service.core.conversation_manager import ConversationManager
+
     async def run_test():
         manager = ConversationManager()
         await manager.initialize()
@@ -158,7 +143,9 @@ def test_conversation_manager_creates_and_updates_context():
     asyncio.run(run_test())
 
 
-def test_mvp_team_manager_initialization_and_recovery(monkeypatch):
+def test_mvp_team_manager_initialization_and_recovery(monkeypatch, httpx_stub):
+    from conversation_service.core.mvp_team_manager import MVPTeamManager
+
     async def run_test():
         manager = MVPTeamManager()
 
@@ -203,7 +190,9 @@ def test_mvp_team_manager_initialization_and_recovery(monkeypatch):
     asyncio.run(run_test())
 
 
-def test_deepseek_client_cache_and_timeout(monkeypatch):
+def test_deepseek_client_cache_and_timeout(monkeypatch, httpx_stub):
+    from conversation_service.core.deepseek_client import DeepSeekClient, DeepSeekTimeoutError
+
     async def run_test():
         monkeypatch.setenv("DEEPSEEK_API_KEY", "test")
         monkeypatch.setenv("REDIS_CACHE_ENABLED", "false")


### PR DESCRIPTION
## Summary
- replace global httpx overrides with a shared `httpx_stub` fixture
- load agent and core modules only after applying the stub to avoid polluting other tests
- add package init files so tests import correctly

## Testing
- `pytest tests/conversation_service/test_search_query_agent.py`
- `pytest tests/conversation_service/agents/test_agents.py`
- `pytest tests/conversation_service/core/test_core_components.py`


------
https://chatgpt.com/codex/tasks/task_e_689ba99e338483209b6608cd615a35c8