### PR TITLE
Add intent retry with timeout and fallback

### DIFF
--- a/config_service/config.py
+++ b/config_service/config.py
@@ -178,8 +178,6 @@ class GlobalSettings(BaseSettings):
     # ==========================================
     # PARAMÈTRES DE RECHERCHE PAR DÉFAUT
     # ==========================================
-    DEFAULT_LEXICAL_WEIGHT: float = float(os.environ.get("DEFAULT_LEXICAL_WEIGHT", "0.6"))
-    DEFAULT_SEMANTIC_WEIGHT: float = float(os.environ.get("DEFAULT_SEMANTIC_WEIGHT", "0.4"))
     DEFAULT_TOP_K_INITIAL: int = int(os.environ.get("DEFAULT_TOP_K_INITIAL", "50"))
     DEFAULT_TOP_K_FINAL: int = int(os.environ.get("DEFAULT_TOP_K_FINAL", "10"))
     
@@ -231,12 +229,6 @@ class GlobalSettings(BaseSettings):
     SEARCH_CACHE_TTL: int = int(os.environ.get("SEARCH_CACHE_TTL", "300"))
     SEARCH_CACHE_MAX_SIZE: int = int(os.environ.get("SEARCH_CACHE_MAX_SIZE", "1000"))
     SEARCH_CACHE_SIZE: int = int(os.environ.get("SEARCH_CACHE_SIZE", "1000"))
-    
-    # Configuration de la recherche hybride
-    DEFAULT_SEARCH_TYPE: str = os.environ.get("DEFAULT_SEARCH_TYPE", "semantic")
-    MIN_LEXICAL_SCORE: float = float(os.environ.get("MIN_LEXICAL_SCORE", "1.0"))
-    MIN_SEMANTIC_SCORE: float = float(os.environ.get("MIN_SEMANTIC_SCORE", "0.5"))
-    MAX_RESULTS_PER_ENGINE: int = int(os.environ.get("MAX_RESULTS_PER_ENGINE", "50"))
     
     # Limites de recherche principales
     MAX_SEARCH_RESULTS: int = int(os.environ.get("MAX_SEARCH_RESULTS", "1000"))
@@ -596,11 +588,6 @@ class GlobalSettings(BaseSettings):
                 "embedding_enabled": self.EMBEDDING_CACHE_ENABLED,
                 "embedding_ttl": self.EMBEDDING_CACHE_TTL
             },
-            "hybrid_search": {
-                "default_type": self.DEFAULT_SEARCH_TYPE,
-                "lexical_weight": self.DEFAULT_LEXICAL_WEIGHT,
-                "semantic_weight": self.DEFAULT_SEMANTIC_WEIGHT
-            },
             "limits": {
                 "default_search": self.DEFAULT_SEARCH_LIMIT,
                 "max_search": self.MAX_SEARCH_LIMIT,
@@ -622,8 +609,6 @@ class GlobalSettings(BaseSettings):
                 "max_search_fields": self.MAX_SEARCH_FIELDS
             },
             "min_scores": {
-                "lexical": self.MIN_LEXICAL_SCORE,
-                "semantic": self.MIN_SEMANTIC_SCORE,
                 "threshold": self.MIN_SCORE_THRESHOLD
             },
             "quality_thresholds": {
@@ -642,12 +627,6 @@ class GlobalSettings(BaseSettings):
     def validate_search_config(self) -> dict:
         """Valide la cohérence de la configuration de recherche."""
         validation = {"valid": True, "warnings": [], "errors": []}
-        
-        # Validation des poids hybrides
-        total_weight = self.DEFAULT_LEXICAL_WEIGHT + self.DEFAULT_SEMANTIC_WEIGHT
-        if abs(total_weight - 1.0) > 0.01:
-            validation["errors"].append(f"Lexical + semantic weights must equal 1.0, got {total_weight}")
-            validation["valid"] = False
         
         # Validation des seuils de similarité
         if self.SIMILARITY_THRESHOLD_LOOSE > self.SIMILARITY_THRESHOLD_DEFAULT:
@@ -776,8 +755,6 @@ class GlobalSettings(BaseSettings):
             "HIGHLIGHT_MAX_FRAGMENTS": self.HIGHLIGHT_MAX_FRAGMENTS,
             
             # Scores minimums
-            "MIN_LEXICAL_SCORE": self.MIN_LEXICAL_SCORE,
-            "MIN_SEMANTIC_SCORE": self.MIN_SEMANTIC_SCORE,
             "MIN_SCORE_THRESHOLD": self.MIN_SCORE_THRESHOLD,
             
             # Timeouts spécialisés
@@ -830,7 +807,7 @@ class GlobalSettings(BaseSettings):
             "DIVERSITY_FACTOR": self.DIVERSITY_FACTOR,
             "MAX_SAME_MERCHANT": self.MAX_SAME_MERCHANT,
             
-            # Configuration fusion hybride
+            # Configuration fusion
             "DEFAULT_FUSION_STRATEGY": self.DEFAULT_FUSION_STRATEGY,
             "SCORE_NORMALIZATION_METHOD": self.SCORE_NORMALIZATION_METHOD,
             "RRF_K": self.RRF_K,

--- a/conversation_service/agents/llm_intent_agent.py
+++ b/conversation_service/agents/llm_intent_agent.py
@@ -120,13 +120,12 @@ class LLMIntentAgent(BaseFinancialAgent):
                 logger.warning("DeepSeek call failed (attempt %s): %s", attempt + 1, err)
                 await asyncio.sleep(2 ** attempt)
         if response is None:
+            raise RuntimeError("LLM intent detection failed")
+        try:
+            data = json.loads(response.content)
+        except Exception as err:  # pragma: no cover - defensive fallback
+            logger.warning("Failed to parse LLM output: %s", err)
             data = {"intent": "OUT_OF_SCOPE", "confidence": 0.0, "entities": []}
-        else:
-            try:
-                data = json.loads(response.content)
-            except Exception as err:  # pragma: no cover - defensive fallback
-                logger.warning("Failed to parse LLM output: %s", err)
-                data = {"intent": "OUT_OF_SCOPE", "confidence": 0.0, "entities": []}
 
         intent_type = data.get("intent", "OUT_OF_SCOPE")
         entities: List[FinancialEntity] = []

--- a/conversation_service/agents/orchestrator_agent.py
+++ b/conversation_service/agents/orchestrator_agent.py
@@ -17,6 +17,8 @@ Version: 1.0.0 MVP - Multi-Agent Orchestration
 
 import time
 import logging
+import asyncio
+import os
 from typing import Dict, Any, Optional, List, Deque
 from dataclasses import dataclass
 from enum import Enum
@@ -34,6 +36,11 @@ from ..core.conversation_manager import ConversationManager
 from ..utils.metrics import get_default_metrics_collector
 
 logger = logging.getLogger(__name__)
+
+
+INTENT_TIMEOUT_SECONDS = float(os.getenv("INTENT_TIMEOUT_SECONDS", "10"))
+INTENT_MAX_RETRIES = int(os.getenv("INTENT_MAX_RETRIES", "3"))
+INTENT_BACKOFF_BASE = float(os.getenv("INTENT_BACKOFF_BASE", "1"))
 
 
 class WorkflowStepStatus(Enum):
@@ -133,31 +140,43 @@ class WorkflowExecutor:
             intent_timer = metrics.performance_monitor.start_timer("intent_detection")
             
             try:
-                intent_response = await self.intent_agent.execute_with_metrics(
-                    {"user_message": user_message}, user_id
-                )
-                intent_result = (
-                    intent_response.metadata.get("intent_result")
-                    if intent_response.metadata
-                    else None
-                )
-                logger.info(
-                    f"Intent: {intent_result.intent_type}, "
-                    f"Entities: {[e.model_dump() for e in getattr(intent_result, 'entities', [])]}"
-                )
-
-                if intent_response.success:
-                    workflow_data["intent_result"] = intent_result
-                    intent_step.status = WorkflowStepStatus.COMPLETED
-                    intent_step.result = intent_response
-                else:
-                    raise Exception(intent_response.error_message or "Intent detection failed")
-                    
+                intent_response = None
+                for attempt in range(1, INTENT_MAX_RETRIES + 1):
+                    try:
+                        intent_response = await asyncio.wait_for(
+                            self.intent_agent.execute_with_metrics({"user_message": user_message}, user_id),
+                            timeout=INTENT_TIMEOUT_SECONDS,
+                        )
+                        if intent_response.success:
+                            intent_result = (
+                                intent_response.metadata.get("intent_result")
+                                if intent_response.metadata
+                                else None
+                            )
+                            logger.info(
+                                f"Intent: {intent_result.intent_type}, "
+                                f"Entities: {[e.model_dump() for e in getattr(intent_result, 'entities', [])]}"
+                            )
+                            workflow_data["intent_result"] = intent_result
+                            intent_step.status = WorkflowStepStatus.COMPLETED
+                            intent_step.result = intent_response
+                            break
+                        raise Exception(intent_response.error_message or "Intent detection failed")
+                    except Exception as e:
+                        logger.error(
+                            f"Intent detection attempt {attempt}/{INTENT_MAX_RETRIES} failed: {e}"
+                        )
+                        if attempt < INTENT_MAX_RETRIES:
+                            backoff = INTENT_BACKOFF_BASE * (2 ** (attempt - 1))
+                            if backoff > 0:
+                                await asyncio.sleep(backoff)
+                        else:
+                            raise
             except Exception as e:
                 intent_step.status = WorkflowStepStatus.FAILED
                 intent_step.error = str(e)
-                logger.error(f"Intent detection step failed: {e}")
-                
+                logger.error(f"Intent detection step failed after retries: {e}")
+
                 # Try to continue with fallback intent
                 workflow_data["intent_result"] = self._create_fallback_intent()
             
@@ -349,7 +368,8 @@ class WorkflowExecutor:
             confidence=0.3,
             entities=[],
             method=DetectionMethod.FALLBACK,
-            processing_time_ms=0.0
+            processing_time_ms=0.0,
+            search_required=True
         )
     
     def _create_empty_search_results(self) -> AgentResponse:

--- a/tests/test_enhanced_llm_intent_agent.py
+++ b/tests/test_enhanced_llm_intent_agent.py
@@ -45,14 +45,14 @@ class FallbackAgent:
             intent_category=IntentCategory.GENERAL_QUESTION,
             confidence=1.0,
             entities=[],
-            method=DetectionMethod.RULE_BASED,
+            method=DetectionMethod.FALLBACK,
             processing_time_ms=0.0,
         )
         return {
             "content": "{}",
             "metadata": {
                 "intent_result": intent_result,
-                "detection_method": DetectionMethod.RULE_BASED,
+                "detection_method": DetectionMethod.FALLBACK,
                 "confidence": intent_result.confidence,
                 "intent_type": intent_result.intent_type,
                 "entities": [],

--- a/tests/test_orchestrator_fallback.py
+++ b/tests/test_orchestrator_fallback.py
@@ -1,0 +1,64 @@
+import asyncio
+
+import conversation_service.agents.orchestrator_agent as oa
+from conversation_service.agents.orchestrator_agent import WorkflowExecutor
+from conversation_service.models.agent_models import AgentResponse
+from conversation_service.models.financial_models import DetectionMethod
+
+
+oa.INTENT_TIMEOUT_SECONDS = 0.01
+oa.INTENT_MAX_RETRIES = 2
+oa.INTENT_BACKOFF_BASE = 0
+
+
+class FailingIntentAgent:
+    name = "intent_agent"
+
+    def __init__(self):
+        self.calls = 0
+
+    async def execute_with_metrics(self, input_data, user_id):
+        self.calls += 1
+        raise Exception("fail")
+
+
+class DummySearchAgent:
+    name = "search_agent"
+
+    async def execute_with_metrics(self, input_data, user_id):
+        return AgentResponse(
+            agent_name=self.name,
+            content="search",
+            metadata={"search_results_count": 0},
+            execution_time_ms=0,
+            success=True,
+        )
+
+
+class DummyResponseAgent:
+    name = "response_agent"
+
+    async def execute_with_metrics(self, input_data, user_id):
+        return AgentResponse(
+            agent_name=self.name,
+            content="ok",
+            metadata={},
+            execution_time_ms=0,
+            success=True,
+        )
+
+
+def test_fallback_intent_keeps_workflow_running():
+    intent_agent = FailingIntentAgent()
+    executor = WorkflowExecutor(intent_agent, DummySearchAgent(), DummyResponseAgent())
+
+    result = asyncio.run(executor.execute_workflow("hello", "c1", 1))
+
+    assert intent_agent.calls == 2
+    assert result["workflow_data"]["intent_result"].method == DetectionMethod.FALLBACK
+
+    search_step = next(
+        step for step in result["execution_details"]["steps"] if step["name"] == "search_query"
+    )
+    assert search_step["status"] == "completed"
+    assert result["final_response"] == "ok"


### PR DESCRIPTION
## Summary
- remove legacy hybrid agent config entries
- add configurable timeout and exponential backoff retry to intent detection
- use fallback intent and non-blocking workflow on repeated failures
- raise on LLM intent errors and add orchestrator fallback test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d915be9e08320857b672f290a4a50