### PR TITLE
Handle per-request timeout in HarenaTestClient

### DIFF
--- a/tests/harena_test_client.py
+++ b/tests/harena_test_client.py
@@ -1,0 +1,20 @@
+from typing import Any, Dict, Optional
+
+REQUEST_TIMEOUT = 5
+
+class HarenaTestClient:
+    """Minimal HTTP client used for testing timeout behaviour."""
+
+    def __init__(self, base_url: str, session: Any):
+        self.base_url = base_url.rstrip('/')
+        self.session = session
+
+    def _make_request(self, method: str, endpoint: str, **kwargs: Any) -> Any:
+        url = f"{self.base_url}{endpoint}"
+        return self.session.request(method, url, timeout=REQUEST_TIMEOUT, **kwargs)
+
+    def get(self, endpoint: str, **kwargs: Any) -> Any:
+        return self._make_request("GET", endpoint, **kwargs)
+
+    def post(self, endpoint: str, json: Optional[Dict[str, Any]] = None, **kwargs: Any) -> Any:
+        return self._make_request("POST", endpoint, json=json, **kwargs)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,18 @@
+import pytest
+
+from .harena_test_client import HarenaTestClient, REQUEST_TIMEOUT
+
+
+class TimeoutException(Exception):
+    pass
+
+
+def test_timeout_triggers_error():
+    class SlowSession:
+        def request(self, method, url, timeout=None, **kwargs):
+            assert timeout == REQUEST_TIMEOUT
+            raise TimeoutException("timed out")
+
+    client = HarenaTestClient("http://example.com", session=SlowSession())
+    with pytest.raises(TimeoutException):
+        client.get("/slow")


### PR DESCRIPTION
## Summary
- add lightweight HarenaTestClient that applies `timeout=REQUEST_TIMEOUT` for every request
- test that a timeout in `_make_request` surfaces as an error

## Testing
- `pytest tests/test_main.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install fastapi pydantic httpx requests` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_689bbda9cb248320b354945f167f9cc8