### PR TITLE
Fix SearchServiceQuery example structure

### DIFF
--- a/conversation_service/models/service_contracts.py
+++ b/conversation_service/models/service_contracts.py
@@ -370,24 +370,21 @@ class SearchServiceQuery(BaseModel):
                 "filters": {
                     "date": {
                         "gte": "2024-01-01",
-                        "lte": "2024-01-31"
+                        "lte": "2024-01-31",
                     },
                     "amount": {
                         "gte": 100.0,
-                        "lte": 1000.0
+                        "lte": 1000.0,
                     },
-                    "category_name": ["food", "transport"]
+                    "category_name": ["food", "transport"],
                 },
-                "categories": ["food", "transport"]
-
-
-                    "categories": ["food", "transport"]
-
-                    "category_name": ["food", "transport"]
-
-                }
+                "aggregations": {
+                    "group_by": ["category_name"],
+                    "metrics": ["sum"],
+                },
             }
         }
+    }
 
     def to_search_request(self) -> Dict[str, Any]:
         """Convert this query to the simplified SearchRequest schema."""


### PR DESCRIPTION
## Summary
- clean up SearchServiceQuery example payload by removing duplicate category fields
- provide valid example with aggregations and correct braces

## Testing
- `python -c "import conversation_service.models.service_contracts"`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dc881cafc8320bc76bfc50be5d293