### PR TITLE
Add detailed logging for response generation

### DIFF
--- a/conversation_service/agents/response_agent.py
+++ b/conversation_service/agents/response_agent.py
@@ -226,9 +226,12 @@ class ResponseAgent(BaseFinancialAgent):
             conversation_context = await self._get_conversation_context(context)
 
             # Log context summary and search results count
+            context_summary = (
+                conversation_context[:200] if conversation_context else ""
+            )
             logger.info(
-                "Generating response with context: %s | returned results: %s",
-                conversation_context,
+                "Generating response with context summary: %s | returned results: %s",
+                context_summary,
                 search_response.response_metadata.returned_results,
             )
 
@@ -243,8 +246,9 @@ class ResponseAgent(BaseFinancialAgent):
             completion_tokens = usage.get("completion_tokens", 0)
             total_tokens = usage.get("total_tokens", 0)
             logger.info(
-                "Generated response: %s | total tokens used: %s",
+                "Generated response: %s | transactions used: %s | total tokens used: %s",
                 ai_response.content,
+                search_response.response_metadata.returned_results,
                 total_tokens,
             )
 


### PR DESCRIPTION
## Summary
- Log conversation context summary and returned search result count before invoking the AI responder
- Record generated response along with transaction count and token usage after response generation

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install pydantic==2.11.3` *(fails: Could not find a version that satisfies the requirement pydantic==2.11.3)*

------
https://chatgpt.com/codex/tasks/task_e_689c66482acc8320a2ea2a3a0e216ac9