### PR TITLE
refactor: streamline LLM intent prompts

### DIFF
--- a/conversation_service/prompts/__init__.py
+++ b/conversation_service/prompts/__init__.py
@@ -6,7 +6,7 @@ d'agents AutoGen financiers. Chaque module expose des prompts spécialisés
 et des fonctions de formatage pour maximiser la précision des réponses.
 
 Modules:
-    intent_prompts: Prompts fallback détection d'intention
+    intent_prompts: Prompts détection d'intention (LLM principal)
     search_prompts: Prompts génération requêtes Search Service  
     response_prompts: Prompts génération réponses contextuelles
     orchestrator_prompts: Prompts orchestrateur principal
@@ -14,8 +14,8 @@ Modules:
 
 # Import des prompts système principaux
 from .intent_prompts import (
-    INTENT_FALLBACK_SYSTEM_PROMPT,
-    INTENT_FALLBACK_USER_TEMPLATE,
+    INTENT_SYSTEM_PROMPT,
+    INTENT_USER_TEMPLATE,
     INTENT_EXAMPLES_FEW_SHOT,
     format_intent_prompt
 )
@@ -54,8 +54,8 @@ from .orchestrator_prompts import build_workflow_state
 
 __all__ = [
     # Intent Detection
-    "INTENT_FALLBACK_SYSTEM_PROMPT",
-    "INTENT_FALLBACK_USER_TEMPLATE", 
+    "INTENT_SYSTEM_PROMPT",
+    "INTENT_USER_TEMPLATE",
     "INTENT_EXAMPLES_FEW_SHOT",
     "format_intent_prompt",
     "build_context_summary",

--- a/tests/test_enhanced_llm_intent_agent.py
+++ b/tests/test_enhanced_llm_intent_agent.py
@@ -45,14 +45,14 @@ class FallbackAgent:
             intent_category=IntentCategory.GENERAL_QUESTION,
             confidence=1.0,
             entities=[],
-            method=DetectionMethod.RULE_BASED,
+            method=DetectionMethod.AI_DETECTION,
             processing_time_ms=0.0,
         )
         return {
             "content": "{}",
             "metadata": {
                 "intent_result": intent_result,
-                "detection_method": DetectionMethod.RULE_BASED,
+                "detection_method": DetectionMethod.AI_DETECTION,
                 "confidence": intent_result.confidence,
                 "intent_type": intent_result.intent_type,
                 "entities": [],


### PR DESCRIPTION
## Summary
- drop rule/fallback language from intent prompts and package exports
- expand few-shot examples for new intents and enforce strict DeepSeek output format
- raise errors on LLM failure to trigger fallback logic and update tests accordingly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d916756bc832099b8c5d7cde6a0ab