### PR TITLE
Validate date and amount filter bounds

### DIFF
--- a/conversation_service/models/service_contracts.py
+++ b/conversation_service/models/service_contracts.py
@@ -251,11 +251,33 @@ class SearchFilters(BaseModel):
     @classmethod
     def validate_date(cls, v: Optional[Dict[str, str]]) -> Optional[Dict[str, str]]:
         """Validate date filter has proper gte/lte."""
+        if v is None:
+            return v
+        # Ensure both bounds are provided
+        if "gte" not in v or "lte" not in v:
+            raise ValueError("date filter must contain both 'gte' and 'lte'")
+
+        try:
+            gte = datetime.fromisoformat(v["gte"])
+            lte = datetime.fromisoformat(v["lte"])
+        except ValueError as exc:  # pragma: no cover - pydantic already validates format
+            raise ValueError("invalid date format") from exc
+
+        if gte > lte:
+            raise ValueError("'gte' must be less than or equal to 'lte'")
+        return v
 
     @field_validator("amount")
     @classmethod
     def validate_amount(cls, v: Optional[Dict[str, float]]) -> Optional[Dict[str, float]]:
         """Validate amount filter has proper gte/lte."""
+        if v is None:
+            return v
+        if "gte" not in v or "lte" not in v:
+            raise ValueError("amount filter must contain both 'gte' and 'lte'")
+        if v["gte"] > v["lte"]:
+            raise ValueError("'gte' must be less than or equal to 'lte'")
+        return v
 
     model_config = {
         "populate_by_name": True,
@@ -365,9 +387,7 @@ class SearchServiceQuery(BaseModel):
                         "end": "2024-01-31"
                     }
                 },
-
-                    "categories": ["food", "transport"]
-                }
+                "categories": ["food", "transport"]
             }
         }
     }

--- a/tests/conversation_service/test_service_contracts_filters.py
+++ b/tests/conversation_service/test_service_contracts_filters.py
@@ -1,0 +1,45 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "service_contracts", Path(__file__).resolve().parents[2] / "conversation_service/models/service_contracts.py"
+)
+service_contracts = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(service_contracts)
+SearchFilters = service_contracts.SearchFilters
+
+
+def test_date_filter_valid():
+    filters = SearchFilters(date={"gte": "2024-01-01", "lte": "2024-01-31"})
+    assert filters.date == {"gte": "2024-01-01", "lte": "2024-01-31"}
+
+
+def test_date_filter_missing_keys():
+    with pytest.raises(ValueError):
+        SearchFilters.validate_date({"gte": "2024-01-01"})
+    with pytest.raises(ValueError):
+        SearchFilters.validate_date({"lte": "2024-01-31"})
+
+
+def test_date_filter_inverted_range():
+    with pytest.raises(ValueError):
+        SearchFilters.validate_date({"gte": "2024-02-01", "lte": "2024-01-01"})
+
+
+def test_amount_filter_valid():
+    filters = SearchFilters(amount={"gte": 10.0, "lte": 100.0})
+    assert filters.amount == {"gte": 10.0, "lte": 100.0}
+
+
+def test_amount_filter_missing_keys():
+    with pytest.raises(ValueError):
+        SearchFilters.validate_amount({"gte": 10.0})
+    with pytest.raises(ValueError):
+        SearchFilters.validate_amount({"lte": 100.0})
+
+
+def test_amount_filter_inverted_range():
+    with pytest.raises(ValueError):
+        SearchFilters.validate_amount({"gte": 100.0, "lte": 10.0})


### PR DESCRIPTION
## Summary
- ensure date filters have `gte`/`lte` and gte <= lte
- ensure amount filters have `gte`/`lte` and gte <= lte
- add tests for valid, missing, and inverted filter ranges

## Testing
- `pytest tests/conversation_service/test_service_contracts_filters.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dc59d16b08320906c6025c2d5daf5