### PR TITLE
feat: add LLM intent agent with strict JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,27 @@ initialization so that every call is properly authenticated.
 `SEARCH_SERVICE_URL` sets the base URL for the Search Service. It defaults to
 `http://localhost:8000/api/v1/search` and the service automatically appends
 `/search` when issuing queries.
+
+## LLMIntentAgent output
+
+The `LLMIntentAgent` always responds with a strict JSON object and never adds
+free-form text. The allowed intent values are:
+
+`SEARCH_BY_TEXT`, `SEARCH_BY_MERCHANT`, `SEARCH_BY_CATEGORY`,
+`SEARCH_BY_AMOUNT`, `SEARCH_BY_DATE`, `SEARCH_BY_OPERATION_TYPE`,
+`ANALYZE_SPENDING`, `ANALYZE_TRENDS`, `COUNT_TRANSACTIONS`,
+`TRANSACTION_SEARCH`, `SPENDING_ANALYSIS`, `BALANCE_INQUIRY`,
+`GENERAL_QUESTION`, `GREETING`, `OUT_OF_SCOPE`.
+
+Entity types must be one of the values from `EntityType` in
+`conversation_service/models/financial_models.py`.
+
+Example response:
+
+```json
+{
+  "intent": "SEARCH_BY_MERCHANT",
+  "confidence": 0.92,
+  "entities": [{"entity_type": "MERCHANT", "value": "AMAZON"}]
+}
+```

--- a/conversation_service/agents/__init__.py
+++ b/conversation_service/agents/__init__.py
@@ -31,13 +31,15 @@ except ImportError:
 if TYPE_CHECKING or AUTOGEN_AVAILABLE:
     from .base_financial_agent import BaseFinancialAgent
     from .hybrid_intent_agent import HybridIntentAgent
+    from .llm_intent_agent import LLMIntentAgent
     from .search_query_agent import SearchQueryAgent
     from .response_agent import ResponseAgent
     from .orchestrator_agent import OrchestratorAgent
 
 __all__ = [
     "BaseFinancialAgent",
-    "HybridIntentAgent", 
+    "HybridIntentAgent",
+    "LLMIntentAgent",
     "SearchQueryAgent",
     "ResponseAgent",
     "OrchestratorAgent"
@@ -64,7 +66,8 @@ def get_available_agents():
     return [
         "BaseFinancialAgent",
         "HybridIntentAgent",
-        "SearchQueryAgent", 
+        "LLMIntentAgent",
+        "SearchQueryAgent",
         "ResponseAgent",
         "OrchestratorAgent"
     ]

--- a/conversation_service/agents/llm_intent_agent.py
+++ b/conversation_service/agents/llm_intent_agent.py
@@ -1,0 +1,163 @@
+"""LLM-only intent detection agent.
+
+This agent uses a large language model to classify user messages into a
+restricted set of intents and to extract financial entities. The model is
+instructed via the system message to only use the provided intents and entity
+types and to return strict JSON without any free text.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import logging
+from typing import Any, Dict, List, Optional
+
+from .base_financial_agent import BaseFinancialAgent
+from ..models.agent_models import AgentConfig
+from ..core.deepseek_client import DeepSeekClient
+from ..models.financial_models import (
+    IntentResult,
+    IntentCategory,
+    DetectionMethod,
+    FinancialEntity,
+    EntityType,
+)
+
+logger = logging.getLogger(__name__)
+
+
+ALLOWED_INTENTS = [
+    "SEARCH_BY_TEXT",
+    "SEARCH_BY_MERCHANT",
+    "SEARCH_BY_CATEGORY",
+    "SEARCH_BY_AMOUNT",
+    "SEARCH_BY_DATE",
+    "SEARCH_BY_OPERATION_TYPE",
+    "ANALYZE_SPENDING",
+    "ANALYZE_TRENDS",
+    "COUNT_TRANSACTIONS",
+    "TRANSACTION_SEARCH",
+    "SPENDING_ANALYSIS",
+    "BALANCE_INQUIRY",
+    "GENERAL_QUESTION",
+    "GREETING",
+    "OUT_OF_SCOPE",
+]
+
+
+class LLMIntentAgent(BaseFinancialAgent):
+    """Intent detection relying solely on an LLM."""
+
+    def __init__(self, deepseek_client: DeepSeekClient, config: Optional[AgentConfig] = None) -> None:
+        if config is None:
+            config = AgentConfig(
+                name="llm_intent_agent",
+                model_client_config={
+                    "model": "deepseek-chat",
+                    "api_key": deepseek_client.api_key,
+                    "base_url": deepseek_client.base_url,
+                },
+                system_message=self._build_system_message(),
+                max_consecutive_auto_reply=1,
+                description="LLM-based intent detection agent",
+                temperature=0.0,
+                max_tokens=200,
+                timeout_seconds=8,
+            )
+        super().__init__(
+            name=config.name,
+            config=config,
+            deepseek_client=deepseek_client,
+        )
+
+    @staticmethod
+    def _build_system_message() -> str:
+        intents = ", ".join(ALLOWED_INTENTS)
+        entity_types = ", ".join(e.value for e in EntityType)
+        return (
+            "Tu es un classificateur d'intentions financières."
+            "\nIntents autorisés : " + intents +
+            "\nTypes d'entités autorisés : " + entity_types +
+            "\nIgnore toute autre catégorie."
+            "\nRéponds uniquement avec un JSON strict au format :"
+            ' {"intent": "INTENT", "confidence": 0-1,'
+            ' "entities": [{"entity_type": "TYPE", "value": "VALEUR"}]}.'
+        )
+
+    async def _execute_operation(self, input_data: Dict[str, Any], user_id: int) -> Dict[str, Any]:
+        user_message = input_data.get("user_message", "")
+        if not user_message:
+            raise ValueError("user_message is required for intent detection")
+        return await self.detect_intent(user_message, user_id)
+
+    async def detect_intent(self, user_message: str, user_id: int) -> Dict[str, Any]:
+        start = time.perf_counter()
+        response = await self.deepseek_client.generate_response(
+            messages=[
+                {"role": "system", "content": self.config.system_message},
+                {"role": "user", "content": user_message},
+            ],
+            temperature=self.config.temperature,
+            max_tokens=self.config.max_tokens,
+            user=str(user_id),
+            use_cache=True,
+        )
+        try:
+            data = json.loads(response.content)
+        except Exception as err:
+            logger.warning("Failed to parse LLM output: %s", err)
+            data = {"intent": "OUT_OF_SCOPE", "confidence": 0.0, "entities": []}
+
+        intent_type = data.get("intent", "OUT_OF_SCOPE")
+        entities: List[FinancialEntity] = []
+        for ent in data.get("entities", []):
+            try:
+                e_type = EntityType(ent.get("entity_type", "").upper())
+                entities.append(
+                    FinancialEntity(
+                        entity_type=e_type,
+                        raw_value=ent.get("value", ""),
+                        normalized_value=ent.get("value", ""),
+                        confidence=ent.get("confidence", data.get("confidence", 0.0)),
+                        detection_method=DetectionMethod.LLM_BASED,
+                    )
+                )
+            except Exception as err:
+                logger.debug("Skipping entity parsing error: %s", err)
+                continue
+
+        intent_result = IntentResult(
+            intent_type=intent_type,
+            intent_category=self._infer_category(intent_type),
+            confidence=data.get("confidence", 0.0),
+            entities=entities,
+            method=DetectionMethod.LLM_BASED,
+            processing_time_ms=(time.perf_counter() - start) * 1000,
+        )
+
+        return {
+            "content": json.dumps(data),
+            "metadata": {
+                "intent_result": intent_result,
+                "detection_method": DetectionMethod.LLM_BASED,
+                "confidence": intent_result.confidence,
+                "intent_type": intent_result.intent_type,
+                "entities": [e.model_dump() for e in intent_result.entities],
+                "intent_detected": intent_result.intent_type,
+                "entities_extracted": [e.model_dump() for e in intent_result.entities],
+            },
+            "confidence_score": intent_result.confidence,
+        }
+
+    @staticmethod
+    def _infer_category(intent: str) -> IntentCategory:
+        if intent.startswith("SEARCH") or intent == "TRANSACTION_SEARCH":
+            return IntentCategory.TRANSACTION_SEARCH
+        if intent.startswith("ANALYZE") or intent.endswith("ANALYSIS") or intent in {"SPENDING_ANALYSIS", "COUNT_TRANSACTIONS"}:
+            return IntentCategory.SPENDING_ANALYSIS
+        if intent == "BALANCE_INQUIRY":
+            return IntentCategory.BALANCE_INQUIRY
+        if intent == "GREETING":
+            return IntentCategory.GREETING
+        return IntentCategory.GENERAL_QUESTION


### PR DESCRIPTION
## Summary
- add `LLMIntentAgent` with explicit intent/entity whitelist and strict JSON system prompt
- expose new agent and document JSON output format in README

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'ConfigDict' from 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_689d77af215083208fe45ef351d4d3dc