### PR TITLE
fix: remove duplicate IntentCategory member

### DIFF
--- a/quick_intent_test.py
+++ b/quick_intent_test.py
@@ -39,7 +39,6 @@ class IntentCategory(str, Enum):
     UNCLEAR_INTENT = "UNCLEAR_INTENT"
     UNKNOWN = "UNKNOWN"
     FILTER_REQUEST = "FILTER_REQUEST"
-    UNCLEAR_INTENT = "UNCLEAR_INTENT"
 
 class EntityType(str, Enum):
     """Types d'entités financières."""


### PR DESCRIPTION
## Summary
- remove duplicate `UNCLEAR_INTENT` enum value from `IntentCategory`

## Testing
- `python quick_intent_test.py` *(fails: OPENAI_API_KEY not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a193a207888320b247095de805e8f5