### PR TITLE
Fix duplicate category filter example

### DIFF
--- a/conversation_service/models/service_contracts.py
+++ b/conversation_service/models/service_contracts.py
@@ -368,16 +368,8 @@ class SearchServiceQuery(BaseModel):
                     "search_strategy": "semantic",
                 },
                 "filters": {
-                    "date": {
-                        "gte": "2024-01-01",
-                        "lte": "2024-01-31",
-                    },
-                    "amount": {
-                        "gte": 100.0,
-                        "lte": 1000.0,
-                    },
-                    "category_name": ["food", "transport"]
-
+                    "date": {"gte": "2024-01-01", "lte": "2024-01-31"},
+                    "amount": {"gte": 100.0, "lte": 1000.0},
                     "category_name": ["food", "transport"],
                 },
                 "aggregations": {


### PR DESCRIPTION
## Summary
- Deduplicate `category_name` filter example and restore trailing comma in `SearchServiceQuery`

## Testing
- `python local_app.py` (fails: No module named 'jose')

------
https://chatgpt.com/codex/tasks/task_e_689dd32388d483208d2560f5675a36ed