### PR TITLE
fix conv_models module setup in agent tests

### DIFF
--- a/tests/conversation_service/agents/test_agents.py
+++ b/tests/conversation_service/agents/test_agents.py
@@ -16,6 +16,7 @@ sys.path.insert(0, ROOT_DIR)
 
 
 # --- Stub definitions used in tests ---
+conv_models = types.ModuleType("conversation_service.models.conversation_models")
 
 @dataclass
 class AgentConfig:
@@ -278,9 +279,9 @@ def agent_classes(monkeypatch, httpx_stub):
     monkeypatch.setitem(sys.modules, "conversation_service.models.financial_models", financial_models)
 
     # Stub conversation_models
-    conv_models = types.ModuleType("conversation_service.models.conversation_models")
-    conv_models.ConversationContext = ConversationContext
-    monkeypatch.setitem(sys.modules, "conversation_service.models.conversation_models", conv_models)
+    monkeypatch.setitem(
+        sys.modules, "conversation_service.models.conversation_models", conv_models
+    )
 
     # Stub service_contracts
     service_contracts = types.ModuleType("conversation_service.models.service_contracts")


### PR DESCRIPTION
## Summary
- define conversation models stub before dataclass declarations in agent tests
- reuse conversation models stub in agent test fixtures

## Testing
- `pytest tests/conversation_service/agents/test_agents.py`

------
https://chatgpt.com/codex/tasks/task_e_689bb292096c8320b2959f3d0dbac0ad