### PR TITLE
Enforce strict additionalProperties in intent schema

### DIFF
--- a/quick_intent_test.py
+++ b/quick_intent_test.py
@@ -227,7 +227,7 @@ Exemples:
                                     "anyOf": [
                                         {"type": "string"},
                                         {"type": "number"},
-                                        {"type": "object"},
+                                        {"type": "object", "additionalProperties": False},
                                         {"type": "array"},
                                         {"type": "boolean"},
                                         {"type": "null"}
@@ -274,14 +274,19 @@ Exemples:
                                 "intent_type": {"type": "string"},
                                 "confidence": {"type": "number"}
                             },
-                            "required": ["intent_type", "confidence"]
+                            "required": ["intent_type", "confidence"],
+                            "additionalProperties": False
                         }
                     },
                     "validation_errors": {
                         "type": ["array", "null"],
                         "items": {"type": "string"}
                     },
-                    "context_influence": {"type": ["object", "null"]}
+                    "context_influence": {
+                        "type": ["object", "null"],
+                        "properties": {},
+                        "additionalProperties": False
+                    }
                 },
                 "required": [
                     "intent_type", "intent_category", "confidence", "entities",


### PR DESCRIPTION
## Summary
- Disallow unspecified fields in alternative intents and context influence within the intent schema
- Tighten entity normalized_value object to forbid extra keys

## Testing
- `python quick_intent_test.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a16433f0208320a20b73f948b644cf