### PR TITLE
Allow one-sided amount filters in service contracts

### DIFF
--- a/conversation_service/models/service_contracts.py
+++ b/conversation_service/models/service_contracts.py
@@ -268,9 +268,9 @@ class SearchFilters(BaseModel):
         """Validate amount filter has proper gte/lte."""
         if v is None:
             return v
-        if "gte" not in v or "lte" not in v:
-            raise ValueError("amount filter must contain both 'gte' and 'lte'")
-        if v["gte"] > v["lte"]:
+        if "gte" not in v and "lte" not in v:
+            raise ValueError("amount filter must contain 'gte' or 'lte'")
+        if "gte" in v and "lte" in v and v["gte"] > v["lte"]:
             raise ValueError("'gte' must be less than or equal to 'lte'")
         return v
 

--- a/tests/conversation_service/test_service_contracts_filters.py
+++ b/tests/conversation_service/test_service_contracts_filters.py
@@ -28,16 +28,26 @@ def test_date_filter_inverted_range():
         SearchFilters.validate_date({"gte": "2024-02-01", "lte": "2024-01-01"})
 
 
-def test_amount_filter_valid():
+def test_amount_filter_valid_range():
     filters = SearchFilters(amount={"gte": 10.0, "lte": 100.0})
     assert filters.amount == {"gte": 10.0, "lte": 100.0}
 
 
+def test_amount_filter_valid_gte_only():
+    filters = SearchFilters(amount={"gte": 10.0})
+    assert filters.amount == {"gte": 10.0}
+
+
+def test_amount_filter_valid_lte_only():
+    filters = SearchFilters(amount={"lte": 100.0})
+    assert filters.amount == {"lte": 100.0}
+
+
 def test_amount_filter_missing_keys():
     with pytest.raises(ValueError):
-        SearchFilters.validate_amount({"gte": 10.0})
+        SearchFilters.validate_amount({})
     with pytest.raises(ValueError):
-        SearchFilters.validate_amount({"lte": 100.0})
+        SearchFilters.validate_amount({"foo": 1.0})
 
 
 def test_amount_filter_inverted_range():

--- a/tests/test_search_query_agent.py
+++ b/tests/test_search_query_agent.py
@@ -3,7 +3,7 @@ from conversation_service.agents import base_financial_agent
 # Ensure the base agent does not require AutoGen during tests
 base_financial_agent.AUTOGEN_AVAILABLE = True
 
-from conversation_service.agents.search_query_agent import SearchQueryAgent
+from conversation_service.agents.search_query_agent import SearchQueryAgent, QueryOptimizer
 from conversation_service.models.financial_models import (
     FinancialEntity,
     EntityType,
@@ -51,6 +51,25 @@ class DummyHTTPClient:
 
     async def post(self, url, json, headers):
         return DummyHTTPResponse(self._data)
+
+
+def make_amount_intent(normalized_value, actions=None):
+    return IntentResult(
+        intent_type="TRANSACTION_SEARCH",
+        intent_category=IntentCategory.TRANSACTION_SEARCH,
+        confidence=0.9,
+        entities=[
+            FinancialEntity(
+                entity_type=EntityType.AMOUNT,
+                raw_value="amount",
+                normalized_value=normalized_value,
+                confidence=0.9,
+            )
+        ],
+        method=DetectionMethod.LLM_BASED,
+        suggested_actions=actions,
+        processing_time_ms=1.0,
+    )
 
 
 def test_prepare_entity_context_with_string_entity_type():
@@ -137,6 +156,24 @@ def test_relative_date_current_month():
 
     assert date_filter["gte"] == start.strftime("%Y-%m-%d")
     assert date_filter["lte"] == end.strftime("%Y-%m-%d")
+
+
+def test_extract_amount_filters_gte_only():
+    intent_result = make_amount_intent({"gte": 50})
+    filters = QueryOptimizer.extract_amount_filters(intent_result)
+    assert filters == {"amount": {"gte": 50.0}}
+
+
+def test_extract_amount_filters_lte_only():
+    intent_result = make_amount_intent({"lte": 100})
+    filters = QueryOptimizer.extract_amount_filters(intent_result)
+    assert filters == {"amount": {"lte": 100.0}}
+
+
+def test_extract_amount_filters_range():
+    intent_result = make_amount_intent({"gte": 50, "lte": 100})
+    filters = QueryOptimizer.extract_amount_filters(intent_result)
+    assert filters == {"amount": {"gte": 50.0, "lte": 100.0}}
 
 
 def test_execute_search_query_converts_fields():


### PR DESCRIPTION
## Summary
- Permit amount filter ranges to specify only `gte` or `lte`
- Enhance amount filter extraction to respect provided bounds
- Expand tests for one-sided and full range amount filters

## Testing
- `pytest tests/conversation_service/test_service_contracts_filters.py tests/test_search_query_agent.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1b363a2688320bf6e3ddd721a3cca