### PR TITLE
Fix metrics aggregation and add counter test

### DIFF
--- a/tests/metrics/test_metrics_collector.py
+++ b/tests/metrics/test_metrics_collector.py
@@ -1,0 +1,23 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+from conversation_service.utils.metrics import MetricsCollector
+
+
+def test_metrics_counters_update_after_response():
+    metrics = MetricsCollector()
+
+    metrics.record_request("chat", 1)
+    metrics.record_response_time("chat", 100)
+    summary = metrics.get_summary()
+    assert summary["total_requests"] == 1
+    assert summary["avg_response_time"] == pytest.approx(100.0)
+
+    metrics.record_request("chat", 1)
+    metrics.record_response_time("chat", 200)
+    summary = metrics.get_summary()
+    assert summary["total_requests"] == 2
+    assert summary["avg_response_time"] == pytest.approx(150.0)


### PR DESCRIPTION
## Summary
- aggregate metrics across labels to provide total request count and average response time
- add regression test for metrics counters and averages

## Testing
- `pytest tests/metrics/test_metrics_collector.py -q`
- `pytest -q` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_689c61d2aa508320811aa4839801212c