### PR TITLE
Allow MockIntentAgent to handle string entity types

### DIFF
--- a/conversation_service/agents/mock_intent_agent.py
+++ b/conversation_service/agents/mock_intent_agent.py
@@ -714,7 +714,9 @@ class MockIntentAgent(LLMIntentAgent):
             "confidence": intent_result.confidence,
             "entities": [
                 {
-                    "entity_type": e.entity_type.value,
+                    "entity_type": e.entity_type.value
+                    if isinstance(e.entity_type, EntityType)
+                    else e.entity_type,
                     "value": e.normalized_value,
                     "confidence": e.confidence,
                 }

--- a/tests/test_mock_intent_agent.py
+++ b/tests/test_mock_intent_agent.py
@@ -9,6 +9,7 @@ from conversation_service.agents.mock_intent_agent import (
     MockIntentAgent,
     MOCK_INTENT_RESPONSES,
 )
+from conversation_service.models.financial_models import IntentResult
 
 
 @pytest.mark.parametrize("question,expected", list(MOCK_INTENT_RESPONSES.items()))
@@ -30,3 +31,9 @@ def test_mock_intent_agent_returns_predefined_results(question, expected):
         if "position" in exp_entity:
             assert entity.start_position == exp_entity["position"][0]
             assert entity.end_position == exp_entity["position"][1]
+
+
+def test_detect_intent_returns_intent_result_for_known_question():
+    agent = MockIntentAgent()
+    result = asyncio.run(agent.detect_intent("Mes transactions Netflix ce mois", user_id=1))
+    assert isinstance(result["metadata"]["intent_result"], IntentResult)


### PR DESCRIPTION
## Summary
- Handle both `EntityType` enums and string entity types when building intent result payloads
- Add test ensuring `detect_intent` returns an `IntentResult` for known questions

## Testing
- `pytest tests/test_mock_intent_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689de0fc1d948320a3a66639656da597