### PR TITLE
feat: add advanced LLM intent agent with caching and retry

### DIFF
--- a/conversation_service/agents/__init__.py
+++ b/conversation_service/agents/__init__.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING or AUTOGEN_AVAILABLE:
     from .hybrid_intent_agent import HybridIntentAgent
 
     from .llm_intent_agent import LLMIntentAgent
+    from .advanced_llm_intent_agent import AdvancedLLMIntentAgent
     from .search_query_agent import SearchQueryAgent
     from .response_agent import ResponseAgent
     from .orchestrator_agent import OrchestratorAgent
@@ -41,6 +42,7 @@ __all__ = [
     "BaseFinancialAgent",
     "HybridIntentAgent",
     "LLMIntentAgent",
+    "AdvancedLLMIntentAgent",
     "SearchQueryAgent",
     "ResponseAgent",
     "OrchestratorAgent"
@@ -68,6 +70,7 @@ def get_available_agents():
         "BaseFinancialAgent",
         "HybridIntentAgent",
         "LLMIntentAgent",
+        "AdvancedLLMIntentAgent",
         "SearchQueryAgent",
         "ResponseAgent",
         "OrchestratorAgent"

--- a/conversation_service/agents/advanced_llm_intent_agent.py
+++ b/conversation_service/agents/advanced_llm_intent_agent.py
@@ -1,0 +1,110 @@
+"""Advanced LLM intent agent with few-shot prompts, caching, and retries."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Dict, Optional, Tuple
+
+from .llm_intent_agent import LLMIntentAgent
+from ..models.agent_models import AgentConfig
+from ..utils.cache import generate_cache_key
+from ..utils.llm_intent_cache import llm_intent_cache
+
+logger = logging.getLogger(__name__)
+
+# Few-shot examples to prime the LLM
+FEW_SHOT_EXAMPLES: Tuple[Tuple[str, str], ...] = (
+    (
+        "Quel est mon solde actuel ?",
+        '{"intent": "BALANCE_INQUIRY", "confidence": 0.9, "entities": []}',
+    ),
+    (
+        "Bonjour",
+        '{"intent": "GREETING", "confidence": 0.9, "entities": []}',
+    ),
+)
+
+
+class AdvancedLLMIntentAgent(LLMIntentAgent):
+    """Extended intent agent with prompt engineering, retry, and caching."""
+
+    def __init__(
+        self,
+        deepseek_client,
+        config: Optional[AgentConfig] = None,
+        cache: Optional[Any] = None,
+        max_retries: int = 3,
+        backoff_factor: float = 0.5,
+    ) -> None:
+        self.cache = cache or llm_intent_cache
+        self.max_retries = max_retries
+        self.backoff_factor = backoff_factor
+
+        if config is None:
+            config = AgentConfig(
+                name="advanced_llm_intent_agent",
+                model_client_config={
+                    "model": "deepseek-chat",
+                    "api_key": deepseek_client.api_key,
+                    "base_url": deepseek_client.base_url,
+                },
+                system_message=self._build_system_message(),
+                max_consecutive_auto_reply=1,
+                description="LLM intent agent with few-shot prompts and caching",
+                temperature=0.0,
+                max_tokens=200,
+                timeout_seconds=8,
+            )
+
+        super().__init__(deepseek_client=deepseek_client, config=config)
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _build_system_message() -> str:
+        base = LLMIntentAgent._build_system_message()
+        examples = "\n".join(
+            f"Utilisateur: {u}\nAssistant: {a}" for u, a in FEW_SHOT_EXAMPLES
+        )
+        return base + "\n\nExemples:\n" + examples
+
+    # ------------------------------------------------------------------
+    async def detect_intent(self, user_message: str, user_id: int) -> Dict[str, Any]:
+        """Detect intent with caching, retry, and fallback."""
+        cache_key = generate_cache_key(user_message, user_id)
+        try:
+            cached = await self.cache.get(cache_key)
+        except Exception as err:  # pragma: no cover - cache failure shouldn't crash
+            logger.debug("Cache retrieval failed: %s", err)
+            cached = None
+        if cached is not None:
+            return cached
+
+        attempt = 0
+        delay = self.backoff_factor
+        last_error: Optional[Exception] = None
+        while attempt < self.max_retries:
+            try:
+                result = await super().detect_intent(user_message, user_id)
+                try:
+                    await self.cache.set(cache_key, result)
+                except Exception as err:  # pragma: no cover
+                    logger.debug("Cache set failed: %s", err)
+                return result
+            except Exception as err:
+                last_error = err
+                attempt += 1
+                logger.warning(
+                    "Intent detection attempt %d failed: %s", attempt, err
+                )
+                await asyncio.sleep(delay)
+                delay *= 2
+
+        logger.error(
+            "All retries failed for AdvancedLLMIntentAgent, falling back: %s",
+            last_error,
+        )
+        fallback_agent = LLMIntentAgent(deepseek_client=self.deepseek_client)
+        return await fallback_agent.detect_intent(user_message, user_id)
+
+__all__ = ["AdvancedLLMIntentAgent"]

--- a/conversation_service/utils/llm_intent_cache.py
+++ b/conversation_service/utils/llm_intent_cache.py
@@ -1,0 +1,11 @@
+"""Dedicated cache instance for LLM intent detection results."""
+
+from __future__ import annotations
+
+from .cache import MultiLevelCache, get_default_cache_sync
+
+# Reuse the package-level default cache but expose a named instance for intent
+# detection so agents can share cached results.
+llm_intent_cache: MultiLevelCache = get_default_cache_sync()
+
+__all__ = ["llm_intent_cache"]

--- a/tests/test_advanced_llm_intent_agent.py
+++ b/tests/test_advanced_llm_intent_agent.py
@@ -1,0 +1,98 @@
+import asyncio
+import conversation_service.agents.base_financial_agent as base_financial_agent
+base_financial_agent.AUTOGEN_AVAILABLE = True
+
+from conversation_service.agents.advanced_llm_intent_agent import AdvancedLLMIntentAgent
+from conversation_service.utils.cache import MultiLevelCache
+
+
+class CountingClient:
+    def __init__(self):
+        self.calls = 0
+        self.api_key = "test-key"
+        self.base_url = "http://api"
+
+    async def generate_response(self, messages, temperature, max_tokens, user, use_cache):
+        self.calls += 1
+
+        class Response:
+            content = '{"intent": "GREETING", "confidence": 0.9, "entities": []}'
+
+        return Response()
+
+
+def test_system_prompt_contains_examples():
+    client = CountingClient()
+    agent = AdvancedLLMIntentAgent(deepseek_client=client)
+    assert "Exemples" in agent.config.system_message
+
+
+def test_caching_reduces_llm_calls():
+    client = CountingClient()
+    cache = MultiLevelCache()
+    agent = AdvancedLLMIntentAgent(deepseek_client=client, cache=cache)
+
+    msg = "Bonjour"
+    first = asyncio.run(agent.detect_intent(msg, user_id=1))
+    second = asyncio.run(agent.detect_intent(msg, user_id=1))
+
+    assert first == second
+    assert client.calls == 1
+
+
+class FlakyClient:
+    def __init__(self):
+        self.calls = 0
+        self.api_key = "test-key"
+        self.base_url = "http://api"
+
+    async def generate_response(self, messages, temperature, max_tokens, user, use_cache):
+        self.calls += 1
+        if self.calls < 2:
+            raise RuntimeError("temporary failure")
+
+        class Response:
+            content = '{"intent": "GREETING", "confidence": 0.9, "entities": []}'
+
+        return Response()
+
+
+def test_retry_with_backoff_succeeds():
+    client = FlakyClient()
+    cache = MultiLevelCache()
+    agent = AdvancedLLMIntentAgent(
+        deepseek_client=client, cache=cache, max_retries=3, backoff_factor=0
+    )
+
+    result = asyncio.run(agent.detect_intent("Salut", user_id=1))
+    assert client.calls == 2
+    assert result["metadata"]["intent_result"].intent_type == "GREETING"
+
+
+class FailThenSucceedClient:
+    def __init__(self):
+        self.calls = 0
+        self.api_key = "test-key"
+        self.base_url = "http://api"
+
+    async def generate_response(self, messages, temperature, max_tokens, user, use_cache):
+        self.calls += 1
+        if self.calls == 1:
+            raise RuntimeError("failure")
+
+        class Response:
+            content = '{"intent": "GREETING", "confidence": 0.9, "entities": []}'
+
+        return Response()
+
+
+def test_fallback_to_base_agent():
+    client = FailThenSucceedClient()
+    cache = MultiLevelCache()
+    agent = AdvancedLLMIntentAgent(
+        deepseek_client=client, cache=cache, max_retries=1, backoff_factor=0
+    )
+
+    result = asyncio.run(agent.detect_intent("Salut", user_id=1))
+    assert client.calls == 2
+    assert result["metadata"]["intent_result"].intent_type == "GREETING"


### PR DESCRIPTION
## Summary
- add `AdvancedLLMIntentAgent` with few-shot prompting, intelligent caching, retries and fallback
- expose shared `llm_intent_cache`
- test caching behavior, retry logic and fallback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689d882c81448320be0169123fb146d8