### PR TITLE
Use rule-based detection for mock intent agent

### DIFF
--- a/conversation_service/agents/mock_intent_agent.py
+++ b/conversation_service/agents/mock_intent_agent.py
@@ -694,7 +694,7 @@ class MockIntentAgent(LLMIntentAgent):
                     confidence=ent["confidence"],
                     start_position=start_pos,
                     end_position=end_pos,
-                    detection_method=DetectionMethod.LLM_BASED,
+                    detection_method=DetectionMethod.RULE_BASED,
                 )
             )
 
@@ -703,7 +703,7 @@ class MockIntentAgent(LLMIntentAgent):
             intent_category=IntentCategory(data["intent_category"]),
             confidence=data["confidence"],
             entities=entities,
-            method=DetectionMethod.LLM_BASED,
+            method=DetectionMethod.RULE_BASED,
             processing_time_ms=data.get("processing_time_ms", (time.perf_counter() - start) * 1000),
             requires_clarification=data.get("requires_clarification", False),
             suggested_actions=data.get("suggested_actions", []),
@@ -728,7 +728,7 @@ class MockIntentAgent(LLMIntentAgent):
             "content": json.dumps(result_payload),
             "metadata": {
                 "intent_result": intent_result,
-                "detection_method": DetectionMethod.LLM_BASED,
+                "detection_method": DetectionMethod.RULE_BASED,
                 "confidence": intent_result.confidence,
                 "intent_type": intent_result.intent_type,
                 "entities": [

--- a/tests/test_mock_intent_agent.py
+++ b/tests/test_mock_intent_agent.py
@@ -9,7 +9,7 @@ from conversation_service.agents.mock_intent_agent import (
     MockIntentAgent,
     MOCK_INTENT_RESPONSES,
 )
-from conversation_service.models.financial_models import IntentResult
+from conversation_service.models.financial_models import DetectionMethod, IntentResult
 
 
 @pytest.mark.parametrize("question,expected", list(MOCK_INTENT_RESPONSES.items()))
@@ -22,12 +22,14 @@ def test_mock_intent_agent_returns_predefined_results(question, expected):
     assert intent_result.intent_category.value == expected["intent_category"]
     assert abs(intent_result.confidence - expected["confidence"]) < 1e-6
     assert len(intent_result.entities) == len(expected["entities"])
+    assert intent_result.method == DetectionMethod.RULE_BASED
 
     for exp_entity, entity in zip(expected["entities"], intent_result.entities):
         assert entity.entity_type.value == exp_entity["entity_type"]
         assert entity.raw_value == exp_entity["raw_value"]
         assert entity.normalized_value == exp_entity["normalized_value"]
         assert abs(entity.confidence - exp_entity["confidence"]) < 1e-6
+        assert entity.detection_method == DetectionMethod.RULE_BASED
         if "position" in exp_entity:
             assert entity.start_position == exp_entity["position"][0]
             assert entity.end_position == exp_entity["position"][1]
@@ -36,4 +38,7 @@ def test_mock_intent_agent_returns_predefined_results(question, expected):
 def test_detect_intent_returns_intent_result_for_known_question():
     agent = MockIntentAgent()
     result = asyncio.run(agent.detect_intent("Mes transactions Netflix ce mois", user_id=1))
-    assert isinstance(result["metadata"]["intent_result"], IntentResult)
+    intent_result = result["metadata"]["intent_result"]
+    assert isinstance(intent_result, IntentResult)
+    assert intent_result.method == DetectionMethod.RULE_BASED
+    assert result["metadata"]["detection_method"] == DetectionMethod.RULE_BASED


### PR DESCRIPTION
## Summary
- mark mock intent agent results as rule-based instead of LLM-based
- verify mock agent returns rule-based detection method in tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dfbc39fe48320939cc410407b433d