### PR TITLE
refactor: remove obsolete range filters

### DIFF
--- a/conversation_service/models/service_contracts.py
+++ b/conversation_service/models/service_contracts.py
@@ -188,15 +188,6 @@ class SearchFilters(BaseModel):
         description="Amount filter with 'gte' and 'lte' keys"
     )
 
-    date_range: Optional[Dict[str, str]] = Field(
-        default=None, description="Date range filter with 'start' and 'end' keys"
-    )
-
-    amount_range: Optional[Dict[str, float]] = Field(
-        default=None, description="Amount range filter with 'min' and 'max' keys"
-
-    )
-
     category_name: Optional[List[str]] = Field(
         default=None,
         description="List of transaction categories to include",
@@ -359,18 +350,17 @@ class SearchServiceQuery(BaseModel):
                         "gte": "2024-01-01",
                         "lte": "2024-01-31"
                     },
-                    "category_name": ["food", "transport"],
-                    "date_range": {
-                        "start": "2024-01-01",
-                        "end": "2024-01-31"
-                    }
+                    "amount": {
+                        "gte": 100.0,
+                        "lte": 1000.0
+                    },
+                    "category_name": ["food", "transport"]
                 },
 
                     "categories": ["food", "transport"]
                 }
             }
         }
-    }
 
     def to_search_request(self) -> Dict[str, Any]:
         """Convert this query to the simplified SearchRequest schema."""
@@ -611,8 +601,6 @@ class SearchServiceResponse(BaseModel):
                 "date": None,
                 "categories": [],
                 "merchants": [],
-                "date_range": None,
-
                 "category_name": [],
                 "merchant_name": [],
         }
@@ -632,8 +620,6 @@ class SearchServiceResponse(BaseModel):
             } if dates else None,
             "categories": categories,
             "merchants": merchants,
-            "date_range": {"start": min(dates), "end": max(dates)} if dates else None,
-
             "category_name": categories,
             "merchant_name": merchants,
         }


### PR DESCRIPTION
## Summary
- remove `date_range` and `amount_range` from `SearchFilters`
- update documentation and examples to use `date` and `amount` dictionaries
- drop `date_range` from summary statistics

## Testing
- `python -m py_compile conversation_service/models/service_contracts.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dc524511c8320910e212ebf6a0523