### PR TITLE
docs: document SEARCH_BY_TEXT intent

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ free-form text. The allowed intent values are:
 `TRANSACTION_SEARCH`, `SPENDING_ANALYSIS`, `BALANCE_INQUIRY`,
 `GENERAL_QUESTION`, `GREETING`, `OUT_OF_SCOPE`.
 
+The following table maps key intents to their categories and suggested actions:
+
+| Intent | Category | Suggested actions |
+| ------ | -------- | ----------------- |
+| SEARCH_BY_MERCHANT | FINANCIAL_QUERY | `["search_by_merchant","list_transactions"]` |
+| SEARCH_BY_TEXT | FINANCIAL_QUERY | `["search_by_text","list_transactions"]` |
+
 Entity types must be one of the values from `EntityType` in
 `conversation_service/models/financial_models.py`.
 

--- a/tests/test_llm_intent_agent.py
+++ b/tests/test_llm_intent_agent.py
@@ -31,3 +31,21 @@ def test_llm_intent_agent_parses_output_correctly():
         e for e in intent_result.entities if e.entity_type == EntityType.MERCHANT
     )
     assert merchant.normalized_value == "Netflix"
+
+
+class DummyDeepSeekClientSearchByText:
+    api_key = "test-key"
+    base_url = "http://api.example.com"
+
+    async def generate_response(self, messages, temperature, max_tokens, user, use_cache):
+        class Response:
+            content = '{"intent": "SEARCH_BY_TEXT", "entities": []}'
+
+        return Response()
+
+
+def test_llm_intent_agent_parses_search_by_text():
+    agent = LLMIntentAgent(deepseek_client=DummyDeepSeekClientSearchByText())
+    result = asyncio.run(agent.detect_intent("Recherche textuelle", user_id=1))
+    intent_result = result["metadata"]["intent_result"]
+    assert intent_result.intent_type == "SEARCH_BY_TEXT"


### PR DESCRIPTION
## Summary
- document intent mapping and include SEARCH_BY_TEXT with its category and actions
- add unit test verifying LLMIntentAgent handles SEARCH_BY_TEXT intents

## Testing
- `pytest tests/test_llm_intent_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1a35579888320a67823946886b04b