### PR TITLE
Support "dépensé pour" merchant queries

### DIFF
--- a/conversation_service/intent_rules/financial_patterns.json
+++ b/conversation_service/intent_rules/financial_patterns.json
@@ -68,6 +68,12 @@
           "entity_extract": {"type": "merchant", "extract_group": 3, "normalize": "uppercase"}
         },
         {
+          "regex": "\\bd[ée]pens[ée]s?\\s+pour\\s+(amazon|netflix|carrefour|uber|sncf|mcdo|mcdonald|apple|google)\\b",
+          "case_sensitive": false,
+          "weight": 0.9,
+          "entity_extract": {"type": "merchant", "extract_group": 1, "normalize": "uppercase"}
+        },
+        {
           "regex": "\\b(chez|à)\\s+([A-Z][a-z]+(?:\\s+[A-Z][a-z]+)?)\\b",
           "case_sensitive": false,
           "weight": 0.7,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,94 @@
+import sys
+import types
+
+
+# Minimal stub for pydantic to avoid external dependency during tests
+pydantic_stub = types.ModuleType("pydantic")
+
+class _BaseModel:
+    def __init__(self, **data):
+        for k, v in data.items():
+            setattr(self, k, v)
+
+    def dict(self, *args, **kwargs):
+        result = {}
+        for k, v in self.__dict__.items():
+            if hasattr(v, "dict"):
+                result[k] = v.dict()
+            else:
+                result[k] = v
+        return result
+
+def _Field(*args, **kwargs):
+    return kwargs.get("default")
+
+def _field_validator(*args, **kwargs):
+    def decorator(func):
+        return func
+    return decorator
+
+def _model_validator(*args, **kwargs):
+    def decorator(func):
+        return func
+    return decorator
+
+pydantic_stub.BaseModel = _BaseModel
+pydantic_stub.Field = _Field
+pydantic_stub.field_validator = _field_validator
+pydantic_stub.model_validator = _model_validator
+pydantic_stub.ValidationError = type("ValidationError", (Exception,), {})
+sys.modules.setdefault("pydantic", pydantic_stub)
+
+
+# Stub for openai module used by DeepSeekClient
+openai_stub = types.ModuleType("openai")
+
+class _AsyncOpenAI:
+    pass
+
+openai_stub.AsyncOpenAI = _AsyncOpenAI
+
+openai_types = types.ModuleType("openai.types")
+openai_chat = types.ModuleType("openai.types.chat")
+openai_chat.ChatCompletion = object
+openai_types.chat = openai_chat
+openai_stub.types = openai_types
+
+sys.modules.setdefault("openai", openai_stub)
+sys.modules.setdefault("openai.types", openai_types)
+sys.modules.setdefault("openai.types.chat", openai_chat)
+
+
+# Stub for httpx library
+httpx_stub = types.ModuleType("httpx")
+
+class _AsyncClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def post(self, *args, **kwargs):
+        return types.SimpleNamespace(json=lambda: {}, raise_for_status=lambda: None)
+
+    async def aclose(self):
+        pass
+
+httpx_stub.AsyncClient = _AsyncClient
+httpx_stub.RequestError = Exception
+httpx_stub.HTTPStatusError = Exception
+sys.modules.setdefault("httpx", httpx_stub)
+
+
+# Stub for autogen AssistantAgent
+autogen_stub = types.ModuleType("autogen")
+
+class _AssistantAgent:
+    def __init__(self, name=None, system_message=None, llm_config=None, max_consecutive_auto_reply=None, description=None, **kwargs):
+        self.name = name
+        self.system_message = system_message
+        self.llm_config = llm_config
+        self.max_consecutive_auto_reply = max_consecutive_auto_reply
+        self.description = description
+
+autogen_stub.AssistantAgent = _AssistantAgent
+sys.modules.setdefault("autogen", autogen_stub)
+

--- a/tests/test_search_by_merchant_depense_pour.py
+++ b/tests/test_search_by_merchant_depense_pour.py
@@ -1,0 +1,25 @@
+from conversation_service.intent_rules import create_rule_engine
+from conversation_service.agents.hybrid_intent_agent import HybridIntentAgent
+from conversation_service.models.financial_models import EntityType
+
+
+def test_depense_pour_netflix_matches_rule_and_entity():
+    engine = create_rule_engine()
+    message = "Combien j'ai dépensé pour Netflix ce mois ?"
+
+    # Verify RuleMatch intent and normalized entity
+    match = engine.match_intent(message, confidence_threshold=0.3)
+    assert match is not None
+    assert match.intent == "SEARCH_BY_MERCHANT"
+    merchants = match.entities.get("merchant")
+    assert merchants
+    assert merchants[0].normalized_value.get("merchant") == "NETFLIX"
+
+    # Convert to FinancialEntity via HybridIntentAgent without full initialization
+    agent = HybridIntentAgent.__new__(HybridIntentAgent)
+    entities = agent._convert_rule_entities(match.entities)
+    assert any(
+        e.entity_type == EntityType.MERCHANT and e.normalized_value.get("merchant") == "NETFLIX"
+        for e in entities
+    )
+


### PR DESCRIPTION
## Summary
- match phrases like "dépensé pour Netflix" to the SEARCH_BY_MERCHANT intent
- cover entity conversion to FinancialEntity and add Netflix unit test
- add lightweight stubs so tests run without external deps

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ce77e74988320b638744eca58e1c5