### PR TITLE
refactor: use explicit model module imports

### DIFF
--- a/conversation_service/api/__init__.py
+++ b/conversation_service/api/__init__.py
@@ -51,16 +51,16 @@ from .routes import (
 )
 
 # API Models for external use
-from ..models import (
+from ..models.conversation_models import (
     ConversationRequest,
     ConversationResponse,
     ConversationTurn,
-    ConversationContext
+    ConversationContext,
 )
 
 from ..models.agent_models import (
     AgentResponse,
-    TeamWorkflow
+    TeamWorkflow,
 )
 
 # Package metadata

--- a/conversation_service/api/dependencies.py
+++ b/conversation_service/api/dependencies.py
@@ -33,7 +33,7 @@ from jose import JWTError, jwt
 from db_service.session import SessionLocal
 from ..core import load_team_manager
 from ..core.conversation_manager import ConversationManager
-from ..models import ConversationRequest, ConversationResponse
+from ..models.conversation_models import ConversationRequest, ConversationResponse
 from ..utils.metrics import MetricsCollector
 from ..utils.logging import log_unauthorized_access
 from ..services.conversation_db import (

--- a/conversation_service/api/routes.py
+++ b/conversation_service/api/routes.py
@@ -35,7 +35,7 @@ from .dependencies import (
     get_conversation_read_service,
 )
 from ..core.conversation_manager import ConversationManager
-from ..models import (
+from ..models.conversation_models import (
     ConversationRequest,
     ConversationResponse,
     ConversationOut,


### PR DESCRIPTION
## Summary
- replace `..models` imports with `..models.conversation_models` in API dependencies and routes
- import conversation models explicitly in API package `__init__`

## Testing
- `pytest` *(fails: No module named 'fastapi'; ImportError: cannot import name 'TeamWorkflow' from 'conversation_service.models.agent_models'; No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_689bb6732d908320b452d8d8468fb4ff