### PR TITLE
feat: enhance intent agent and migrate validators

### DIFF
--- a/user_service/schemas/bridge.py
+++ b/user_service/schemas/bridge.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 from typing import Optional, List
 
 
@@ -10,8 +10,9 @@ class ConnectSessionRequest(BaseModel):
     provider_id: Optional[int] = None
     item_id: Optional[int] = None
 
-    @validator('context')
-    def context_length(cls, v):
+    @field_validator('context')
+    @classmethod
+    def context_length(cls, v: Optional[str]):
         if v and len(v) > 100:
             raise ValueError('context must be 100 characters or less')
         return v

--- a/user_service/schemas/user.py
+++ b/user_service/schemas/user.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, EmailStr, Field, validator
+from pydantic import BaseModel, EmailStr, Field, field_validator, FieldValidationInfo
 from typing import Optional, Dict, Any, List
 from datetime import datetime
 
@@ -15,9 +15,10 @@ class UserCreate(UserBase):
     password: str = Field(..., min_length=8)
     confirm_password: str
 
-    @validator('confirm_password')
-    def passwords_match(cls, v, values, **kwargs):
-        if 'password' in values and v != values['password']:
+    @field_validator('confirm_password')
+    @classmethod
+    def passwords_match(cls, v: str, info: FieldValidationInfo):
+        if info.data.get('password') and v != info.data['password']:
             raise ValueError('Passwords do not match')
         return v
 


### PR DESCRIPTION
## Summary
- replace deprecated `@validator` usage with `@field_validator`
- enrich intent system prompt with few-shot examples and add cache with retry/backoff
- handle JSON errors and fallback to `OUT_OF_SCOPE`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689d87f518648320a11cbbad0072982c