### PR TITLE
Handle LLM parsing failures

### DIFF
--- a/run_benchmark.py
+++ b/run_benchmark.py
@@ -1,0 +1,22 @@
+import asyncio
+from typing import Iterable
+
+from conversation_service.agents.llm_intent_agent import (
+    LLMIntentAgent,
+    LLMOutputParsingError,
+)
+
+
+def run_benchmark(agent: LLMIntentAgent, samples: Iterable[str]) -> None:
+    """Simple benchmark runner for the intent agent.
+
+    Any :class:`LLMOutputParsingError` raised by the agent is caught and
+    displayed to make debugging easier during benchmarking.
+    """
+    for text in samples:
+        try:
+            asyncio.run(agent.detect_intent(text, user_id=1))
+        except LLMOutputParsingError as err:
+            print(f"Parsing error: {err}")
+        except Exception as err:  # pragma: no cover - benchmark helper
+            print(f"Unexpected error: {err}")


### PR DESCRIPTION
## Summary
- add explicit `LLMOutputParsingError` when the LLM response cannot be parsed
- use fallback parsing of `output_text` when `output_parsed` is missing
- expose parsing errors in the simple benchmark helper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0d70b331c8320bf1ed81f88901f53