### PR TITLE
Remove redundant user filter from search contract

### DIFF
--- a/conversation_service/agents/search_query_agent.py
+++ b/conversation_service/agents/search_query_agent.py
@@ -344,9 +344,6 @@ class SearchQueryAgent(BaseFinancialAgent):
         ]
         if merchants:
             search_filters["merchants"] = merchants
-
-        # Always filter by user_id for security and multi-tenant isolation
-        search_filters["user_id"] = user_id
         logger.debug("Calculated search filters: %s", search_filters)
 
         # Create query metadata

--- a/tests/test_query_builder.py
+++ b/tests/test_query_builder.py
@@ -1,0 +1,17 @@
+import pytest
+
+try:
+    from search_service.core.query_builder import QueryBuilder
+    from search_service.models.request import SearchRequest
+except Exception:  # pragma: no cover - skip if dependencies missing
+    QueryBuilder = None
+    SearchRequest = None
+
+
+@pytest.mark.skipif(QueryBuilder is None, reason="search_service not available")
+def test_query_builder_includes_user_id_filter():
+    builder = QueryBuilder()
+    request = SearchRequest(user_id=42, query="coffee")
+    query = builder.build_query(request)
+    assert {"term": {"user_id": 42}} in query["query"]["bool"]["must"]
+

--- a/tests/test_search_query_agent.py
+++ b/tests/test_search_query_agent.py
@@ -64,3 +64,5 @@ def test_generate_search_contract_deduplicates_terms():
     request = search_query.to_search_request()
     assert request["query"].split().count("carrefour") == 1
     assert request["filters"].get("merchants") == ["carrefour"]
+    assert "user_id" not in request["filters"]
+    assert request["user_id"] == 1


### PR DESCRIPTION
## Summary
- stop injecting `user_id` into search filters; QueryBuilder already enforces it
- add tests to confirm `user_id` stays outside filters and that QueryBuilder adds the term filter

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dba4b0dd48320b285b8dbe7ba43bb