### PR TITLE
Fix SearchServiceQuery example syntax

### DIFF
--- a/conversation_service/models/service_contracts.py
+++ b/conversation_service/models/service_contracts.py
@@ -359,14 +359,7 @@ class SearchServiceQuery(BaseModel):
                         "gte": "2024-01-01",
                         "lte": "2024-01-31"
                     },
-                    "category_name": ["food", "transport"],
-                    "date_range": {
-                        "start": "2024-01-01",
-                        "end": "2024-01-31"
-                    }
-                },
-
-                    "categories": ["food", "transport"]
+                    "category_name": ["food", "transport"]
                 }
             }
         }


### PR DESCRIPTION
## Summary
- remove stray `categories` block in SearchServiceQuery example
- simplify `filters` example to valid keys only

## Testing
- `python -m py_compile conversation_service/models/service_contracts.py`


------
https://chatgpt.com/codex/tasks/task_e_689dc520d8488320bbe49fa1ded56f83