### PR TITLE
Profile conversation steps and tune LLM performance

### DIFF
--- a/conversation_service/agents/hybrid_intent_agent.py
+++ b/conversation_service/agents/hybrid_intent_agent.py
@@ -86,8 +86,8 @@ class HybridIntentAgent(BaseFinancialAgent):
                 max_consecutive_auto_reply=1,
                 description="Hybrid intent detection agent for financial conversations",
                 temperature=0.1,  # Low temperature for consistent intent detection
-                max_tokens=200,   # Small response for intent classification
-                timeout_seconds=10
+                max_tokens=150,   # Smaller responses for faster detection
+                timeout_seconds=8
             )
         
         super().__init__(
@@ -337,6 +337,7 @@ class HybridIntentAgent(BaseFinancialAgent):
                 temperature=self.config.temperature,
                 max_tokens=self.config.max_tokens,
                 user=str(user_id),
+                use_cache=True,
             )
             logger.debug("Raw AI response: %s", response.content)
 

--- a/conversation_service/agents/response_agent.py
+++ b/conversation_service/agents/response_agent.py
@@ -147,8 +147,8 @@ class ResponseAgent(BaseFinancialAgent):
                 max_consecutive_auto_reply=1,
                 description="Contextual response generation agent for financial conversations",
                 temperature=0.3,  # Slightly higher for more natural responses
-                max_tokens=400,   # Larger for complete responses
-                timeout_seconds=20
+                max_tokens=300,   # Limit tokens for faster responses
+                timeout_seconds=15
             )
         
         super().__init__(
@@ -391,6 +391,7 @@ class ResponseAgent(BaseFinancialAgent):
                 temperature=self.config.temperature,
                 max_tokens=self.config.max_tokens,
                 user=str(user_id),
+                use_cache=True,
             )
 
             response.content = response.content.strip()

--- a/conversation_service/agents/search_query_agent.py
+++ b/conversation_service/agents/search_query_agent.py
@@ -168,8 +168,8 @@ class SearchQueryAgent(BaseFinancialAgent):
                 max_consecutive_auto_reply=1,
                 description="Search query generation and execution agent",
                 temperature=0.2,  # Low temperature for consistent entity extraction
-                max_tokens=300,
-                timeout_seconds=15
+                max_tokens=250,
+                timeout_seconds=12
             )
         
         super().__init__(
@@ -487,8 +487,9 @@ class SearchQueryAgent(BaseFinancialAgent):
                     {"role": "user", "content": context}
                 ],
                 temperature=0.1,
-                max_tokens=150,
+                max_tokens=120,
                 user=str(user_id),
+                use_cache=True,
             )
             
             # Parse AI response

--- a/conversation_service/utils/metrics.py
+++ b/conversation_service/utils/metrics.py
@@ -155,7 +155,7 @@ class PerformanceMonitor:
         self._lock = threading.RLock()
         
         # Seuils d'alerte depuis env vars
-        self.performance_threshold_ms = float(os.getenv('PERFORMANCE_ALERT_THRESHOLD_MS', '2000'))
+        self.performance_threshold_ms = float(os.getenv('PERFORMANCE_ALERT_THRESHOLD_MS', '1000'))
         self.error_rate_threshold = float(os.getenv('ERROR_RATE_ALERT_THRESHOLD', '0.05'))
         
         logger.debug(f"PerformanceMonitor initialized: window={window_size}, threshold={self.performance_threshold_ms}ms")


### PR DESCRIPTION
## Summary
- profile orchestrator workflow steps and log performance alerts
- cache and tighten DeepSeek calls to cut latency and cost
- lower metrics alert threshold to flag slow operations earlier

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ca2f6f0008320bdb099e2c74357e4