### PR TITLE
Refine normalized_value schema for date ranges

### DIFF
--- a/quick_intent_test.py
+++ b/quick_intent_test.py
@@ -227,7 +227,15 @@ Exemples:
                                     "anyOf": [
                                         {"type": "string"},
                                         {"type": "number"},
-                                        {"type": "object"},
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "start_date": {"type": "string"},
+                                                "end_date": {"type": "string"}
+                                            },
+                                            "required": ["start_date", "end_date"],
+                                            "additionalProperties": False
+                                        },
                                         {"type": "array"},
                                         {"type": "boolean"},
                                         {"type": "null"}


### PR DESCRIPTION
## Summary
- Specify explicit object schema for `normalized_value` to represent date ranges with start and end dates

## Testing
- `pytest -q`
- `python quick_intent_test.py` *(fails: OPENAI_API_KEY non trouvée)*

------
https://chatgpt.com/codex/tasks/task_e_68a1642fc2d883208ef01a038d79b1d8