### PR TITLE
docs: add intent benchmark instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ python test_model.py --use-model --debug
 ```
 
 
+Pour un benchmark d'intention, consultez [README_intent_benchmark.md](README_intent_benchmark.md).
+
 ## Service startup
 
 The conversation service now performs a full agent health check during

--- a/README_intent_benchmark.md
+++ b/README_intent_benchmark.md
@@ -1,0 +1,24 @@
+# Intent Benchmark
+
+Ce document explique comment exécuter le script `intent_benchmark.py`.
+
+## Dépendances
+
+- `openai`
+- `python-dotenv`
+- `jsonschema`
+
+## Variable d'environnement
+
+Avant d'exécuter le script, définissez la variable d'environnement `OPENAI_API_KEY` avec votre clé API OpenAI.
+
+## Utilisation
+
+Installez les dépendances puis lancez :
+
+```bash
+python intent_benchmark.py --model <nom_du_modèle>
+```
+
+Remplacez `<nom_du_modèle>` par le modèle OpenAI ou local souhaité.
+


### PR DESCRIPTION
## Summary
- add README for intent benchmark usage and dependencies
- reference intent benchmark docs from main README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0d70fd3848320aa994ee656562b2c