### PR TITLE
Optimize search query cleanup and relax matching

### DIFF
--- a/conversation_service/agents/search_query_agent.py
+++ b/conversation_service/agents/search_query_agent.py
@@ -17,6 +17,7 @@ Version: 1.0.0 MVP - Search Service Integration
 import time
 import logging
 import unicodedata
+import re
 import json
 import httpx
 from typing import Dict, Any, Optional, List
@@ -63,11 +64,17 @@ class QueryOptimizer:
             ch for ch in search_text if unicodedata.category(ch) != 'Mn'
         )
 
-        # Remove common stop words and generic terms that don't help search
+        # Remove punctuation
+        search_text = re.sub(r"[^\w\s]", " ", search_text)
+
+        # Remove common stop words, question words, and generic terms
         stop_words = {
             'le', 'la', 'les', 'de', 'du', 'des', 'un', 'une', 'mon', 'ma', 'mes',
             'recherche', 'rechercher', 'depense', 'depenses', 'transaction',
-            'transactions'
+            'transactions',
+            'combien', 'pourquoi', 'pour', 'quel', 'quelle', 'quels', 'quelles',
+            'qui', 'que', 'quoi', 'ou', 'quand', 'comment', 'ce', 'cet', 'cette',
+            'ces', 'mois', 'je', 'j', 'ai', 'jai'
         }
         words = [word for word in search_text.split() if word not in stop_words]
 
@@ -188,6 +195,9 @@ class SearchQueryAgent(BaseFinancialAgent):
             config=config,
             deepseek_client=deepseek_client
         )
+
+        # Ensure name is always set even when AutoGen isn't fully available
+        self.name = config.name
         
         self.search_service_url = search_service_url.rstrip('/')
         self.http_client = httpx.AsyncClient(timeout=30.0)

--- a/search_service/core/query_builder.py
+++ b/search_service/core/query_builder.py
@@ -53,13 +53,15 @@ class QueryBuilder:
     
     def _build_text_query(self, query_text: str) -> Dict[str, Any]:
         """Construction de la requête textuelle optimisée"""
+        terms_count = len(query_text.split())
+        minimum_should_match = "50%" if terms_count > 2 else "100%"
         return {
             "multi_match": {
                 "query": query_text,
                 "fields": self.search_fields,
                 "type": "best_fields",
                 "fuzziness": "AUTO",
-                "minimum_should_match": "75%"
+                "minimum_should_match": minimum_should_match
             }
         }
     

--- a/tests/test_search_end_to_end.py
+++ b/tests/test_search_end_to_end.py
@@ -1,0 +1,82 @@
+import asyncio
+
+from conversation_service.agents import base_financial_agent
+
+# Ensure BaseFinancialAgent does not require AutoGen during tests
+base_financial_agent.AUTOGEN_AVAILABLE = True
+
+from conversation_service.agents.search_query_agent import SearchQueryAgent
+from conversation_service.models.financial_models import (
+    FinancialEntity,
+    EntityType,
+    IntentResult,
+    IntentCategory,
+    DetectionMethod,
+)
+from search_service.core.search_engine import SearchEngine
+from search_service.models.request import SearchRequest
+
+
+class DummyDeepSeekClient:
+    api_key = "test-key"
+    base_url = "http://api.example.com"
+
+
+class DummyElasticsearchClient:
+    async def search(self, index, body, size, from_):
+        return {
+            "hits": {
+                "total": {"value": 1},
+                "hits": [
+                    {
+                        "_score": 1.0,
+                        "_source": {
+                            "transaction_id": "t1",
+                            "user_id": 1,
+                            "amount": -15.99,
+                            "amount_abs": 15.99,
+                            "currency_code": "EUR",
+                            "transaction_type": "debit",
+                            "date": "2025-02-01",
+                            "primary_description": "Netflix abonnement",
+                            "merchant_name": "Netflix",
+                            "category_name": "Streaming",
+                            "operation_type": "card",
+                        },
+                    }
+                ],
+            }
+        }
+
+
+def test_netflix_month_question_returns_transactions():
+    agent = SearchQueryAgent(
+        deepseek_client=DummyDeepSeekClient(),
+        search_service_url="http://search.example.com",
+    )
+    intent_result = IntentResult(
+        intent_type="TRANSACTION_SEARCH",
+        intent_category=IntentCategory.TRANSACTION_SEARCH,
+        confidence=0.9,
+        entities=[
+            FinancialEntity(
+                entity_type=EntityType.MERCHANT,
+                raw_value="Netflix",
+                normalized_value="netflix",
+                confidence=0.9,
+            )
+        ],
+        method=DetectionMethod.RULE_BASED,
+        processing_time_ms=1.0,
+    )
+    user_message = "Combien j’ai dépensé pour Netflix ce mois ?"
+    search_contract = asyncio.run(
+        agent._generate_search_contract(intent_result, user_message, user_id=1)
+    )
+    request_dict = search_contract.to_search_request()
+    assert request_dict["query"] == "netflix"
+
+    engine = SearchEngine(elasticsearch_client=DummyElasticsearchClient())
+    response = asyncio.run(engine.search(SearchRequest(**request_dict)))
+    assert response["results"] and response["results"][0]["merchant_name"] == "Netflix"
+


### PR DESCRIPTION
## Summary
- Strip punctuation and question words during query optimization so user questions reduce to merchant names
- Relax `minimum_should_match` to 50% for longer queries
- Add end-to-end test verifying Netflix monthly spending question returns transactions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ce77e69b08320892f1ee48657a839