### PR TITLE
Handle search errors in conversation workflow

### DIFF
--- a/conversation_service/agents/orchestrator_agent.py
+++ b/conversation_service/agents/orchestrator_agent.py
@@ -128,7 +128,8 @@ class WorkflowExecutor:
             "conversation_id": conversation_id,
             "intent_result": None,
             "search_results": None,
-            "final_response": None
+            "final_response": None,
+            "search_error": False
         }
         
         try:
@@ -223,6 +224,7 @@ class WorkflowExecutor:
                         search_step.error = str(e)
                         logger.error(f"Search query step failed: {e}")
                         workflow_data["search_results"] = self._create_empty_search_results()
+                        workflow_data["search_error"] = True
                     finally:
                         search_step.end_time = time.perf_counter()
                         duration_ms = metrics.performance_monitor.end_timer(search_timer)
@@ -278,6 +280,7 @@ class WorkflowExecutor:
                             "user_message": user_message,
                             "search_results": workflow_data["search_results"],
                             "context": context,
+                            "search_error": workflow_data.get("search_error", False),
                         },
                         user_id,
                     )

--- a/conversation_service/agents/response_agent.py
+++ b/conversation_service/agents/response_agent.py
@@ -167,15 +167,23 @@ class ResponseAgent(BaseFinancialAgent):
         Execute response generation operation.
 
         Args:
-            input_data: Dict containing 'user_message', 'search_results', and 'context'
+            input_data: Dict containing 'user_message', 'search_results', 'context',
+                and optional 'search_error'
             user_id: ID of the requesting user
 
         Returns:
             Dict with generated response and metadata
         """
         user_message = input_data.get("user_message", "")
-        search_results = input_data.get("search_results", {})
         context = input_data.get("context")
+        if input_data.get("search_error"):
+            return {
+                "content": "La recherche n'a pas pu être effectuée.",
+                "metadata": {"error": "search_failed", "fallback_used": True},
+                "confidence_score": 0.0,
+            }
+
+        search_results = input_data.get("search_results", {})
 
         if not search_results:
             raise ValueError("search_results are required for response generation")


### PR DESCRIPTION
## Summary
- Track search failures with `search_error` flag in orchestrator workflow data
- Response agent returns explicit failure message when search fails
- Test added to ensure user is informed when search step raises an exception

## Testing
- `pytest tests/test_response_agent.py tests/test_orchestrator_fallback.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a1b3657b408320b39fcc2ae617d42d