### PR TITLE
Align transaction search intent names

### DIFF
--- a/conversation_service/models/financial_models.py
+++ b/conversation_service/models/financial_models.py
@@ -437,7 +437,7 @@ class IntentResult(BaseModel):
         "use_enum_values": True,
         "json_schema_extra": {
             "example": {
-                "intent_type": "TRANSACTION_SEARCH_BY_AMOUNT_AND_DATE",
+                "intent_type": "SEARCH_BY_AMOUNT_AND_DATE",
                 "intent_category": "TRANSACTION_SEARCH",
                 "confidence": 0.92,
                 "method": "llm_based",

--- a/conversation_service/models/service_contracts.py
+++ b/conversation_service/models/service_contracts.py
@@ -358,7 +358,7 @@ class SearchServiceQuery(BaseModel):
                 "query_metadata": {
                     "conversation_id": "550e8400-e29b-41d4-a716-446655440001",
                     "user_id": 12345,
-                    "intent_type": "TRANSACTION_SEARCH_BY_DATE",
+                    "intent_type": "SEARCH_BY_DATE",
                     "source_agent": "search_query_agent",
                 },
                 "search_parameters": {


### PR DESCRIPTION
## Summary
- Rename `TRANSACTION_SEARCH_BY_AMOUNT_AND_DATE` example to `SEARCH_BY_AMOUNT_AND_DATE`
- Update `TRANSACTION_SEARCH_BY_DATE` example to `SEARCH_BY_DATE`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1a3624d9c83209600eb0186dd29e4