### PR TITLE
Remove strict requirement from intent JSON schema

### DIFF
--- a/quick_intent_test.py
+++ b/quick_intent_test.py
@@ -194,7 +194,6 @@ Exemples:
         """
         return {
             "name": "intent_result",
-            "strict": True,  # Force le respect strict du schéma
             "schema": {
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
## Summary
- drop `strict` from `_get_json_schema` so optional fields no longer need placeholder values
- retain `additionalProperties: False` to reject unexpected keys

## Testing
- `OPENAI_API_KEY=dummy python quick_intent_test.py` *(fails: connection error)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a16b797d288320bc8dde5f25c3c977