### PR TITLE
Reuse intent validator instance

### DIFF
--- a/intent_benchmark.py
+++ b/intent_benchmark.py
@@ -1,0 +1,33 @@
+"""Intent benchmark utilities.
+
+Provides schema validation for intent detection benchmark results.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from jsonschema import Draft7Validator
+
+# JSON schema describing the expected structure of an intent result
+INTENT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "intent": {"type": "string"},
+        "confidence": {"type": "number"},
+        "entities": {"type": "array"},
+    },
+    "required": ["intent", "confidence"],
+}
+
+# Reuse a single validator instance rather than recreating it for each call
+INTENT_VALIDATOR = Draft7Validator(INTENT_SCHEMA)
+
+def validate_intent_result(obj: Any) -> None:
+    """Validate an intent result object against ``INTENT_SCHEMA``.
+
+    Parameters
+    ----------
+    obj:
+        The object to validate.
+    """
+    INTENT_VALIDATOR.validate(obj)


### PR DESCRIPTION
## Summary
- reuse a single Draft7Validator instance for intent benchmark validation
- validate intent results with the shared validator

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0d706975083209ed4d86b01bf49bf