### PR TITLE
feat: add transaction count intent mapping

### DIFF
--- a/conversation_service/agents/llm_intent_agent.py
+++ b/conversation_service/agents/llm_intent_agent.py
@@ -267,10 +267,13 @@ class LLMIntentAgent(BaseFinancialAgent):
             "SEARCH_BY_MERCHANT",
             "SEARCH_BY_CATEGORY",
             "SEARCH_BY_TEXT",
-            "COUNT_TRANSACTIONS",
         }:
             category = IntentCategory.TRANSACTION_SEARCH
-        elif intent_type in {"SPENDING_ANALYSIS", "CATEGORY_ANALYSIS"}:
+        elif intent_type in {
+            "SPENDING_ANALYSIS",
+            "CATEGORY_ANALYSIS",
+            "COUNT_TRANSACTIONS",
+        }:
             category = IntentCategory.SPENDING_ANALYSIS
         elif intent_type in {"BALANCE_CHECK", "BALANCE_INQUIRY"}:
             category = IntentCategory.BALANCE_INQUIRY

--- a/conversation_service/agents/mock_intent_agent.py
+++ b/conversation_service/agents/mock_intent_agent.py
@@ -196,6 +196,24 @@ MOCK_INTENT_RESPONSES: Dict[str, Dict[str, Any]] = {
         "suggested_actions": ["search_by_category", "monthly_average"],
     },
 
+    "Combien de transactions ce mois ?": {
+        "intent_type": "COUNT_TRANSACTIONS",
+        "intent_category": "SPENDING_ANALYSIS",
+        "confidence": 0.91,
+        "entities": [
+            {
+                "entity_type": "RELATIVE_DATE",
+                "raw_value": "ce mois",
+                "normalized_value": "current_month",
+                "confidence": 0.9,
+            }
+        ],
+        "method": "llm_detection",
+        "processing_time_ms": 105.0,
+        "requires_clarification": False,
+        "suggested_actions": ["count_transactions"],
+    },
+
     # TREND_ANALYSIS
     "Évolution de mes dépenses ces 3 derniers mois": {
         "intent_type": "TREND_ANALYSIS",

--- a/tests/test_search_end_to_end.py
+++ b/tests/test_search_end_to_end.py
@@ -79,6 +79,11 @@ class DummyElasticsearchClientNoMerchant:
             }
         }
 
+
+class DummyElasticsearchClientCount:
+    async def count(self, index, body):
+        return {"count": 5}
+
 @pytest.mark.skipif(SearchEngine is None, reason="search_service not available")
 def test_netflix_month_question_returns_transactions():
     agent = SearchQueryAgent(
@@ -146,4 +151,12 @@ def test_text_search_returns_results_without_merchant_name():
     assert response["results"]
     assert response["results"][0]["merchant_name"] is None
     assert "netflix" in response["results"][0]["primary_description"].lower()
+
+
+@pytest.mark.skipif(SearchEngine is None, reason="search_service not available")
+def test_count_transactions_returns_correct_count():
+    engine = SearchEngine(elasticsearch_client=DummyElasticsearchClientCount())
+    request = SearchRequest(user_id=1, query="", filters={})
+    count = asyncio.run(engine.count(request))
+    assert count == 5
 


### PR DESCRIPTION
## Summary
- map COUNT_TRANSACTIONS intents to spending analysis
- add mock intent dataset entry for counting transactions
- cover SearchEngine count functionality with a new test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1a3586b988320b955bc66e3dd8345