### PR TITLE
feat: add operation type search intent

### DIFF
--- a/conversation_service/agents/llm_intent_agent.py
+++ b/conversation_service/agents/llm_intent_agent.py
@@ -263,7 +263,9 @@ class LLMIntentAgent(BaseFinancialAgent):
                 )
             )
 
-        if intent_type in {
+        if intent_type == "SEARCH_BY_OPERATION_TYPE":
+            category = IntentCategory.FINANCIAL_QUERY
+        elif intent_type in {
             "SEARCH_BY_MERCHANT",
             "SEARCH_BY_CATEGORY",
             "SEARCH_BY_TEXT",

--- a/conversation_service/agents/mock_intent_agent.py
+++ b/conversation_service/agents/mock_intent_agent.py
@@ -126,6 +126,25 @@ MOCK_INTENT_RESPONSES: Dict[str, Dict[str, Any]] = {
         "suggested_actions": ["filter_by_amount_greater"],
     },
 
+    "Opérations carte": {
+        "intent_type": "SEARCH_BY_OPERATION_TYPE",
+        "intent_category": "FINANCIAL_QUERY",
+        "confidence": 0.93,
+        "entities": [
+            {
+                "entity_type": "OPERATION_TYPE",
+                "raw_value": "carte",
+                "normalized_value": "card",
+                "confidence": 0.96,
+                "position": [11, 16],
+            }
+        ],
+        "method": "llm_detection",
+        "processing_time_ms": 130.0,
+        "requires_clarification": False,
+        "suggested_actions": ["filter_by_operation_type", "list_transactions"],
+    },
+
     # SPENDING_ANALYSIS
     "Mes dépenses restaurant cette semaine": {
         "intent_type": "SPENDING_ANALYSIS",

--- a/conversation_service/agents/search_query_agent.py
+++ b/conversation_service/agents/search_query_agent.py
@@ -435,6 +435,14 @@ class SearchQueryAgent(BaseFinancialAgent):
         if categories:
             search_filters["category_name"] = categories
 
+        operation_types = [
+            str(e.normalized_value)
+            for e in all_entities
+            if e.entity_type in {EntityType.OPERATION_TYPE, "OPERATION_TYPE"} and e.normalized_value
+        ]
+        if operation_types:
+            search_filters["operation_type"] = operation_types[0]
+
         # Merchant name filtering is intentionally avoided. Some databases may
         # store transactions with an empty ``merchant_name`` field. Adding a
         # ``merchant_name`` filter would exclude those records, even though the

--- a/conversation_service/models/financial_models.py
+++ b/conversation_service/models/financial_models.py
@@ -48,6 +48,7 @@ class EntityType(str, Enum):
     
     # Transaction entities
     TRANSACTION_TYPE = "TRANSACTION_TYPE"
+    OPERATION_TYPE = "OPERATION_TYPE"
     MERCHANT = "MERCHANT"
     CATEGORY = "CATEGORY"
     DESCRIPTION = "DESCRIPTION"
@@ -234,7 +235,8 @@ class FinancialEntity(BaseModel):
             EntityType.DATE_RANGE: {"field": "date", "value": self.normalized_value},
             EntityType.CATEGORY: {"field": "category", "value": self.normalized_value},
             EntityType.MERCHANT: {"field": "merchant", "value": self.normalized_value},
-            EntityType.TRANSACTION_TYPE: {"field": "transaction_type", "value": self.normalized_value}
+            EntityType.TRANSACTION_TYPE: {"field": "transaction_type", "value": self.normalized_value},
+            EntityType.OPERATION_TYPE: {"field": "operation_type", "value": self.normalized_value}
         }
         
         return filter_map.get(self.entity_type)

--- a/conversation_service/models/service_contracts.py
+++ b/conversation_service/models/service_contracts.py
@@ -204,6 +204,10 @@ class SearchFilters(BaseModel):
         default=None, description="List of transaction types to include"
     )
 
+    operation_type: Optional[str] = Field(
+        default=None, description="Operation type to include"
+    )
+
     account_ids: Optional[List[str]] = Field(
         default=None, description="List of account IDs to include"
     )
@@ -287,6 +291,7 @@ class SearchFilters(BaseModel):
                 "category_name": ["food", "transport"],
                 "merchant_name": ["Carrefour", "SNCF"],
                 "transaction_types": ["debit"],
+                "operation_type": "card",
                 "text_query": "restaurant paris",
             }
         },
@@ -494,6 +499,12 @@ class TransactionResult(BaseModel):
         ..., description="Type of transaction"
     )
 
+    operation_type: Optional[str] = Field(
+        default=None,
+        description="Type of operation",
+        validation_alias="operation_type",
+    )
+
     balance_after: Optional[float] = Field(
         default=None, description="Account balance after transaction"
     )
@@ -686,6 +697,12 @@ class SearchServiceResponse(BaseModel):
             filtered = [r for r in filtered if r.amount <= max_amount]
 
         return filtered
+
+    def filter_by_operation_type(self, operation_type: Optional[str] = None) -> List[TransactionResult]:
+        """Filter results by operation type."""
+        if not operation_type:
+            return self.results
+        return [r for r in self.results if r.operation_type == operation_type]
 
     def group_by_category(self) -> Dict[str, List[TransactionResult]]:
         """Group results by transaction category."""


### PR DESCRIPTION
## Summary
- support OPERATION_TYPE entity and intent mapping
- allow SearchQueryAgent to build operation type filters
- extend mock intents and service contracts with operation type utilities

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1a3566700832095a911303990e94f