### PR TITLE
Add search service field mapping and response normalization

### DIFF
--- a/conversation_service/agents/search_query_agent.py
+++ b/conversation_service/agents/search_query_agent.py
@@ -524,6 +524,20 @@ class SearchQueryAgent(BaseFinancialAgent):
 
             # Parse response
             response_data = response.json()
+
+            # Normalize field names from Search Service before model validation
+            for result in response_data.get("results", []):
+                if "currency_code" in result and "currency" not in result:
+                    result["currency"] = result.pop("currency_code")
+                if "primary_description" in result and "description" not in result:
+                    result["description"] = result.pop("primary_description")
+                if "merchant_name" in result and "merchant" not in result:
+                    result["merchant"] = result.pop("merchant_name")
+                if "category_name" in result and "category" not in result:
+                    result["category"] = result.pop("category_name")
+                if "account_id" in result and isinstance(result["account_id"], int):
+                    result["account_id"] = str(result["account_id"])
+
             search_response = SearchServiceResponse(**response_data)
 
             results_len = len(search_response.results or [])

--- a/conversation_service/models/service_contracts.py
+++ b/conversation_service/models/service_contracts.py
@@ -464,14 +464,29 @@ class TransactionResult(BaseModel):
     amount: float = Field(..., description="Transaction amount")
 
     currency: str = Field(
-        ..., description="Transaction currency", pattern=r"^[A-Z]{3}$"
+        ...,
+        description="Transaction currency",
+        pattern=r"^[A-Z]{3}$",
+        validation_alias="currency_code",
     )
 
-    description: str = Field(..., description="Transaction description")
+    description: str = Field(
+        ...,
+        description="Transaction description",
+        validation_alias="primary_description",
+    )
 
-    merchant: Optional[str] = Field(default=None, description="Merchant name")
+    merchant: Optional[str] = Field(
+        default=None,
+        description="Merchant name",
+        validation_alias="merchant_name",
+    )
 
-    category: Optional[str] = Field(default=None, description="Transaction category")
+    category: Optional[str] = Field(
+        default=None,
+        description="Transaction category",
+        validation_alias="category_name",
+    )
 
     account_id: str = Field(..., description="Account identifier")
 
@@ -499,7 +514,16 @@ class TransactionResult(BaseModel):
         default=None, description="Highlighted text matches"
     )
 
+    @field_validator("account_id", mode="before")
+    @classmethod
+    def convert_account_id(cls, v: Any) -> str:
+        """Ensure account_id is always stored as a string."""
+        if isinstance(v, int):
+            return str(v)
+        return v
+
     model_config = {
+        "populate_by_name": True,
         "json_schema_extra": {
             "example": {
                 "transaction_id": "txn_123456789",
@@ -519,7 +543,7 @@ class TransactionResult(BaseModel):
                     "merchant": ["<em>Carrefour</em>"],
                 },
             }
-        }
+        },
     }
 
 


### PR DESCRIPTION
## Summary
- map Search Service field names to TransactionResult model and normalize account IDs
- normalize search response fields in SearchQueryAgent before validation
- test SearchQueryAgent field conversion to ensure valid Search Service results are handled

## Testing
- `pytest tests/test_search_query_agent.py::test_execute_search_query_converts_fields -q`
- `pytest tests/test_search_query_agent.py::test_generate_search_contract_deduplicates_terms -q`


------
https://chatgpt.com/codex/tasks/task_e_689e0289fd48832095e1e0baf0c56da0