### PR TITLE
feat: include current date in response prompts

### DIFF
--- a/conversation_service/agents/response_agent.py
+++ b/conversation_service/agents/response_agent.py
@@ -405,16 +405,25 @@ class ResponseAgent(BaseFinancialAgent):
             )
             return DeepSeekResponse(content=fallback, raw=None)
     
-    def _build_response_prompt(self, user_message: str, formatted_results: str, 
+    def _build_response_prompt(self, user_message: str, formatted_results: str,
                               conversation_context: str) -> str:
         """Build the complete prompt for response generation."""
-        return f"""Question utilisateur: "{user_message}"
+        current_date = datetime.utcnow().strftime("%d/%m/%Y")
+        no_results_instruction = ""
+        if "Aucun résultat" in formatted_results:
+            no_results_instruction = "Aucune transaction trouvée pour le mois en cours."
+
+        return f"""Nous sommes le {current_date}.
+
+Question utilisateur: "{user_message}"
 
 Résultats de recherche:
 {formatted_results}
 
 Contexte conversationnel:
 {conversation_context}
+
+{no_results_instruction}
 
 Génère une réponse naturelle et utile qui:
 1. Répond directement à la question

--- a/conversation_service/prompts/response_prompts.py
+++ b/conversation_service/prompts/response_prompts.py
@@ -52,6 +52,8 @@ MÉTADONNÉES DE LA RECHERCHE :
 - Temps d'exécution : {execution_time}ms
 - Type de requête : {query_type}
 
+DATE ACTUELLE : {current_date}
+
 {context_section}
 
 OBJECTIF : Créer une réponse qui répond précisément à la question de l'utilisateur, en utilisant les données trouvées de manière claire et actionnable.
@@ -92,7 +94,8 @@ def format_response_prompt(
     user_message: str,
     search_results: Dict[str, Any],
     context: str = "",
-    user_profile: Optional[Dict[str, Any]] = None
+    user_profile: Optional[Dict[str, Any]] = None,
+    current_date: Optional[str] = None,
 ) -> str:
     """Formate le prompt complet pour la génération de réponse finale."""
     if not user_message or not user_message.strip():
@@ -118,6 +121,7 @@ def format_response_prompt(
         total_results=total_results,
         execution_time=processing_time,
         query_type=query_type,
+        current_date=current_date or "",
         context_section=context_section
     )
 

--- a/tests/test_response_agent.py
+++ b/tests/test_response_agent.py
@@ -2,6 +2,8 @@ import asyncio
 import conversation_service.agents.base_financial_agent as base_financial_agent
 base_financial_agent.AUTOGEN_AVAILABLE = True
 
+from datetime import datetime
+
 from conversation_service.agents.response_agent import ResponseAgent
 from conversation_service.models.service_contracts import (
     SearchServiceResponse,
@@ -17,7 +19,8 @@ class DummyDeepSeekClient:
     async def generate_response(self, messages, temperature, max_tokens, user, use_cache):
         class Raw:
             usage = type("Usage", (), {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2})()
-        return type("Resp", (), {"content": "Réponse test", "raw": Raw()})()
+        # Echo the user's prompt to make assertions on the built prompt
+        return type("Resp", (), {"content": messages[-1]["content"], "raw": Raw()})()
 
 
 def test_response_agent_handles_full_search_results():
@@ -56,4 +59,32 @@ def test_response_agent_handles_full_search_results():
 
     assert "content" in result
     assert result["metadata"]["search_stats"]["total_results"] == 1
+
+
+def test_response_agent_handles_no_transactions_current_month():
+    agent = ResponseAgent(deepseek_client=DummyDeepSeekClient())
+
+    search_response = SearchServiceResponse(
+        response_metadata=ResponseMetadata(
+            query_id="q2",
+            processing_time_ms=1.0,
+            total_results=0,
+            returned_results=0,
+            has_more_results=False,
+            search_strategy_used="semantic",
+        ),
+        results=[],
+        success=True,
+    )
+
+    search_results = {"metadata": {"search_response": search_response}}
+
+    result = asyncio.run(
+        agent.generate_response("Mes transactions ce mois-ci ?", search_results, user_id=1)
+    )
+
+    today = datetime.utcnow().strftime("%d/%m/%Y")
+    assert "Aucune transaction" in result["content"]
+    assert "mois en cours" in result["content"]
+    assert today in result["content"]
 


### PR DESCRIPTION
## Summary
- add `{current_date}` placeholder to response generation template and allow passing it through `format_response_prompt`
- ensure `ResponseAgent` inserts today's date and flags no current-month transactions
- cover empty current-month transactions with a unit test

## Testing
- `pytest tests/test_response_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689e284dae448320804c012bf0f13e8b