### PR TITLE
chore: remove redundant agent name assignment

### DIFF
--- a/tests/test_search_query_agent.py
+++ b/tests/test_search_query_agent.py
@@ -41,7 +41,6 @@ def test_generate_search_contract_deduplicates_terms():
         deepseek_client=DummyDeepSeekClient(),
         search_service_url="http://search.example.com",
     )
-    agent.name = "search_query_agent"
     intent_result = IntentResult(
         intent_type="TRANSACTION_SEARCH",
         intent_category=IntentCategory.TRANSACTION_SEARCH,


### PR DESCRIPTION
## Summary
- remove manual name setting in search query agent test so default name is used

## Testing
- `pytest tests/test_search_query_agent.py::test_generate_search_contract_deduplicates_terms -q`


------
https://chatgpt.com/codex/tasks/task_e_689ca7a7e874832092a8b48c6312c739