### PR TITLE
Expose conversation_service agents subpackage

### DIFF
--- a/conversation_service/__init__.py
+++ b/conversation_service/__init__.py
@@ -7,6 +7,14 @@ pour le domaine financier avec détection d'intentions hybride.
 
 __version__ = "1.0.0"
 __author__ = "Conversation Service Team"
+from . import agents
 
-# Export only public metadata; submodules remain discoverable.
-__all__ = ["__version__", "__author__"]
+# Expose commonly used subpackages when available
+__all__ = ["__version__", "__author__", "agents"]
+for _mod in ["api", "core", "models", "services", "utils"]:
+    try:
+        globals()[_mod] = __import__(f"{__name__}.{_mod}", fromlist=["*"])
+    except Exception:
+        continue
+    else:
+        __all__.append(_mod)


### PR DESCRIPTION
## Summary
- import the `agents` subpackage from `conversation_service` for easier access
- dynamically expose other common subpackages when available

## Testing
- `python -c "import conversation_service.agents"`
- `pytest` *(fails: SyntaxError in conversation_service/agents/llm_intent_agent.py)*

------
https://chatgpt.com/codex/tasks/task_e_689d80f144cc83208ac4950ceab59fcb