### PR TITLE
Fix SearchServiceQuery example formatting

### DIFF
--- a/conversation_service/models/service_contracts.py
+++ b/conversation_service/models/service_contracts.py
@@ -377,8 +377,6 @@ class SearchServiceQuery(BaseModel):
                         "lte": 1000.0,
                     },
                     "category_name": ["food", "transport"]
-                }
-                    "category_name": ["food", "transport"],
                 },
                 "aggregations": {
                     "group_by": ["category_name"],


### PR DESCRIPTION
## Summary
- remove duplicate `category_name` entry in `SearchServiceQuery` example
- keep `aggregations` within example dict and tidy closing braces

## Testing
- `python -m py_compile conversation_service/models/service_contracts.py`


------
https://chatgpt.com/codex/tasks/task_e_689dccd9005083208870db6fd66afdfc