### PR TITLE
Clarify security test for unauthenticated request

### DIFF
--- a/test_harena_nominal.py
+++ b/test_harena_nominal.py
@@ -418,7 +418,9 @@ class HarenaTestClient:
             )
 
         # Vérification cloisonnement
+        # Test de sécurité : une requête sans token doit être refusée (401)
         turns_endpoint = f"/conversation/conversations/{conversation_id}/turns"
+        # utilisation volontaire d'une requête non authentifiée
         resp = self._make_request("GET", turns_endpoint, use_auth=False)
         success, _ = self._print_response(resp, expected_status=401)
         if not success:


### PR DESCRIPTION
## Summary
- Annotate conversation turns check to clarify unauthenticated request is a deliberate security test

## Testing
- `python -m py_compile test_harena_nominal.py`
- `pytest -q` *(fails: SearchQueryAgent object has no attribute 'name')*

------
https://chatgpt.com/codex/tasks/task_e_689ccb60743083209bae00b5a9353eed