### PR TITLE
Conditionally add merchant_name filter based on index data

### DIFF
--- a/conversation_service/agents/search_query_agent.py
+++ b/conversation_service/agents/search_query_agent.py
@@ -416,7 +416,12 @@ class SearchQueryAgent(BaseFinancialAgent):
         if merchants:
             search_filters["merchants"] = merchants
 
-            search_filters["merchant_name"] = merchants
+            has_index_merchant = any(
+                e.entity_type in {EntityType.MERCHANT, "MERCHANT"} and e.normalized_value
+                for e in (enhanced_entities or [])
+            )
+            if has_index_merchant:
+                search_filters["merchant_name"] = merchants
 
         # Always filter by user_id for security and multi-tenant isolation
         search_filters["user_id"] = user_id

--- a/tests/test_search_query_agent.py
+++ b/tests/test_search_query_agent.py
@@ -64,5 +64,6 @@ def test_generate_search_contract_deduplicates_terms():
     request = search_query.to_search_request()
     assert request["query"].split().count("carrefour") == 1
     assert request["filters"].get("merchants") == ["carrefour"]
+    assert "merchant_name" not in request["filters"]
     assert "user_id" not in request["filters"]
     assert request["user_id"] == 1


### PR DESCRIPTION
## Summary
- Only include `merchant_name` filter when search index provides a concrete merchant entity
- Expand tests to verify search behavior when transactions lack `merchant_name`
- Ensure search contract generation leaves `merchant_name` out of filters by default

## Testing
- `pytest tests/test_search_query_agent.py tests/test_search_end_to_end.py` *(search end-to-end tests skipped: search_service not available)*

------
https://chatgpt.com/codex/tasks/task_e_689de0feb74083208126c2a5a724d3f9