### PR TITLE
test: avoid default date filter when using amount

### DIFF
--- a/tests/test_search_query_agent.py
+++ b/tests/test_search_query_agent.py
@@ -139,6 +139,38 @@ def test_relative_date_current_month():
     assert date_filter["lte"] == end.strftime("%Y-%m-%d")
 
 
+def test_amount_filter_without_date():
+    agent = SearchQueryAgent(
+        deepseek_client=DummyDeepSeekClient(),
+        search_service_url="http://search.example.com",
+    )
+    intent_result = IntentResult(
+        intent_type="TRANSACTION_SEARCH",
+        intent_category=IntentCategory.TRANSACTION_SEARCH,
+        confidence=0.9,
+        entities=[
+            FinancialEntity(
+                entity_type=EntityType.AMOUNT,
+                raw_value="100",
+                normalized_value=100,
+                confidence=0.9,
+            )
+        ],
+        method=DetectionMethod.LLM_BASED,
+        processing_time_ms=1.0,
+        suggested_actions=["filter_by_amount_greater"],
+    )
+
+    search_query = asyncio.run(
+        agent._generate_search_contract(
+            intent_result, "transactions supérieures à 100€", user_id=1
+        )
+    )
+    request = search_query.to_search_request()
+    assert "amount" in request["filters"]
+    assert "date" not in request["filters"]
+
+
 def test_execute_search_query_converts_fields():
     agent = SearchQueryAgent(
         deepseek_client=DummyDeepSeekClient(),


### PR DESCRIPTION
## Summary
- add regression test for amount-only queries to ensure no implicit date filter is applied

## Testing
- `pytest tests/test_search_query_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1b36711a883209fce06434c1f2ceb