### PR TITLE
Specify schema for normalized_value arrays

### DIFF
--- a/quick_intent_test.py
+++ b/quick_intent_test.py
@@ -238,7 +238,18 @@ Exemples:
                                             "required": ["start_date", "end_date"],
                                             "additionalProperties": False
                                         },
-                                        {"type": "array"},
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "anyOf": [
+                                                    {"type": "string"},
+                                                    {"type": "number"},
+                                                    {"type": "boolean"},
+                                                    {"type": "object", "properties": {}, "additionalProperties": False},
+                                                    {"type": "null"}
+                                                ]
+                                            }
+                                        },
                                         {"type": "boolean"},
                                         {"type": "null"}
                                     ]


### PR DESCRIPTION
## Summary
- refine JSON schema for `normalized_value` arrays in `quick_intent_test.py`

## Testing
- `python quick_intent_test.py` *(fails: OPENAI_API_KEY non trouvée)*

------
https://chatgpt.com/codex/tasks/task_e_68a1677a4c308320993fc499b67f1153