### PR TITLE
Clean up fallback agent detection method handling in tests

### DIFF
--- a/tests/test_enhanced_llm_intent_agent.py
+++ b/tests/test_enhanced_llm_intent_agent.py
@@ -45,9 +45,6 @@ class FallbackAgent:
             intent_category=IntentCategory.GENERAL_QUESTION,
             confidence=1.0,
             entities=[],
-            method=DetectionMethod.AI_DETECTION,
-            method=DetectionMethod.AI_FALLBACK,
-
             method=DetectionMethod.FALLBACK,
             processing_time_ms=0.0,
         )
@@ -55,9 +52,6 @@ class FallbackAgent:
             "content": "{}",
             "metadata": {
                 "intent_result": intent_result,
-                "detection_method": DetectionMethod.AI_DETECTION,
-                "detection_method": DetectionMethod.AI_FALLBACK,
-
                 "detection_method": DetectionMethod.FALLBACK,
                 "confidence": intent_result.confidence,
                 "intent_type": intent_result.intent_type,


### PR DESCRIPTION
## Summary
- remove duplicated `method` args when building `IntentResult`
- only keep one `detection_method` in returned metadata

## Testing
- `pytest tests/test_enhanced_llm_intent_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689dac20d76c83209117c805cbd025e2