### PR TITLE
Fix ResponseAgent transaction source handling

### DIFF
--- a/conversation_service/agents/response_agent.py
+++ b/conversation_service/agents/response_agent.py
@@ -216,7 +216,10 @@ class ResponseAgent(BaseFinancialAgent):
             search_response_data = (
                 search_results_dict.get("metadata", {}).get("search_response", {})
             )
-            search_response = SearchServiceResponse(**search_response_data)
+            if isinstance(search_response_data, SearchServiceResponse):
+                search_response = search_response_data
+            else:
+                search_response = SearchServiceResponse(**search_response_data)
 
             # Format search results into readable text
             formatted_results = await self._format_search_results(search_response)
@@ -315,7 +318,7 @@ class ResponseAgent(BaseFinancialAgent):
         
         # Transaction list
         if search_response.results:
-            transactions = [result.source for result in search_response.results]
+            transactions = [result.to_source() for result in search_response.results]
             transaction_list = self.formatter.format_transaction_list(transactions)
             sections.append(f"\n**Détail des transactions:**\n{transaction_list}")
         

--- a/conversation_service/models/service_contracts.py
+++ b/conversation_service/models/service_contracts.py
@@ -522,6 +522,13 @@ class TransactionResult(BaseModel):
             return str(v)
         return v
 
+    def to_source(self) -> Dict[str, Any]:
+        """Return transaction data using alias names for display."""
+        dump = getattr(self, "model_dump", None)
+        if callable(dump):
+            return dump(by_alias=True)
+        return self.dict(by_alias=True)
+
     model_config = {
         "populate_by_name": True,
         "json_schema_extra": {

--- a/tests/test_response_agent.py
+++ b/tests/test_response_agent.py
@@ -1,0 +1,59 @@
+import asyncio
+import conversation_service.agents.base_financial_agent as base_financial_agent
+base_financial_agent.AUTOGEN_AVAILABLE = True
+
+from conversation_service.agents.response_agent import ResponseAgent
+from conversation_service.models.service_contracts import (
+    SearchServiceResponse,
+    ResponseMetadata,
+    TransactionResult,
+)
+
+
+class DummyDeepSeekClient:
+    api_key = "test-key"
+    base_url = "http://api.example.com"
+
+    async def generate_response(self, messages, temperature, max_tokens, user, use_cache):
+        class Raw:
+            usage = type("Usage", (), {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2})()
+        return type("Resp", (), {"content": "Réponse test", "raw": Raw()})()
+
+
+def test_response_agent_handles_full_search_results():
+    agent = ResponseAgent(deepseek_client=DummyDeepSeekClient())
+
+    search_response = SearchServiceResponse(
+        response_metadata=ResponseMetadata(
+            query_id="q1",
+            processing_time_ms=1.0,
+            total_results=1,
+            returned_results=1,
+            has_more_results=False,
+            search_strategy_used="semantic",
+        ),
+        results=[
+            TransactionResult(
+                transaction_id="t1",
+                date="2024-01-01T00:00:00Z",
+                amount=20.5,
+                currency="EUR",
+                description="Coffee shop",
+                merchant="Starbucks",
+                category="Food",
+                account_id="acc1",
+                transaction_type="debit",
+            )
+        ],
+        success=True,
+    )
+
+    search_results = {"metadata": {"search_response": search_response}}
+
+    result = asyncio.run(
+        agent.generate_response("Quels sont mes derniers achats ?", search_results, user_id=1)
+    )
+
+    assert "content" in result
+    assert result["metadata"]["search_stats"]["total_results"] == 1
+


### PR DESCRIPTION
## Summary
- Ensure ResponseAgent works with SearchServiceResponse objects directly and uses TransactionResult.to_source for formatting
- Provide helper `to_source` on TransactionResult to expose aliased fields
- Add regression test for ResponseAgent handling of search results

## Testing
- `pytest tests/test_response_agent.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e0957ab5083209e556d6f3b060bfc