### PR TITLE
Add safe lookup for intent_agent metrics

### DIFF
--- a/test_harena_chat_direct.py
+++ b/test_harena_chat_direct.py
@@ -51,11 +51,17 @@ def main() -> None:
     # ----- VÉRIFICATION DU MOCK ---------------------------------------------
     metrics_resp = session.get(f"{BASE_URL}/conversation/metrics")
     metrics_resp.raise_for_status()
-    intent_agent_type = metrics_resp.json()["agent_metrics"]["intent_agent"]["agent_type"]
-    if intent_agent_type == "MockIntentAgent":
-        print("✅ Ok si mock utilisé")
+    metrics_data = metrics_resp.json()
+    if "intent_agent" in metrics_data["agent_metrics"]["agent_performance"]:
+        intent_agent_type = metrics_data["agent_metrics"]["agent_performance"]["intent_agent"][
+            "agent_type"
+        ]
+        if intent_agent_type == "MockIntentAgent":
+            print("✅ Ok si mock utilisé")
+        else:
+            print(f"❌ Mock non utilisé (agent_type={intent_agent_type})")
     else:
-        print(f"❌ Mock non utilisé (agent_type={intent_agent_type})")
+        print("❌ Mock non utilisé (agent_type inconnu)")
 
     # ----- RECHERCHE EFFECTUÉE PAR L’AGENT ----------------------------------
     merchant = next(


### PR DESCRIPTION
## Summary
- read intent agent type from agent_performance
- guard metrics parsing when intent_agent is missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dffc01f20832099d3a51351bd07b1