### PR TITLE
Refactor evaluation loop and add accuracy metrics

### DIFF
--- a/test_model.py
+++ b/test_model.py
@@ -431,8 +431,80 @@ Query: "{}"
             model_result = self.detect_with_model(query)
         else:
             model_result = None
-        
+
         return mock_result, model_result
+
+# ==================== ÉVALUATION ====================
+
+def evaluate(detector, dataset):
+    """Exécute la boucle de test et retourne les prédictions et succès."""
+
+    test_questions = list(dataset.keys())
+    print(f"\n🚀 TEST DE {len(test_questions)} QUESTIONS\n")
+
+    successes = 0
+    latencies = []
+    predictions = {}
+
+    for i, query in enumerate(test_questions, 1):
+        print(f"\n[{i}/{len(test_questions)}] 💬 {query}")
+        print("-" * 60)
+
+        mock_result, model_result = detector.detect(query)
+
+        expected_intent = mock_result.intent_type
+        print(f"📌 Attendu : {expected_intent} ({mock_result.confidence:.2f})")
+
+        if model_result:
+            predicted_intent = model_result.intent_type
+            predictions[query] = predicted_intent
+            print(f"🤖 Modèle  : {predicted_intent} ({model_result.confidence:.2f})")
+            print(f"⏱️ Latence : {model_result.processing_time_ms:.1f}ms")
+
+            if predicted_intent == expected_intent:
+                print("✅ Match!")
+                successes += 1
+            else:
+                print("❌ Différent")
+
+            latencies.append(model_result.processing_time_ms)
+        else:
+            predictions[query] = None
+            print("⚠️ Mode mock uniquement")
+
+    total = len(test_questions)
+    print("\n" + "=" * 80)
+    print("📊 RÉSUMÉ")
+    print("=" * 80)
+
+    if latencies:
+        print(f"\n🎯 PRÉCISION:")
+        print(f"   Succès : {successes}/{total} ({(successes/total)*100:.1f}%)")
+        print(f"   Échecs : {total - successes}/{total}")
+
+        print(f"\n⏱️ PERFORMANCE:")
+        print(f"   Latence moyenne : {sum(latencies)/len(latencies):.1f}ms")
+        print(f"   Latence min : {min(latencies):.1f}ms")
+        print(f"   Latence max : {max(latencies):.1f}ms")
+
+    print("\n✅ Test terminé!")
+    return predictions, successes
+
+
+def compute_accuracy(predictions, expected):
+    """Calcule précision, rappel et F1."""
+
+    total = len(expected)
+    true_positive = sum(
+        1 for q, p in predictions.items()
+        if q in expected and p == expected[q]["intent_type"]
+    )
+
+    precision = true_positive / len(predictions) if predictions else 0.0
+    recall = true_positive / total if total else 0.0
+    f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
+
+    return {"precision": precision, "recall": recall, "f1": f1}
 
 # ==================== FONCTION PRINCIPALE ====================
 
@@ -458,66 +530,24 @@ def main():
     
     print()
     detector = ImprovedIntentDetector(use_model=use_model, debug=debug)
-    
-    # Questions de test sélectionnées
-    test_questions = list(MOCK_INTENT_RESPONSES.keys())
-    
-    print(f"\n🚀 TEST DE {len(test_questions)} QUESTIONS\n")
-    
-    successes = 0
-    failures = 0
-    latencies = []
-    
-    for i, query in enumerate(test_questions, 1):
-        print(f"\n[{i}/{len(test_questions)}] 💬 {query}")
-        print("-" * 60)
-        
-        mock_result, model_result = detector.detect(query)
-        
-        # Afficher résultat attendu
-        print(f"📌 Attendu : {mock_result.intent_type} ({mock_result.confidence:.2f})")
-        
-        if model_result:
-            # Afficher résultat modèle
-            print(f"🤖 Modèle  : {model_result.intent_type} ({model_result.confidence:.2f})")
-            print(f"⏱️ Latence : {model_result.processing_time_ms:.1f}ms")
-            
-            # Vérifier match
-            if mock_result.intent_type == model_result.intent_type:
-                print("✅ Match!")
-                successes += 1
-            else:
-                print("❌ Différent")
-                failures += 1
-            
-            latencies.append(model_result.processing_time_ms)
-        else:
-            print("⚠️ Mode mock uniquement")
-    
-    # Résumé
-    print("\n" + "=" * 80)
-    print("📊 RÉSUMÉ")
-    print("=" * 80)
-    
-    if latencies:
-        total = successes + failures
-        print(f"\n🎯 PRÉCISION:")
-        print(f"   Succès : {successes}/{total} ({(successes/total)*100:.1f}%)")
-        print(f"   Échecs : {failures}/{total}")
-        
-        print(f"\n⏱️ PERFORMANCE:")
-        print(f"   Latence moyenne : {sum(latencies)/len(latencies):.1f}ms")
-        print(f"   Latence min : {min(latencies):.1f}ms") 
-        print(f"   Latence max : {max(latencies):.1f}ms")
-    
-    print("\n✅ Test terminé!")
+
+    predictions, successes = evaluate(detector, MOCK_INTENT_RESPONSES)
+    metrics = compute_accuracy(predictions, MOCK_INTENT_RESPONSES)
+
+    print(f"\nScore global (F1) : {metrics['f1']:.2f}")
+
+    threshold = 0.8
+    return 0 if metrics['f1'] >= threshold else 1
+
 
 if __name__ == "__main__":
     try:
-        main()
+        sys.exit(main())
     except KeyboardInterrupt:
         print("\n\n⚠️ Test interrompu")
+        sys.exit(1)
     except Exception as e:
         print(f"\n❌ Erreur : {e}")
         import traceback
         traceback.print_exc()
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- Extract evaluation loop to `evaluate` helper returning predictions and success count
- Introduce `compute_accuracy` to calculate precision, recall and F1
- Update `main` to print global score and exit based on F1 threshold

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a019034778832091de540a21b998e7