### PR TITLE
Log intent type and entities in orchestrator agent

### DIFF
--- a/conversation_service/agents/orchestrator_agent.py
+++ b/conversation_service/agents/orchestrator_agent.py
@@ -139,9 +139,8 @@ class WorkflowExecutor:
                     else None
                 )
                 logger.info(
-                    "Intent detection result: %s entities=%s",
-                    getattr(intent_result, "intent_type", None),
-                    [e.model_dump() for e in getattr(intent_result, "entities", [])],
+                    f"Intent: {intent_result.intent_type}, "
+                    f"Entities: {[e.model_dump() for e in getattr(intent_result, 'entities', [])]}"
                 )
 
                 if intent_response.success:


### PR DESCRIPTION
## Summary
- log intent type and serialized entities after intent detection

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install fastapi -q` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pip install pydantic -q` *(fails: Could not find a version that satisfies the requirement pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_689c61d4ef64832086d2fee2167ed1b6