### PR TITLE
Handle string entity types in search query agent

### DIFF
--- a/conversation_service/agents/search_query_agent.py
+++ b/conversation_service/agents/search_query_agent.py
@@ -541,7 +541,10 @@ class SearchQueryAgent(BaseFinancialAgent):
                                     )
                         logger.debug(
                             "Recognized entities: %s",
-                            [f"{e.entity_type.value}: {e.normalized_value}" for e in entities],
+                            [
+                                f"{getattr(e.entity_type, 'value', e.entity_type)}: {e.normalized_value}"
+                                for e in entities
+                            ],
                         )
                         return entities
                 except json.JSONDecodeError as e:
@@ -573,7 +576,10 @@ class SearchQueryAgent(BaseFinancialAgent):
 
             logger.debug(
                 "Recognized entities: %s",
-                [f"{e.entity_type.value}: {e.normalized_value}" for e in entities],
+                [
+                    f"{getattr(e.entity_type, 'value', e.entity_type)}: {e.normalized_value}"
+                    for e in entities
+                ],
             )
 
         except Exception as e:

--- a/tests/test_search_query_agent.py
+++ b/tests/test_search_query_agent.py
@@ -1,0 +1,29 @@
+from conversation_service.agents import base_financial_agent
+
+# Ensure the base agent does not require AutoGen during tests
+base_financial_agent.AUTOGEN_AVAILABLE = True
+
+from conversation_service.agents.search_query_agent import SearchQueryAgent
+from conversation_service.models.financial_models import FinancialEntity, EntityType
+
+
+class DummyDeepSeekClient:
+    api_key = "test-key"
+    base_url = "http://api.example.com"
+
+
+def test_prepare_entity_context_with_string_entity_type():
+    agent = SearchQueryAgent(
+        deepseek_client=DummyDeepSeekClient(),
+        search_service_url="http://search.example.com",
+    )
+    entity = FinancialEntity(
+        entity_type=EntityType.MERCHANT,
+        raw_value="Starbucks",
+        normalized_value="Starbucks",
+        confidence=0.9,
+    )
+    # Simulate an entity where entity_type is a plain string
+    entity.entity_type = "MERCHANT"
+    context = agent._prepare_entity_extraction_context("message", [entity])
+    assert "MERCHANT" in context


### PR DESCRIPTION
## Summary
- Use `getattr` when logging entity types in search query agent to support enums and raw strings
- Add regression test ensuring entity_type strings are accepted when preparing extraction context

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi', 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_689c61c999548320859a473296986e61