### PR TITLE
Fix password confirmation validator

### DIFF
--- a/user_service/schemas/user.py
+++ b/user_service/schemas/user.py
@@ -1,5 +1,11 @@
-from pydantic import BaseModel, EmailStr, Field, model_validator, ConfigDict
-from pydantic import BaseModel, EmailStr, Field, field_validator, FieldValidationInfo
+from pydantic import (
+    BaseModel,
+    EmailStr,
+    Field,
+    FieldValidationInfo,
+    ConfigDict,
+    field_validator,
+)
 from typing import Optional, Dict, Any, List
 from datetime import datetime
 
@@ -16,15 +22,12 @@ class UserCreate(UserBase):
     password: str = Field(..., min_length=8)
     confirm_password: str
 
-    @model_validator(mode="after")
-    def passwords_match(cls, values):
-        if values.password != values.confirm_password:
-    @field_validator('confirm_password')
+    @field_validator("confirm_password")
     @classmethod
     def passwords_match(cls, v: str, info: FieldValidationInfo):
-        if info.data.get('password') and v != info.data['password']:
-            raise ValueError('Passwords do not match')
-        return values
+        if info.data.get("password") and v != info.data["password"]:
+            raise ValueError("Passwords do not match")
+        return v
 
 
 # Mise à jour d'utilisateur


### PR DESCRIPTION
## Summary
- remove duplicate pydantic imports
- validate confirm_password using `@field_validator`

## Testing
- `pytest` *(fails: keyword argument repeated: method)*

------
https://chatgpt.com/codex/tasks/task_e_689d9d43712c83209c58ca78c60c1560