### PR TITLE
Rename search filter fields for search requests

### DIFF
--- a/conversation_service/agents/search_query_agent.py
+++ b/conversation_service/agents/search_query_agent.py
@@ -42,16 +42,16 @@ audit_logger = logging.getLogger("audit")
 
 class QueryOptimizer:
     """Helper class for optimizing search queries."""
-    
+
     @staticmethod
     def optimize_search_text(user_message: str, intent_result: IntentResult) -> str:
         """
         Optimize search text based on intent and entities.
-        
+
         Args:
             user_message: Original user message
             intent_result: Detected intent with entities
-            
+
         Returns:
             Optimized search text
         """
@@ -59,9 +59,9 @@ class QueryOptimizer:
         search_text = user_message.lower().strip()
 
         # Remove accents for consistent search behavior
-        search_text = unicodedata.normalize('NFD', search_text)
-        search_text = ''.join(
-            ch for ch in search_text if unicodedata.category(ch) != 'Mn'
+        search_text = unicodedata.normalize("NFD", search_text)
+        search_text = "".join(
+            ch for ch in search_text if unicodedata.category(ch) != "Mn"
         )
 
         # Remove punctuation
@@ -69,23 +69,61 @@ class QueryOptimizer:
 
         # Remove common stop words, question words, and generic terms
         stop_words = {
-            'le', 'la', 'les', 'de', 'du', 'des', 'un', 'une', 'mon', 'ma', 'mes',
-            'recherche', 'rechercher', 'depense', 'depenses', 'transaction',
-            'transactions',
-            'combien', 'pourquoi', 'pour', 'quel', 'quelle', 'quels', 'quelles',
-            'qui', 'que', 'quoi', 'ou', 'quand', 'comment', 'ce', 'cet', 'cette',
-            'ces', 'mois', 'je', 'j', 'ai', 'jai'
+            "le",
+            "la",
+            "les",
+            "de",
+            "du",
+            "des",
+            "un",
+            "une",
+            "mon",
+            "ma",
+            "mes",
+            "recherche",
+            "rechercher",
+            "depense",
+            "depenses",
+            "transaction",
+            "transactions",
+            "combien",
+            "pourquoi",
+            "pour",
+            "quel",
+            "quelle",
+            "quels",
+            "quelles",
+            "qui",
+            "que",
+            "quoi",
+            "ou",
+            "quand",
+            "comment",
+            "ce",
+            "cet",
+            "cette",
+            "ces",
+            "mois",
+            "je",
+            "j",
+            "ai",
+            "jai",
         }
         words = [word for word in search_text.split() if word not in stop_words]
 
         # Remove basic verb forms (infinitives) for more aggressive normalization
-        words = [word for word in words if not word.endswith(('er', 'ir', 're'))]
+        words = [word for word in words if not word.endswith(("er", "ir", "re"))]
 
         # Add entity-based keywords without duplicating existing terms
         seen_words = set(words)
         if intent_result.entities:
             for entity in intent_result.entities:
-                if entity.entity_type in {EntityType.MERCHANT, "MERCHANT", EntityType.CATEGORY, "CATEGORY"}:
+                if entity.entity_type in {
+                    EntityType.MERCHANT,
+                    "MERCHANT",
+                    EntityType.CATEGORY,
+                    "CATEGORY",
+                }:
                     if entity.normalized_value:
                         value = str(entity.normalized_value).lower()
                         if value not in seen_words:
@@ -101,7 +139,7 @@ class QueryOptimizer:
         optimized_text = " ".join(unique_words)[:200]
         logger.debug("Normalized search text: %s", optimized_text)
         return optimized_text  # Limit search text length
-    
+
     @staticmethod
     def extract_date_filters(intent_result: IntentResult) -> Dict[str, Any]:
         """Extract date range filters from intent entities."""
@@ -129,7 +167,7 @@ class QueryOptimizer:
                         pass
 
         return date_filters
-    
+
     @staticmethod
     def extract_amount_filters(intent_result: IntentResult) -> Dict[str, Any]:
         """Extract amount range filters from intent entities."""
@@ -139,7 +177,9 @@ class QueryOptimizer:
             return amount_filters
 
         for entity in intent_result.entities:
-            if entity.entity_type == EntityType.AMOUNT and isinstance(entity.normalized_value, (int, float)):
+            if entity.entity_type == EntityType.AMOUNT and isinstance(
+                entity.normalized_value, (int, float)
+            ):
                 normalized_amount = entity.normalized_value
                 tolerance = abs(normalized_amount) * 0.1  # 10% tolerance
                 amount_filters["amount_min"] = normalized_amount - tolerance
@@ -151,24 +191,28 @@ class QueryOptimizer:
 class SearchQueryAgent(BaseFinancialAgent):
     """
     Agent for generating and executing search queries.
-    
+
     This agent takes intent detection results and user messages, then:
     1. Extracts additional entities using AI
     2. Generates optimized SearchServiceQuery contracts
     3. Executes queries against the Search Service
     4. Returns structured search results
-    
+
     Attributes:
         search_service_url: Base URL for the Search Service
         http_client: HTTP client for service communication
         query_optimizer: Helper for query optimization
     """
-    
-    def __init__(self, deepseek_client: DeepSeekClient, search_service_url: str, 
-                 config: Optional[AgentConfig] = None):
+
+    def __init__(
+        self,
+        deepseek_client: DeepSeekClient,
+        search_service_url: str,
+        config: Optional[AgentConfig] = None,
+    ):
         """
         Initialize the search query agent.
-        
+
         Args:
             deepseek_client: Configured DeepSeek client
             search_service_url: Base URL for Search Service
@@ -180,32 +224,34 @@ class SearchQueryAgent(BaseFinancialAgent):
                 model_client_config={
                     "model": "deepseek-chat",
                     "api_key": deepseek_client.api_key,
-                    "base_url": deepseek_client.base_url
+                    "base_url": deepseek_client.base_url,
                 },
                 system_message=self._get_system_message(),
                 max_consecutive_auto_reply=1,
                 description="Search query generation and execution agent",
                 temperature=0.2,  # Low temperature for consistent entity extraction
                 max_tokens=250,
-                timeout_seconds=12
+                timeout_seconds=12,
             )
-        
+
         super().__init__(
-            name=config.name,
-            config=config,
-            deepseek_client=deepseek_client
+            name=config.name, config=config, deepseek_client=deepseek_client
         )
 
         # Ensure a local name attribute exists without overriding base class behavior
         self._name = config.name
-        
-        self.search_service_url = search_service_url.rstrip('/')
+
+        self.search_service_url = search_service_url.rstrip("/")
         self.http_client = httpx.AsyncClient(timeout=30.0)
         self.query_optimizer = QueryOptimizer()
-        
-        logger.info(f"Initialized SearchQueryAgent with service URL: {search_service_url}")
-    
-    async def _execute_operation(self, input_data: Dict[str, Any], user_id: int) -> Dict[str, Any]:
+
+        logger.info(
+            f"Initialized SearchQueryAgent with service URL: {search_service_url}"
+        )
+
+    async def _execute_operation(
+        self, input_data: Dict[str, Any], user_id: int
+    ) -> Dict[str, Any]:
         """
         Execute search query operation.
 
@@ -229,17 +275,17 @@ class SearchQueryAgent(BaseFinancialAgent):
     ) -> Dict[str, Any]:
         """
         Process a search request end-to-end.
-        
+
         Args:
             intent_result: Detected intent with entities
             user_message: Original user message
             user_id: ID of the requesting user
-            
+
         Returns:
             Dictionary containing search results and metadata
         """
         start_time = time.perf_counter()
-        
+
         try:
             # Step 1: Extract additional entities using AI
             enhanced_entities = await self._extract_additional_entities(
@@ -259,36 +305,44 @@ class SearchQueryAgent(BaseFinancialAgent):
 
             # Step 3: Execute search query
             search_response = await self._execute_search_query(search_query)
-            
+
             execution_time = (time.perf_counter() - start_time) * 1000
-            
-            returned_results = getattr(getattr(search_response, "response_metadata", {}), "returned_results", 0)
+
+            returned_results = getattr(
+                getattr(search_response, "response_metadata", {}), "returned_results", 0
+            )
             if isinstance(getattr(search_response, "response_metadata", None), dict):
-                returned_results = search_response.response_metadata.get("returned_results", 0)
+                returned_results = search_response.response_metadata.get(
+                    "returned_results", 0
+                )
 
             return {
                 "content": f"Search completed: {returned_results} results",
                 "metadata": {
                     "search_query": search_query.dict(),
                     "search_response": search_response.dict(),
-                    "enhanced_entities": [
-                        e.dict() for e in enhanced_entities
-                    ] if enhanced_entities else [],
+                    "enhanced_entities": (
+                        [e.dict() for e in enhanced_entities]
+                        if enhanced_entities
+                        else []
+                    ),
                     "execution_time_ms": execution_time,
                     "search_results_count": returned_results,
                 },
-                "confidence_score": min(intent_result.confidence + 0.1, 1.0),  # Boost confidence slightly
+                "confidence_score": min(
+                    intent_result.confidence + 0.1, 1.0
+                ),  # Boost confidence slightly
                 "token_usage": {
                     "prompt_tokens": 50,  # Estimated
                     "completion_tokens": 20,
-                    "total_tokens": 70
-                }
+                    "total_tokens": 70,
+                },
             }
-            
+
         except Exception as e:
             logger.error(f"Search request processing failed: {e}")
             raise
-    
+
     async def _generate_search_contract(
         self,
         intent_result: IntentResult,
@@ -298,24 +352,26 @@ class SearchQueryAgent(BaseFinancialAgent):
     ) -> SearchServiceQuery:
         """
         Generate a SearchServiceQuery contract from intent and message.
-        
+
         Args:
             intent_result: Detected intent with entities
             user_message: Original user message
             user_id: ID of the requesting user
             enhanced_entities: Additional entities from AI extraction
-            
+
         Returns:
             SearchServiceQuery contract for the Search Service
         """
         # Optimize search text
-        search_text = self.query_optimizer.optimize_search_text(user_message, intent_result)
+        search_text = self.query_optimizer.optimize_search_text(
+            user_message, intent_result
+        )
         logger.debug("Optimized search text: %s", search_text)
-        
+
         # Extract filters from entities
         date_filters = self.query_optimizer.extract_date_filters(intent_result)
         amount_filters = self.query_optimizer.extract_amount_filters(intent_result)
-        
+
         # Combine all entities
         all_entities: List[FinancialEntity] = (
             intent_result.entities.copy() if intent_result.entities else []
@@ -335,7 +391,7 @@ class SearchQueryAgent(BaseFinancialAgent):
             if e.entity_type in {EntityType.CATEGORY, "CATEGORY"} and e.normalized_value
         ]
         if categories:
-            search_filters["categories"] = categories
+            search_filters["category_name"] = categories
 
         merchants = [
             str(e.normalized_value)
@@ -343,7 +399,7 @@ class SearchQueryAgent(BaseFinancialAgent):
             if e.entity_type in {EntityType.MERCHANT, "MERCHANT"} and e.normalized_value
         ]
         if merchants:
-            search_filters["merchants"] = merchants
+            search_filters["merchant_name"] = merchants
 
         # Always filter by user_id for security and multi-tenant isolation
         search_filters["user_id"] = user_id
@@ -356,45 +412,50 @@ class SearchQueryAgent(BaseFinancialAgent):
             intent_type=intent_result.intent_type,
             language="fr",
             priority="normal",
-            source_agent=self.name
+            source_agent=self.name,
         )
-        
+
         # Create search parameters based on intent
         search_params = SearchParameters(
             search_text=search_text,
             max_results=20 if intent_result.intent_type == "TRANSACTION_SEARCH" else 10,
             include_highlights=True,
-            boost_recent=intent_result.intent_type in [
+            boost_recent=intent_result.intent_type
+            in [
                 "BALANCE_CHECK",
                 "SPENDING_ANALYSIS",
             ],
-            fuzzy_matching=True if len(search_text.split()) > 1 else False
+            fuzzy_matching=True if len(search_text.split()) > 1 else False,
         )
-        
+
         # Create complete search query
-        filters_obj = SearchFilters(**search_filters) if search_filters else SearchFilters()
+        filters_obj = (
+            SearchFilters(**search_filters) if search_filters else SearchFilters()
+        )
 
         search_query = SearchServiceQuery(
             query_metadata=query_metadata,
             search_parameters=search_params,
-            filters=filters_obj
+            filters=filters_obj,
         )
-        
+
         # Validate the query
         validator = ContractValidator()
         validation_errors = validator.validate_search_query(search_query.dict())
         if validation_errors:
             logger.warning(f"Search query validation warnings: {validation_errors}")
-        
+
         return search_query
-    
-    async def _execute_search_query(self, query: SearchServiceQuery) -> SearchServiceResponse:
+
+    async def _execute_search_query(
+        self, query: SearchServiceQuery
+    ) -> SearchServiceResponse:
         """
         Execute search query against the Search Service.
-        
+
         Args:
             query: SearchServiceQuery contract
-            
+
         Returns:
             SearchServiceResponse from the service
         """
@@ -403,10 +464,14 @@ class SearchQueryAgent(BaseFinancialAgent):
             url = f"{self.search_service_url}/search"
             headers = {
                 "Content-Type": "application/json",
-                "User-Agent": f"ConversationService/{self.name}"
+                "User-Agent": f"ConversationService/{self.name}",
             }
 
-            request_payload = query.to_search_request() if hasattr(query, "to_search_request") else query.dict()
+            request_payload = (
+                query.to_search_request()
+                if hasattr(query, "to_search_request")
+                else query.dict()
+            )
 
             # Audit logging for search execution
             metadata = query.query_metadata
@@ -435,11 +500,9 @@ class SearchQueryAgent(BaseFinancialAgent):
 
             # Execute HTTP request
             response = await self.http_client.post(
-                url=url,
-                json=request_payload,
-                headers=headers
+                url=url, json=request_payload, headers=headers
             )
-            
+
             response.raise_for_status()
 
             # Parse response
@@ -462,18 +525,24 @@ class SearchQueryAgent(BaseFinancialAgent):
                 total_results,
             )
 
-            returned_results = getattr(getattr(search_response, "response_metadata", {}), "returned_results", 0)
+            returned_results = getattr(
+                getattr(search_response, "response_metadata", {}), "returned_results", 0
+            )
             if isinstance(getattr(search_response, "response_metadata", None), dict):
-                returned_results = search_response.response_metadata.get("returned_results", 0)
+                returned_results = search_response.response_metadata.get(
+                    "returned_results", 0
+                )
 
             logger.info(
                 f"Search query executed successfully: {returned_results} results"
             )
 
             return search_response
-            
+
         except httpx.HTTPStatusError as e:
-            logger.error(f"Search service HTTP error: {e.response.status_code} - {e.response.text}")
+            logger.error(
+                f"Search service HTTP error: {e.response.status_code} - {e.response.text}"
+            )
             raise Exception(f"Search service error: {e.response.status_code}")
         except httpx.RequestError as e:
             logger.error(f"Search service request error: {e}")
@@ -481,43 +550,45 @@ class SearchQueryAgent(BaseFinancialAgent):
         except Exception as e:
             logger.error(f"Search query execution failed: {e}")
             raise
-    
+
     async def _extract_additional_entities(
         self, message: str, intent_result: IntentResult, user_id: int
     ) -> List[FinancialEntity]:
         """
         Extract additional entities using AI that weren't detected previously.
-        
+
         Args:
             message: User message
             intent_result: Intent with existing entities
-            
+
         Returns:
             List of additional entities found
         """
         try:
             # Prepare context for entity extraction
             existing_entities = intent_result.entities if intent_result.entities else []
-            context = self._prepare_entity_extraction_context(message, existing_entities)
+            context = self._prepare_entity_extraction_context(
+                message, existing_entities
+            )
 
             # Call DeepSeek for entity extraction
             logger.debug("Extracting additional entities for user_id=%s", user_id)
             response = await self.deepseek_client.generate_response(
                 messages=[
                     {"role": "system", "content": self._get_entity_extraction_prompt()},
-                    {"role": "user", "content": context}
+                    {"role": "user", "content": context},
                 ],
                 temperature=0.1,
                 max_tokens=120,
                 user=str(user_id),
                 use_cache=True,
             )
-            
+
             # Parse AI response
             additional_entities = self._parse_entity_response(response.content)
 
             return additional_entities
-            
+
         except Exception as e:
             logger.warning(f"Additional entity extraction failed: {e}")
             return []
@@ -526,24 +597,24 @@ class SearchQueryAgent(BaseFinancialAgent):
         self, message: str, existing_entities: List[FinancialEntity]
     ) -> str:
         """Prepare context for AI entity extraction."""
-        context = f"Message: \"{message}\"\n\n"
-        
+        context = f'Message: "{message}"\n\n'
+
         if existing_entities:
             context += "Entités déjà détectées:\n"
             entities_by_type: Dict[str, List[str]] = {}
             for entity in existing_entities:
                 entities_by_type.setdefault(
                     getattr(entity.entity_type, "value", entity.entity_type), []
-                ).append(
-                    str(entity.normalized_value)
-                )
+                ).append(str(entity.normalized_value))
             for entity_type, values in entities_by_type.items():
                 context += f"- {entity_type}: {values}\n"
             context += "\n"
-        
-        context += "Extrais toutes les entités financières supplémentaires non détectées."
+
+        context += (
+            "Extrais toutes les entités financières supplémentaires non détectées."
+        )
         return context
-    
+
     def _parse_entity_response(self, ai_content: str) -> List[FinancialEntity]:
         """Parse AI entity extraction response."""
         entities: List[FinancialEntity] = []
@@ -559,7 +630,10 @@ class SearchQueryAgent(BaseFinancialAgent):
                         for item in parsed:
                             if isinstance(item, dict):
                                 for key, value in item.items():
-                                    if not value or (isinstance(value, str) and value.lower() == "aucune"):
+                                    if not value or (
+                                        isinstance(value, str)
+                                        and value.lower() == "aucune"
+                                    ):
                                         continue
                                     try:
                                         entity_type = EntityType(key.upper())
@@ -620,7 +694,7 @@ class SearchQueryAgent(BaseFinancialAgent):
             logger.warning(f"Failed to parse entity response: {e}")
 
         return entities
-    
+
     def _get_system_message(self) -> str:
         """Get system message for the agent."""
         return """Tu es un agent spécialisé dans la génération de requêtes de recherche pour les données financières.
@@ -639,7 +713,7 @@ Types d'entités à extraire:
 - TRANSACTION_TYPE: Types de transactions (débit/crédit)
 
 Optimise les requêtes pour la pertinence et la performance."""
-    
+
     def _get_entity_extraction_prompt(self) -> str:
         """Get entity extraction prompt for DeepSeek."""
         return """Extrais toutes les entités financières du message utilisateur.
@@ -656,7 +730,7 @@ TYPE_ENTITE: valeur_trouvée
 TYPE_ENTITE: autre_valeur
 
 Si aucune entité supplémentaire n'est trouvée, réponds: "aucune"."""
-    
+
     async def close(self) -> None:
         """Close HTTP client resources."""
         await self.http_client.aclose()

--- a/conversation_service/models/service_contracts.py
+++ b/conversation_service/models/service_contracts.py
@@ -47,73 +47,51 @@ __all__ = [
 class QueryMetadata(BaseModel):
     """
     Metadata for search queries sent to Search Service.
-    
+
     This model contains contextual information about the search query,
     including origin, user context, and processing requirements.
     """
-    
+
     query_id: str = Field(
         default_factory=lambda: str(uuid4()),
-        description="Unique identifier for this query"
+        description="Unique identifier for this query",
     )
-    
-    conversation_id: str = Field(
-        ...,
-        description="ID of the originating conversation"
-    )
-    
-    user_id: int = Field(
-        ...,
-        description="ID of the requesting user",
-        gt=0
-    )
-    
+
+    conversation_id: str = Field(..., description="ID of the originating conversation")
+
+    user_id: int = Field(..., description="ID of the requesting user", gt=0)
+
     timestamp: datetime = Field(
-        default_factory=datetime.utcnow,
-        description="When the query was created"
+        default_factory=datetime.utcnow, description="When the query was created"
     )
-    
+
     intent_type: str = Field(
-        ...,
-        description="Detected intent that triggered this query",
-        min_length=1
+        ..., description="Detected intent that triggered this query", min_length=1
     )
-    
+
     language: str = Field(
         default="fr",
         description="Language of the original user message",
-        pattern=r"^[a-z]{2}$"
-    )
-    
-    priority: Literal["low", "normal", "high", "urgent"] = Field(
-        default="normal",
-        description="Processing priority level"
-    )
-    
-    timeout_ms: int = Field(
-        default=5000,
-        description="Maximum processing time allowed",
-        gt=0,
-        le=30000
-    )
-    
-    retry_count: int = Field(
-        default=0,
-        description="Number of retries attempted",
-        ge=0,
-        le=3
-    )
-    
-    source_agent: Optional[str] = Field(
-        default=None,
-        description="Name of the agent that generated this query"
+        pattern=r"^[a-z]{2}$",
     )
 
-    model_config = {
-        "json_encoders": {
-            datetime: lambda v: v.isoformat()
-        }
-    }
+    priority: Literal["low", "normal", "high", "urgent"] = Field(
+        default="normal", description="Processing priority level"
+    )
+
+    timeout_ms: int = Field(
+        default=5000, description="Maximum processing time allowed", gt=0, le=30000
+    )
+
+    retry_count: int = Field(
+        default=0, description="Number of retries attempted", ge=0, le=3
+    )
+
+    source_agent: Optional[str] = Field(
+        default=None, description="Name of the agent that generated this query"
+    )
+
+    model_config = {"json_encoders": {datetime: lambda v: v.isoformat()}}
 
     @field_validator("user_id")
     @classmethod
@@ -127,69 +105,51 @@ class QueryMetadata(BaseModel):
 class SearchParameters(BaseModel):
     """
     Configuration parameters for search behavior.
-    
+
     This model defines how the search should be performed, including
     result limits, sorting, and search strategy preferences.
     """
-    
+
     search_text: Optional[str] = Field(
         default=None,
         description="Text to search for in the Search Service",
     )
 
     max_results: int = Field(
-        default=50,
-        description="Maximum number of results to return",
-        gt=0,
-        le=1000
+        default=50, description="Maximum number of results to return", gt=0, le=1000
     )
-    
-    offset: int = Field(
-        default=0,
-        description="Number of results to skip",
-        ge=0
-    )
-    
+
+    offset: int = Field(default=0, description="Number of results to skip", ge=0)
+
     sort_by: Optional[str] = Field(
-        default="relevance",
-        description="Field to sort results by"
+        default="relevance", description="Field to sort results by"
     )
-    
-    sort_order: Literal["asc", "desc"] = Field(
-        default="desc",
-        description="Sort order"
-    )
-    
+
+    sort_order: Literal["asc", "desc"] = Field(default="desc", description="Sort order")
+
     include_highlights: bool = Field(
-        default=True,
-        description="Whether to include result highlights"
+        default=True, description="Whether to include result highlights"
     )
-    
+
     search_strategy: Literal["exact", "fuzzy", "semantic"] = Field(
         default="semantic",
         description="Strategy for search execution",
     )
-    
+
     boost_recent: bool = Field(
-        default=True,
-        description="Whether to boost recent results"
+        default=True, description="Whether to boost recent results"
     )
-    
+
     include_aggregations: bool = Field(
-        default=False,
-        description="Whether to include aggregation data"
+        default=False, description="Whether to include aggregation data"
     )
-    
+
     fuzzy_matching: bool = Field(
-        default=True,
-        description="Whether to enable fuzzy matching"
+        default=True, description="Whether to enable fuzzy matching"
     )
-    
+
     min_score: Optional[float] = Field(
-        default=None,
-        description="Minimum relevance score for results",
-        ge=0.0,
-        le=1.0
+        default=None, description="Minimum relevance score for results", ge=0.0, le=1.0
     )
 
     model_config = {
@@ -204,7 +164,7 @@ class SearchParameters(BaseModel):
                 "search_strategy": "semantic",
                 "boost_recent": True,
                 "fuzzy_matching": True,
-                "min_score": 0.1
+                "min_score": 0.1,
             }
         }
     }
@@ -213,90 +173,85 @@ class SearchParameters(BaseModel):
 class SearchFilters(BaseModel):
     """
     Filter specifications for search queries.
-    
+
     This model defines various filters that can be applied to narrow
     search results based on transaction attributes, dates, amounts, etc.
     """
-    
+
     date_range: Optional[Dict[str, str]] = Field(
-        default=None,
-        description="Date range filter with 'start' and 'end' keys"
+        default=None, description="Date range filter with 'start' and 'end' keys"
     )
-    
+
     amount_range: Optional[Dict[str, float]] = Field(
-        default=None,
-        description="Amount range filter with 'min' and 'max' keys"
+        default=None, description="Amount range filter with 'min' and 'max' keys"
     )
-    
-    categories: Optional[List[str]] = Field(
+
+    category_name: Optional[List[str]] = Field(
         default=None,
-        description="List of transaction categories to include"
+        description="List of transaction categories to include",
+        alias="categories",  # Backwards compatibility
     )
-    
-    merchants: Optional[List[str]] = Field(
+
+    merchant_name: Optional[List[str]] = Field(
         default=None,
-        description="List of merchants to include"
+        description="List of merchants to include",
+        alias="merchants",  # Backwards compatibility
     )
-    
+
     transaction_types: Optional[List[str]] = Field(
-        default=None,
-        description="List of transaction types to include"
+        default=None, description="List of transaction types to include"
     )
-    
+
     account_ids: Optional[List[str]] = Field(
-        default=None,
-        description="List of account IDs to include"
+        default=None, description="List of account IDs to include"
     )
-    
+
     currencies: Optional[List[str]] = Field(
-        default=None,
-        description="List of currencies to include"
+        default=None, description="List of currencies to include"
     )
-    
+
     tags: Optional[List[str]] = Field(
-        default=None,
-        description="List of tags to include"
+        default=None, description="List of tags to include"
     )
-    
+
     exclude_categories: Optional[List[str]] = Field(
-        default=None,
-        description="Categories to exclude"
+        default=None, description="Categories to exclude"
     )
-    
+
     exclude_merchants: Optional[List[str]] = Field(
-        default=None,
-        description="Merchants to exclude"
+        default=None, description="Merchants to exclude"
     )
-    
+
     text_query: Optional[str] = Field(
         default=None,
         description="Free text query for description matching",
-        max_length=500
+        max_length=500,
     )
-    
+
     custom_filters: Optional[Dict[str, Any]] = Field(
-        default=None,
-        description="Additional custom filters"
+        default=None, description="Additional custom filters"
     )
 
     user_id: Optional[int] = Field(
-        default=None,
-        description="Identifier of the user executing the query",
-        gt=0
+        default=None, description="Identifier of the user executing the query", gt=0
     )
 
     @field_validator("date_range")
     @classmethod
-    def validate_date_range(cls, v: Optional[Dict[str, str]]) -> Optional[Dict[str, str]]:
+    def validate_date_range(
+        cls, v: Optional[Dict[str, str]]
+    ) -> Optional[Dict[str, str]]:
         """Validate date range has proper start and end."""
         if v is not None:
             if "start" not in v or "end" not in v:
                 raise ValueError("date_range must have 'start' and 'end' keys")
         return v
-    
+
     @field_validator("amount_range")
     @classmethod
-    def validate_amount_range(cls, v: Optional[Dict[str, float]]) -> Optional[Dict[str, float]]:
+    def validate_amount_range(
+        cls, v: Optional[Dict[str, float]]
+    ) -> Optional[Dict[str, float]]:
         """Validate amount range has proper min and max."""
         if v is not None:
             if "min" not in v and "max" not in v:
@@ -306,56 +261,46 @@ class SearchFilters(BaseModel):
         return v
 
     model_config = {
+        "populate_by_name": True,
         "json_schema_extra": {
             "example": {
-                "date_range": {
-                    "start": "2024-01-01",
-                    "end": "2024-01-31"
-                },
-                "amount_range": {
-                    "min": 100.0,
-                    "max": 1000.0
-                },
-                "categories": ["food", "transport"],
-                "merchants": ["Carrefour", "SNCF"],
+                "date_range": {"start": "2024-01-01", "end": "2024-01-31"},
+                "amount_range": {"min": 100.0, "max": 1000.0},
+                "category_name": ["food", "transport"],
+                "merchant_name": ["Carrefour", "SNCF"],
                 "transaction_types": ["debit"],
-                "text_query": "restaurant paris"
+                "text_query": "restaurant paris",
             }
-        }
+        },
     }
 
 
 class AggregationRequest(BaseModel):
     """
     Request for data aggregations (optional).
-    
+
     This model defines aggregation requests for analytical queries,
     such as grouping by category, calculating sums, averages, etc.
     """
-    
+
     group_by: Optional[List[str]] = Field(
-        default=None,
-        description="Fields to group aggregations by"
+        default=None, description="Fields to group aggregations by"
     )
-    
+
     metrics: Optional[List[str]] = Field(
-        default=None,
-        description="List of metrics to calculate (sum, avg, count, etc.)"
+        default=None, description="List of metrics to calculate (sum, avg, count, etc.)"
     )
-    
+
     date_histogram: Optional[Dict[str, str]] = Field(
-        default=None,
-        description="Date histogram configuration"
+        default=None, description="Date histogram configuration"
     )
-    
+
     top_values: Optional[Dict[str, Any]] = Field(
-        default=None,
-        description="Configuration for top values aggregation"
+        default=None, description="Configuration for top values aggregation"
     )
-    
+
     custom_aggregations: Optional[Dict[str, Any]] = Field(
-        default=None,
-        description="Custom aggregation definitions"
+        default=None, description="Custom aggregation definitions"
     )
 
     model_config = {
@@ -363,14 +308,8 @@ class AggregationRequest(BaseModel):
             "example": {
                 "group_by": ["category"],
                 "metrics": ["sum", "count", "avg"],
-                "date_histogram": {
-                    "field": "date",
-                    "interval": "month"
-                },
-                "top_values": {
-                    "field": "merchant",
-                    "size": 10
-                }
+                "date_histogram": {"field": "date", "interval": "month"},
+                "top_values": {"field": "merchant", "size": 10},
             }
         }
     }
@@ -379,29 +318,21 @@ class AggregationRequest(BaseModel):
 class SearchServiceQuery(BaseModel):
     """
     Complete search service request contract.
-    
+
     This is the main contract for requests sent from Conversation Service
     to Search Service, containing all necessary information for processing.
     """
-    
-    query_metadata: QueryMetadata = Field(
-        ...,
-        description="Metadata about the query"
-    )
-    
+
+    query_metadata: QueryMetadata = Field(..., description="Metadata about the query")
+
     search_parameters: SearchParameters = Field(
-        ...,
-        description="Search behavior configuration"
+        ..., description="Search behavior configuration"
     )
-    
-    filters: SearchFilters = Field(
-        ...,
-        description="Search filters to apply"
-    )
-    
+
+    filters: SearchFilters = Field(..., description="Search filters to apply")
+
     aggregations: Optional[AggregationRequest] = Field(
-        default=None,
-        description="Optional aggregation requests"
+        default=None, description="Optional aggregation requests"
     )
 
     model_config = {
@@ -411,28 +342,27 @@ class SearchServiceQuery(BaseModel):
                     "conversation_id": "550e8400-e29b-41d4-a716-446655440001",
                     "user_id": 12345,
                     "intent_type": "TRANSACTION_SEARCH_BY_DATE",
-                    "source_agent": "search_query_agent"
+                    "source_agent": "search_query_agent",
                 },
                 "search_parameters": {
                     "max_results": 20,
                     "sort_by": "date",
                     "sort_order": "desc",
-                    "search_strategy": "semantic"
+                    "search_strategy": "semantic",
                 },
                 "filters": {
-                    "date_range": {
-                        "start": "2024-01-01",
-                        "end": "2024-01-31"
-                    },
-                    "categories": ["food", "transport"]
-                }
+                    "date_range": {"start": "2024-01-01", "end": "2024-01-31"},
+                    "category_name": ["food", "transport"],
+                },
             }
         }
     }
 
     def to_search_request(self) -> Dict[str, Any]:
         """Convert this query to the simplified SearchRequest schema."""
-        filters_dict = self.filters.dict(exclude_none=True) if self.filters else {}
+        filters_dict = (
+            self.filters.model_dump(exclude_none=True) if self.filters else {}
+        )
         return {
             "user_id": self.query_metadata.user_id,
             "query": self.search_parameters.search_text or "",
@@ -450,156 +380,100 @@ class SearchServiceQuery(BaseModel):
 class ResponseMetadata(BaseModel):
     """
     Metadata for search service responses.
-    
+
     This model contains information about the search execution,
     performance metrics, and result statistics.
     """
-    
-    query_id: str = Field(
-        ...,
-        description="ID of the original query"
-    )
-    
+
+    query_id: str = Field(..., description="ID of the original query")
+
     response_timestamp: datetime = Field(
-        default_factory=datetime.utcnow,
-        description="When the response was generated"
-    )
-    
-    processing_time_ms: float = Field(
-        ...,
-        description="Time taken to process the query",
-        ge=0.0
-    )
-    
-    total_results: int = Field(
-        ...,
-        description="Total number of matching results",
-        ge=0
-    )
-    
-    returned_results: int = Field(
-        ...,
-        description="Number of results returned",
-        ge=0
-    )
-    
-    has_more_results: bool = Field(
-        ...,
-        description="Whether more results are available"
-    )
-    
-    search_strategy_used: str = Field(
-        ...,
-        description="Actual search strategy used"
-    )
-    
-    elasticsearch_took: Optional[int] = Field(
-        default=None,
-        description="Time Elasticsearch took (internal)",
-        ge=0
-    )
-    
-    cache_hit: bool = Field(
-        default=False,
-        description="Whether the result was served from cache"
-    )
-    
-    warnings: Optional[List[str]] = Field(
-        default=None,
-        description="Any warnings during processing"
-    )
-    
-    debug_info: Optional[Dict[str, Any]] = Field(
-        default=None,
-        description="Debug information (only in development)"
+        default_factory=datetime.utcnow, description="When the response was generated"
     )
 
-    model_config = {
-        "json_encoders": {
-            datetime: lambda v: v.isoformat()
-        }
-    }
+    processing_time_ms: float = Field(
+        ..., description="Time taken to process the query", ge=0.0
+    )
+
+    total_results: int = Field(
+        ..., description="Total number of matching results", ge=0
+    )
+
+    returned_results: int = Field(..., description="Number of results returned", ge=0)
+
+    has_more_results: bool = Field(
+        ..., description="Whether more results are available"
+    )
+
+    search_strategy_used: str = Field(..., description="Actual search strategy used")
+
+    elasticsearch_took: Optional[int] = Field(
+        default=None, description="Time Elasticsearch took (internal)", ge=0
+    )
+
+    cache_hit: bool = Field(
+        default=False, description="Whether the result was served from cache"
+    )
+
+    warnings: Optional[List[str]] = Field(
+        default=None, description="Any warnings during processing"
+    )
+
+    debug_info: Optional[Dict[str, Any]] = Field(
+        default=None, description="Debug information (only in development)"
+    )
+
+    model_config = {"json_encoders": {datetime: lambda v: v.isoformat()}}
 
 
 class TransactionResult(BaseModel):
     """
     Individual transaction result from search.
-    
+
     This model represents a single transaction returned by the search service,
     with all relevant transaction data and search-specific metadata.
     """
-    
-    transaction_id: str = Field(
-        ...,
-        description="Unique transaction identifier"
-    )
-    
-    date: str = Field(
-        ...,
-        description="Transaction date (ISO format)"
-    )
-    
-    amount: float = Field(
-        ...,
-        description="Transaction amount"
-    )
-    
+
+    transaction_id: str = Field(..., description="Unique transaction identifier")
+
+    date: str = Field(..., description="Transaction date (ISO format)")
+
+    amount: float = Field(..., description="Transaction amount")
+
     currency: str = Field(
-        ...,
-        description="Transaction currency",
-        pattern=r"^[A-Z]{3}$"
+        ..., description="Transaction currency", pattern=r"^[A-Z]{3}$"
     )
-    
-    description: str = Field(
-        ...,
-        description="Transaction description"
-    )
-    
-    merchant: Optional[str] = Field(
-        default=None,
-        description="Merchant name"
-    )
-    
-    category: Optional[str] = Field(
-        default=None,
-        description="Transaction category"
-    )
-    
-    account_id: str = Field(
-        ...,
-        description="Account identifier"
-    )
-    
+
+    description: str = Field(..., description="Transaction description")
+
+    merchant: Optional[str] = Field(default=None, description="Merchant name")
+
+    category: Optional[str] = Field(default=None, description="Transaction category")
+
+    account_id: str = Field(..., description="Account identifier")
+
     transaction_type: Literal["debit", "credit"] = Field(
-        ...,
-        description="Type of transaction"
+        ..., description="Type of transaction"
     )
-    
+
     balance_after: Optional[float] = Field(
-        default=None,
-        description="Account balance after transaction"
+        default=None, description="Account balance after transaction"
     )
-    
+
     tags: Optional[List[str]] = Field(
-        default=None,
-        description="List of associated tags"
+        default=None, description="List of associated tags"
     )
-    
+
     metadata: Optional[Dict[str, Any]] = Field(
-        default=None,
-        description="Additional transaction metadata"
+        default=None, description="Additional transaction metadata"
     )
-    
+
     relevance_score: Optional[float] = Field(
-        default=None,
-        description="Search relevance score",
-        ge=0.0,
-        le=1.0
+        default=None, description="Search relevance score", ge=0.0, le=1.0
     )
-    
+
     highlights: Optional[Dict[str, List[str]]] = Field(
-        default=None,
-        description="Highlighted text matches"
+        default=None, description="Highlighted text matches"
     )
 
     model_config = {
@@ -619,8 +493,8 @@ class TransactionResult(BaseModel):
                 "relevance_score": 0.95,
                 "highlights": {
                     "description": ["<em>CARREFOUR</em> PARIS 15"],
-                    "merchant": ["<em>Carrefour</em>"]
-                }
+                    "merchant": ["<em>Carrefour</em>"],
+                },
             }
         }
     }
@@ -629,31 +503,21 @@ class TransactionResult(BaseModel):
 class AggregationResult(BaseModel):
     """
     Results from aggregation requests (optional).
-    
+
     This model contains the results of data aggregations requested
     in the search query, such as category summaries, time-based groupings, etc.
     """
-    
+
     aggregation_type: str = Field(
-        ...,
-        description="Type of aggregation performed",
-        min_length=1
+        ..., description="Type of aggregation performed", min_length=1
     )
-    
-    results: Dict[str, Any] = Field(
-        ...,
-        description="Aggregation results data"
-    )
-    
-    total_count: int = Field(
-        ...,
-        description="Total count across all buckets",
-        ge=0
-    )
-    
+
+    results: Dict[str, Any] = Field(..., description="Aggregation results data")
+
+    total_count: int = Field(..., description="Total count across all buckets", ge=0)
+
     metadata: Optional[Dict[str, Any]] = Field(
-        default=None,
-        description="Additional aggregation metadata"
+        default=None, description="Additional aggregation metadata"
     )
 
     model_config = {
@@ -662,23 +526,15 @@ class AggregationResult(BaseModel):
                 "aggregation_type": "category_summary",
                 "results": {
                     "buckets": [
-                        {
-                            "key": "food",
-                            "doc_count": 25,
-                            "total_amount": -1250.75
-                        },
-                        {
-                            "key": "transport",
-                            "doc_count": 12,
-                            "total_amount": -340.20
-                        }
+                        {"key": "food", "doc_count": 25, "total_amount": -1250.75},
+                        {"key": "transport", "doc_count": 12, "total_amount": -340.20},
                     ]
                 },
                 "total_count": 37,
                 "metadata": {
                     "date_range": "2024-01-01 to 2024-01-31",
-                    "currency": "EUR"
-                }
+                    "currency": "EUR",
+                },
             }
         }
     }
@@ -687,53 +543,47 @@ class AggregationResult(BaseModel):
 class SearchServiceResponse(BaseModel):
     """
     Complete search service response contract.
-    
+
     This is the main contract for responses sent from Search Service
     back to Conversation Service, containing search results and metadata.
     """
-    
+
     response_metadata: ResponseMetadata = Field(
-        ...,
-        description="Metadata about the response"
-    )
-    
-    results: List[TransactionResult] = Field(
-        ...,
-        description="List of transaction results"
-    )
-    
-    aggregations: Optional[List[AggregationResult]] = Field(
-        default=None,
-        description="Optional aggregation results"
-    )
-    
-    success: bool = Field(
-        default=True,
-        description="Whether the search was successful"
-    )
-    
-    error_message: Optional[str] = Field(
-        default=None,
-        description="Error message if search failed"
-    )
-    
-    suggestions: Optional[List[str]] = Field(
-        default=None,
-        description="Suggestions for query improvement"
+        ..., description="Metadata about the response"
     )
 
-    @model_validator(mode='after')
-    def validate_error_consistency(self) -> 'SearchServiceResponse':
+    results: List[TransactionResult] = Field(
+        ..., description="List of transaction results"
+    )
+
+    aggregations: Optional[List[AggregationResult]] = Field(
+        default=None, description="Optional aggregation results"
+    )
+
+    success: bool = Field(default=True, description="Whether the search was successful")
+
+    error_message: Optional[str] = Field(
+        default=None, description="Error message if search failed"
+    )
+
+    suggestions: Optional[List[str]] = Field(
+        default=None, description="Suggestions for query improvement"
+    )
+
+    @model_validator(mode="after")
+    def validate_error_consistency(self) -> "SearchServiceResponse":
         """Validate error message consistency with success flag."""
         if not self.success and not self.error_message:
             raise ValueError("Error message is required when success is False")
         return self
-    
-    @model_validator(mode='after')
-    def validate_results_consistency(self) -> 'SearchServiceResponse':
+
+    @model_validator(mode="after")
+    def validate_results_consistency(self) -> "SearchServiceResponse":
         """Validate results consistency with metadata."""
         if len(self.results) != self.response_metadata.returned_results:
-            raise ValueError("Number of results must match returned_results in metadata")
+            raise ValueError(
+                "Number of results must match returned_results in metadata"
+            )
         return self
 
     def get_summary_stats(self) -> Dict[str, Any]:
@@ -744,40 +594,38 @@ class SearchServiceResponse(BaseModel):
                 "total_amount": 0.0,
                 "avg_amount": 0.0,
                 "date_range": None,
-                "categories": [],
-                "merchants": []
+                "category_name": [],
+                "merchant_name": [],
             }
-        
+
         amounts = [r.amount for r in self.results]
         dates = [r.date for r in self.results]
         categories = list(set(r.category for r in self.results if r.category))
         merchants = list(set(r.merchant for r in self.results if r.merchant))
-        
+
         return {
             "total_transactions": len(self.results),
             "total_amount": sum(amounts),
             "avg_amount": sum(amounts) / len(amounts),
-            "date_range": {
-                "start": min(dates),
-                "end": max(dates)
-            } if dates else None,
-            "categories": categories,
-            "merchants": merchants
+            "date_range": {"start": min(dates), "end": max(dates)} if dates else None,
+            "category_name": categories,
+            "merchant_name": merchants,
         }
-    
-    def filter_by_amount(self, min_amount: Optional[float] = None, 
-                        max_amount: Optional[float] = None) -> List[TransactionResult]:
+
+    def filter_by_amount(
+        self, min_amount: Optional[float] = None, max_amount: Optional[float] = None
+    ) -> List[TransactionResult]:
         """Filter results by amount range."""
         filtered = self.results
-        
+
         if min_amount is not None:
             filtered = [r for r in filtered if r.amount >= min_amount]
-        
+
         if max_amount is not None:
             filtered = [r for r in filtered if r.amount <= max_amount]
-        
+
         return filtered
-    
+
     def group_by_category(self) -> Dict[str, List[TransactionResult]]:
         """Group results by transaction category."""
         groups = {}
@@ -786,7 +634,7 @@ class SearchServiceResponse(BaseModel):
             if category not in groups:
                 groups[category] = []
             groups[category].append(result)
-        
+
         return groups
 
     model_config = {
@@ -799,7 +647,7 @@ class SearchServiceResponse(BaseModel):
                     "returned_results": 20,
                     "has_more_results": True,
                     "search_strategy_used": "semantic",
-                    "cache_hit": False
+                    "cache_hit": False,
                 },
                 "results": [
                     {
@@ -812,7 +660,7 @@ class SearchServiceResponse(BaseModel):
                         "category": "food",
                         "account_id": "acc_987654321",
                         "transaction_type": "debit",
-                        "relevance_score": 0.95
+                        "relevance_score": 0.95,
                     }
                 ],
                 "aggregations": [
@@ -823,18 +671,18 @@ class SearchServiceResponse(BaseModel):
                                 {
                                     "key": "food",
                                     "doc_count": 25,
-                                    "total_amount": -1250.75
+                                    "total_amount": -1250.75,
                                 }
                             ]
                         },
-                        "total_count": 25
+                        "total_count": 25,
                     }
                 ],
                 "success": True,
                 "suggestions": [
                     "Try broadening your date range for more results",
-                    "Consider searching for similar merchants like 'Monoprix'"
-                ]
+                    "Consider searching for similar merchants like 'Monoprix'",
+                ],
             }
         }
     }
@@ -842,69 +690,72 @@ class SearchServiceResponse(BaseModel):
 
 # Utility functions for contract validation and conversion
 
+
 def validate_search_query_contract(query_dict: Dict[str, Any]) -> SearchServiceQuery:
     """
     Validate and convert dictionary to SearchServiceQuery.
-    
+
     Args:
         query_dict: Dictionary representation of query
-        
+
     Returns:
         Validated SearchServiceQuery instance
-        
+
     Raises:
         ValidationError: If validation fails
     """
     return SearchServiceQuery(**query_dict)
 
 
-def validate_search_response_contract(response_dict: Dict[str, Any]) -> SearchServiceResponse:
+def validate_search_response_contract(
+    response_dict: Dict[str, Any],
+) -> SearchServiceResponse:
     """
     Validate and convert dictionary to SearchServiceResponse.
-    
+
     Args:
         response_dict: Dictionary representation of response
-        
+
     Returns:
         Validated SearchServiceResponse instance
-        
+
     Raises:
         ValidationError: If validation fails
     """
     return SearchServiceResponse(**response_dict)
 
 
-def create_minimal_query(conversation_id: str, user_id: int, intent_type: str) -> SearchServiceQuery:
+def create_minimal_query(
+    conversation_id: str, user_id: int, intent_type: str
+) -> SearchServiceQuery:
     """
     Create a minimal search query with default parameters.
-    
+
     Args:
         conversation_id: ID of the conversation
         user_id: ID of the user
         intent_type: Detected intent type
-        
+
     Returns:
         SearchServiceQuery with minimal configuration
     """
     return SearchServiceQuery(
         query_metadata=QueryMetadata(
-            conversation_id=conversation_id,
-            user_id=user_id,
-            intent_type=intent_type
+            conversation_id=conversation_id, user_id=user_id, intent_type=intent_type
         ),
         search_parameters=SearchParameters(),
-        filters=SearchFilters()
+        filters=SearchFilters(),
     )
 
 
 def create_error_response(query_id: str, error_message: str) -> SearchServiceResponse:
     """
     Create an error response for failed searches.
-    
+
     Args:
         query_id: ID of the original query
         error_message: Description of the error
-        
+
     Returns:
         SearchServiceResponse indicating failure
     """
@@ -915,9 +766,9 @@ def create_error_response(query_id: str, error_message: str) -> SearchServiceRes
             total_results=0,
             returned_results=0,
             has_more_results=False,
-            search_strategy_used="none"
+            search_strategy_used="none",
         ),
         results=[],
         success=False,
-        error_message=error_message
+        error_message=error_message,
     )


### PR DESCRIPTION
## Summary
- rename `categories` and `merchants` search filter fields to `category_name` and `merchant_name`
- propagate new filter names to `SearchQueryAgent` and `SearchServiceQuery`
- update summary stats and examples accordingly

## Testing
- `pytest tests/test_search_end_to_end.py::test_netflix_month_question_returns_transactions -q` *(skipped: search_service not available)*
- `python manual_netflix_search.py` *(simulated via inline script: Request dict with `merchant_name`, result returned `Netflix`)*

------
https://chatgpt.com/codex/tasks/task_e_689dba17badc8320a3097fd33a8f2fe1