### PR TITLE
Add GENERAL_QUESTION fallback intent

### DIFF
--- a/conversation_service/agents/mock_intent_agent.py
+++ b/conversation_service/agents/mock_intent_agent.py
@@ -567,6 +567,18 @@ MOCK_INTENT_RESPONSES: Dict[str, Dict[str, Any]] = {
         "suggested_actions": ["export_report", "excel_format"],
     },
 
+    # GENERAL_QUESTION
+    "Quel temps fait-il ?": {
+        "intent_type": "GENERAL_QUESTION",
+        "intent_category": "GENERAL_QUESTION",
+        "confidence": 0.5,
+        "entities": [],
+        "method": "llm_detection",
+        "processing_time_ms": 100.0,
+        "requires_clarification": False,
+        "suggested_actions": ["generic_response"],
+    },
+
     # UNCLEAR_INTENT
     "Trucs bizarres dans mes comptes": {
         "intent_type": "UNCLEAR_INTENT",
@@ -669,16 +681,16 @@ class MockIntentAgent(LLMIntentAgent):
 
         data = self._dataset.get(user_message)
         if data is None:
-            # Unknown question, return unclear intent
+            # Unknown question, return general question intent
             data = {
-                "intent_type": "UNCLEAR_INTENT",
-                "intent_category": "UNCLEAR_INTENT",
+                "intent_type": "GENERAL_QUESTION",
+                "intent_category": "GENERAL_QUESTION",
                 "confidence": 0.0,
                 "entities": [],
                 "method": "mock_detection",
                 "processing_time_ms": 0.0,
-                "requires_clarification": True,
-                "suggested_actions": [],
+                "requires_clarification": False,
+                "suggested_actions": ["generic_response"],
             }
 
         start = time.perf_counter()

--- a/tests/test_mock_intent_agent.py
+++ b/tests/test_mock_intent_agent.py
@@ -60,8 +60,10 @@ def test_conversational_intents_are_supported():
     assert confirmation_result.intent_category == IntentCategory.CONFIRMATION
 
 
-def test_payment_request_returns_unclear_intent():
+def test_unknown_request_returns_general_question():
     agent = MockIntentAgent()
-    result = asyncio.run(agent.detect_intent("Peux-tu transférer 500 euros à Marie ?", user_id=1))
+    result = asyncio.run(
+        agent.detect_intent("Peux-tu transférer 500 euros à Marie ?", user_id=1)
+    )
     intent_result = result["metadata"]["intent_result"]
-    assert intent_result.intent_category == IntentCategory.UNCLEAR_INTENT
+    assert intent_result.intent_category == IntentCategory.GENERAL_QUESTION


### PR DESCRIPTION
## Summary
- map GENERAL_QUESTION to a generic response action
- default MockIntentAgent to GENERAL_QUESTION when no intent matches
- adjust tests for new fallback behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1a359f66883208206e1634934fb18