### PR TITLE
refactor: lazily import conversation models

### DIFF
--- a/conversation_service/models/__init__.py
+++ b/conversation_service/models/__init__.py
@@ -1,126 +1,72 @@
-"""
-Models package for Conversation Service MVP.
+"""Convenience imports for conversation service models.
 
-This module provides all the essential data models for the AutoGen-based
-conversation service, including agent configurations, conversation context,
-financial entities, and service contracts.
-
-Exports:
-    Agent Models:
-        - AgentConfig: Configuration for AutoGen agents
-        - AgentResponse: Standardized agent response format
-        - TeamWorkflow: Team workflow configuration
-    
-    Conversation Models:
-        - ConversationRequest: API request model
-        - ConversationResponse: API response model
-        - ConversationTurn: Individual conversation turn
-        - ConversationContext: Complete conversation context
-    
-    Financial Models:
-        - FinancialEntity: Extracted financial entities
-        - IntentResult: Intent classification results
-    
-    Service Contracts:
-        - SearchServiceQuery: Search service request contract
-        - SearchServiceResponse: Search service response contract
-        - QueryMetadata: Query metadata for search
-        - SearchParameters: Search parameters configuration
-        - SearchFilters: Search filters model
-        - ResponseMetadata: Response metadata model
-        - TransactionResult: Transaction result model
-        - AggregationRequest: Aggregation request model (optional)
-        - AggregationResult: Aggregation result model (optional)
-
-Author: Conversation Service Team
-Created: 2025-01-31
-Version: 1.0.0 MVP - Pydantic V2
+This package exposes a collection of Pydantic models used throughout the
+conversation service.  To keep import time fast and avoid potential side
+effects, the individual model modules are imported lazily on first access
+instead of eagerly at package import time.
 """
 
-# Import agent models
-from .agent_models import (
-    AgentConfig,
-    AgentResponse,
-    TeamWorkflow
-)
+from importlib import import_module
+from typing import Any, Dict
 
-# Import conversation models
-from .conversation_models import (
-    ConversationTurn,
-    ConversationContext,
-    ConversationRequest,
-    ConversationResponse,
-    ConversationOut,
-    ConversationTurnsResponse
-)
+_lazy_modules: Dict[str, str] = {
+    # Agent models
+    "AgentConfig": "agent_models",
+    "AgentResponse": "agent_models",
+    "TeamWorkflow": "agent_models",
 
-# Import financial models
-from .financial_models import (
-    FinancialEntity,
-    IntentResult,
-    EntityType,
-    IntentCategory,
-    DetectionMethod
-)
+    # Conversation models
+    "ConversationRequest": "conversation_models",
+    "ConversationResponse": "conversation_models",
+    "ConversationTurn": "conversation_models",
+    "ConversationContext": "conversation_models",
+    "ConversationOut": "conversation_models",
+    "ConversationTurnsResponse": "conversation_models",
 
-# Import service contracts
-from .service_contracts import (
-    SearchServiceQuery,
-    SearchServiceResponse,
-    QueryMetadata,
-    SearchParameters,
-    SearchFilters,
-    ResponseMetadata,
-    TransactionResult,
-    AggregationRequest,
-    AggregationResult,
-    # Utility functions
-    validate_search_query_contract,
-    validate_search_response_contract,
-    create_minimal_query,
-    create_error_response
-)
+    # Financial models
+    "FinancialEntity": "financial_models",
+    "IntentResult": "financial_models",
+    "EntityType": "financial_models",
+    "IntentCategory": "financial_models",
+    "DetectionMethod": "financial_models",
 
-# Package metadata
-__version__ = "1.0.0"
-__author__ = "Conversation Service Team"
+    # Service contracts
+    "SearchServiceQuery": "service_contracts",
+    "SearchServiceResponse": "service_contracts",
+    "QueryMetadata": "service_contracts",
+    "SearchParameters": "service_contracts",
+    "SearchFilters": "service_contracts",
+    "ResponseMetadata": "service_contracts",
+    "TransactionResult": "service_contracts",
+    "AggregationRequest": "service_contracts",
+    "AggregationResult": "service_contracts",
+    "validate_search_query_contract": "service_contracts",
+    "validate_search_response_contract": "service_contracts",
+    "create_minimal_query": "service_contracts",
+    "create_error_response": "service_contracts",
+}
 
-# Export all models for easy importing
-__all__ = [
-    # Agent Models
-    "AgentConfig",
-    "AgentResponse", 
-    "TeamWorkflow",
-    
-    # Conversation Models
-    "ConversationRequest",
-    "ConversationResponse",
-    "ConversationTurn",
-    "ConversationContext",
-    "ConversationOut",
-    "ConversationTurnsResponse",
-    
-    # Financial Models
-    "FinancialEntity",
-    "IntentResult",
-    "EntityType",
-    "IntentCategory", 
-    "DetectionMethod",
-    
-    # Service Contracts
-    "SearchServiceQuery",
-    "SearchServiceResponse",
-    "QueryMetadata",
-    "SearchParameters", 
-    "SearchFilters",
-    "ResponseMetadata",
-    "TransactionResult",
-    "AggregationRequest",
-    "AggregationResult",
-    
-    # Utility Functions
-    "validate_search_query_contract",
-    "validate_search_response_contract",
-    "create_minimal_query",
-    "create_error_response"
-]
+__all__ = list(_lazy_modules.keys())
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - thin wrapper
+    """Lazily import models when they are accessed.
+
+    This allows ``from conversation_service.models import AgentConfig`` while
+    deferring the actual import of ``agent_models`` until ``AgentConfig`` is
+    requested, avoiding the overhead of importing every model up front.
+    """
+
+    module_name = _lazy_modules.get(name)
+    if module_name is None:  # pragma: no cover - standard error path
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module = import_module(f".{module_name}", __name__)
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> Any:  # pragma: no cover - simple delegation
+    return sorted(__all__)
+

--- a/conversation_service/models/agent_models.py
+++ b/conversation_service/models/agent_models.py
@@ -19,6 +19,8 @@ from typing import Dict, List, Optional, Any, Literal
 from pydantic import BaseModel, Field, field_validator, model_validator
 from datetime import datetime
 
+__all__ = ["AgentConfig", "AgentResponse", "TeamWorkflow"]
+
 
 class AgentConfig(BaseModel):
     """
@@ -148,6 +150,8 @@ class AgentConfig(BaseModel):
             }
         }
     }
+
+
 
 
 class AgentResponse(BaseModel):

--- a/conversation_service/models/conversation_models.py
+++ b/conversation_service/models/conversation_models.py
@@ -21,6 +21,15 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 from datetime import datetime
 from uuid import uuid4
 
+__all__ = [
+    "ConversationRequest",
+    "ConversationResponse",
+    "ConversationTurn",
+    "ConversationContext",
+    "ConversationOut",
+    "ConversationTurnsResponse",
+]
+
 
 class ConversationRequest(BaseModel):
     """

--- a/conversation_service/models/financial_models.py
+++ b/conversation_service/models/financial_models.py
@@ -19,6 +19,14 @@ from datetime import datetime, date
 from decimal import Decimal
 from enum import Enum
 
+__all__ = [
+    "EntityType",
+    "IntentCategory",
+    "DetectionMethod",
+    "FinancialEntity",
+    "IntentResult",
+]
+
 
 class EntityType(str, Enum):
     """Enumeration of supported financial entity types."""

--- a/conversation_service/models/service_contracts.py
+++ b/conversation_service/models/service_contracts.py
@@ -27,6 +27,22 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 from datetime import datetime
 from uuid import uuid4
 
+__all__ = [
+    "QueryMetadata",
+    "SearchParameters",
+    "SearchFilters",
+    "AggregationRequest",
+    "SearchServiceQuery",
+    "ResponseMetadata",
+    "TransactionResult",
+    "AggregationResult",
+    "SearchServiceResponse",
+    "validate_search_query_contract",
+    "validate_search_response_contract",
+    "create_minimal_query",
+    "create_error_response",
+]
+
 
 class QueryMetadata(BaseModel):
     """


### PR DESCRIPTION
## Summary
- load model modules lazily through conversation_service.models to avoid eager imports
- declare explicit __all__ in individual model modules

## Testing
- `pytest` *(fails: No module named 'fastapi'; no module named 'pydantic'; No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_689bb677919c8320bd5e2d5bedd6fbef