### PR TITLE
feat: enforce openai version in quick intent test

### DIFF
--- a/quick_intent_test.py
+++ b/quick_intent_test.py
@@ -23,9 +23,18 @@ import argparse
 import statistics as stats
 from collections import Counter
 
+import openai
+from packaging import version
 from dotenv import load_dotenv
 from jsonschema import Draft7Validator, ValidationError
 from openai import OpenAI
+
+REQUIRED_OPENAI = "1.1.0"
+if version.parse(openai.__version__) < version.parse(REQUIRED_OPENAI):
+    raise RuntimeError(
+        f"openai>={REQUIRED_OPENAI} required, but {openai.__version__} is installed. "
+        "Please update the openai package."
+    )
 
 # -----------------------------
 # 1) JSON Schema & validateur précompilé


### PR DESCRIPTION
## Summary
- import openai and packaging.version
- require minimum openai version and raise error when outdated

## Testing
- `python -m py_compile harena/quick_intent_test.py`
- `python harena/quick_intent_test.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68a15e91e214832085516c9cfd90c8f3