### PR TITLE
feat: expand intent rules for transaction counts

### DIFF
--- a/conversation_service/agents/hybrid_intent_agent.py
+++ b/conversation_service/agents/hybrid_intent_agent.py
@@ -101,10 +101,11 @@ class HybridIntentAgent(BaseFinancialAgent):
         
         # Detection statistics
         self.detection_stats = DetectionStats()
-        
+
         # Configuration parameters
         self.ai_confidence_threshold = 0.7
-        self.rule_confidence_threshold = 0.8
+        # Slightly lower threshold to favor rule matches before using the LLM
+        self.rule_confidence_threshold = 0.75
         
         logger.info("Initialized HybridIntentAgent with rule engine and AI fallback")
     

--- a/conversation_service/intent_rules/financial_patterns.json
+++ b/conversation_service/intent_rules/financial_patterns.json
@@ -584,12 +584,12 @@
       "priority": 2,
       "patterns": [
         {
-          "regex": "\\b(combien|nombre)\\s+(d'opérations?|de\\s+transactions?|d'achats?)\\b",
+          "regex": "\\b(combien|nombre)\\s+(d'opérations?|de\\s+transactions?|d'achats?|de\\s+mouvements?)\\b",
           "case_sensitive": false,
           "weight": 1.0
         },
         {
-          "regex": "\\b(comptage|décompte)\\s+(opérations?|transactions?)\\b",
+          "regex": "\\b(comptage|décompte)\\s+(opérations?|transactions?|mouvements?|achats?)\\b",
           "case_sensitive": false,
           "weight": 0.9
         }
@@ -598,7 +598,9 @@
         "combien d'opérations",
         "nombre de transactions",
         "combien d'achats",
-        "comptage opérations"
+        "comptage opérations",
+        "nombre de mouvements",
+        "comptage mouvements"
       ],
       "search_parameters": {
         "query_type": "count_aggregation",
@@ -615,7 +617,9 @@
       "examples": [
         "combien d'opérations ce mois",
         "nombre de transactions restaurant",
-        "combien d'achats Amazon"
+        "combien d'achats Amazon",
+        "nombre de mouvements ce mois",
+        "compter mes transactions"
       ]
     }
   },

--- a/tests/test_intent_detection_rules.py
+++ b/tests/test_intent_detection_rules.py
@@ -1,0 +1,25 @@
+import pytest
+
+from conversation_service.intent_rules import create_rule_engine
+
+
+# Create a single rule engine instance for all tests
+engine = create_rule_engine()
+
+
+@pytest.mark.parametrize(
+    "text, expected_intent",
+    [
+        ("recherche pizza", "SEARCH_BY_TEXT"),
+        ("combien d'opérations ce mois", "COUNT_TRANSACTIONS"),
+        ("nombre de mouvements ce mois", "COUNT_TRANSACTIONS"),
+        ("tendance budget 2025", "ANALYZE_TRENDS"),
+        ("bonjour", "GREETING"),
+    ],
+)
+def test_rule_engine_detects_intents(text: str, expected_intent: str) -> None:
+    """Verify that the rule engine matches user text to the correct intent."""
+    match = engine.match_intent(text, confidence_threshold=0.3)
+    assert match is not None, f"No intent detected for '{text}'"
+    assert match.intent == expected_intent
+


### PR DESCRIPTION
## Summary
- support extra transaction counting phrases like "mouvements" and more examples
- favor rule-based detection before falling back to the LLM
- cover intent detection with dedicated unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ca372cad483209926c24fca4c50c6