### PR TITLE
feat: make intent model configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ Chaque fichier de test peut également être lancé directement :
 python test_metrics_endpoint.py
 ```
 
+## Test du détecteur d'intentions avec un modèle personnalisé
+
+Le script `test_model.py` utilise par défaut le modèle
+`microsoft/Phi-3.5-mini-instruct`. Pour essayer d'autres poids (locaux ou sur
+HuggingFace), passez le nom du modèle en argument ou via la variable
+d'environnement `MODEL_NAME` :
+
+```bash
+python test_model.py --model-name my-org/mon-modele
+# ou
+MODEL_NAME=/chemin/vers/mon-modele python test_model.py
+```
+
+
 ## Service startup
 
 The conversation service now performs a full agent health check during


### PR DESCRIPTION
## Summary
- allow `ImprovedIntentDetector` to load any model via `model_name` arg or `MODEL_NAME` env var
- expose `--model-name` CLI flag in `test_model.py`
- document custom model usage in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a018f3fee88320bb1600c2675b3b56