### PR TITLE
Align system prompt intent categories

### DIFF
--- a/quick_intent_test.py
+++ b/quick_intent_test.py
@@ -164,9 +164,9 @@ INTENTIONS PRINCIPALES:
 - TRANSACTION_SEARCH: Recherche de transactions (par montant, date, marchand, catégorie)
 - SPENDING_ANALYSIS: Analyse des dépenses (totaux, tendances, comparaisons)
 - ACCOUNT_BALANCE: Consultation de solde (compte courant, épargne)
-- BUDGET_TRACKING: Suivi de budget (par catégorie, alertes)
+- BUDGET_MANAGEMENT: Suivi de budget (par catégorie, alertes)
 - GOAL_TRACKING: Suivi d'objectifs (épargne, dépenses)
-- CONVERSATIONAL: Interactions conversationnelles
+- GREETING: Interactions conversationnelles
 
 ENTITÉS À EXTRAIRE:
 - AMOUNT: Montants (50€, mille euros) → normaliser en float


### PR DESCRIPTION
## Summary
- Replace outdated BUDGET_TRACKING and CONVERSATIONAL categories with BUDGET_MANAGEMENT and GREETING in quick_intent_test system prompt

## Testing
- `OPENAI_API_KEY=sk-test python quick_intent_test.py` *(fails: Connection error)*

------
https://chatgpt.com/codex/tasks/task_e_68a16e3805a8832081850999c2189155