### PR TITLE
feat: add cli flags for intent detector

### DIFF
--- a/test_model.py
+++ b/test_model.py
@@ -11,6 +11,7 @@ import os
 from datetime import datetime
 from typing import Dict, List, Any, Optional, Tuple
 from enum import Enum
+import argparse
 import warnings
 warnings.filterwarnings("ignore")
 
@@ -436,27 +437,21 @@ Query: "{}"
 
 # ==================== FONCTION PRINCIPALE ====================
 
-def main():
+def main(use_model: bool = False, debug: bool = False):
     """Test amélioré avec meilleure gestion d'erreurs"""
-    
+
     print("=" * 80)
     print("🧪 TEST AMÉLIORÉ - DÉTECTION D'INTENTION PHI-3.5")
     print("=" * 80)
     print(f"📅 Date : {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
     print("=" * 80)
     print()
-    
-    print("🔧 OPTIONS DE TEST:")
-    print("1. Mock uniquement (rapide)")
-    print("2. Mock + Modèle (nécessite 4-6GB RAM)")
-    print("3. Mock + Modèle avec DEBUG")
-    print()
-    
-    choice = input("Votre choix (1, 2 ou 3) : ").strip()
-    use_model = choice in ["2", "3"]
-    debug = choice == "3"
-    
-    print()
+
+    mode_desc = "Mock + Modèle" if use_model else "Mock uniquement"
+    if debug:
+        mode_desc += " (DEBUG)"
+    print(f"Mode : {mode_desc}\n")
+
     detector = ImprovedIntentDetector(use_model=use_model, debug=debug)
     
     # Questions de test sélectionnées
@@ -513,8 +508,13 @@ def main():
     print("\n✅ Test terminé!")
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Test de détection d'intention")
+    parser.add_argument("--use-model", action="store_true", help="Activer le modèle")
+    parser.add_argument("--debug", action="store_true", help="Activer le mode débogage")
+    args = parser.parse_args()
+
     try:
-        main()
+        main(use_model=args.use_model, debug=args.debug)
     except KeyboardInterrupt:
         print("\n\n⚠️ Test interrompu")
     except Exception as e:


### PR DESCRIPTION
## Summary
- remove interactive menu from intent detector demo
- add `--use-model` and `--debug` CLI flags with argparse
- run evaluation directly based on provided flags

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a018feeeac8320a4a40913949ac810