### PR TITLE
test: avoid merchant filter in direct search

### DIFF
--- a/test_harena_chat_direct.py
+++ b/test_harena_chat_direct.py
@@ -69,10 +69,14 @@ def main() -> None:
         None,
     )
 
+    # Le filtre ``merchant_name`` est volontairement omis lors de l'appel direct
+    # au Search Service. Certaines bases de données peuvent ne pas renseigner ce
+    # champ pour toutes les transactions, ce qui exclurait à tort des résultats
+    # pertinents si le filtre était appliqué. Le texte de recherche reste
+    # suffisant pour trouver les transactions correspondantes.
     search_payload = {
         "user_id": user_id,
         "query": merchant or QUESTION,
-        "filters": {"merchant_name": [merchant]} if merchant else {},
         "limit": 20,
         "offset": 0,
     }


### PR DESCRIPTION
## Summary
- omit merchant_name filter in direct Search Service call and document reasoning

## Testing
- `pytest -q test_harena_chat_direct.py`

------
https://chatgpt.com/codex/tasks/task_e_689e09557cec8320ab8e97c188322103