### PR TITLE
Refactor LLM intent agent imports and docstring

### DIFF
--- a/conversation_service/agents/llm_intent_agent.py
+++ b/conversation_service/agents/llm_intent_agent.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import json
 import time
 import logging
-import time
 from typing import Any, Dict, List, Optional
 
 from .base_financial_agent import BaseFinancialAgent
@@ -52,7 +51,6 @@ ALLOWED_INTENTS = [
 
 class LLMIntentAgent(BaseFinancialAgent):
     """Intent detection agent that relies solely on the DeepSeek LLM."""
-    """Intent detection agent relying solely on DeepSeek LLM."""
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary
- remove redundant docstring inside `LLMIntentAgent`
- consolidate to a single `import time`

## Testing
- `pytest tests/test_llm_intent_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d847eac1c83208f92bbe7e5a582ed