### PR TITLE
Handle absolute amount comparisons

### DIFF
--- a/conversation_service/agents/search_query_agent.py
+++ b/conversation_service/agents/search_query_agent.py
@@ -239,9 +239,9 @@ class QueryOptimizer:
                     normalized_amount = float(value)
 
                     if "filter_by_amount_greater" in actions:
-                        amount_filters["amount"] = {"gte": normalized_amount}
+                        amount_filters["amount_abs"] = {"gte": normalized_amount}
                     elif "filter_by_amount_less" in actions:
-                        amount_filters["amount"] = {"lte": normalized_amount}
+                        amount_filters["amount_abs"] = {"lte": normalized_amount}
                     else:
                         tolerance = abs(normalized_amount) * 0.1  # 10% tolerance
                         amount_filters["amount"] = {

--- a/conversation_service/models/service_contracts.py
+++ b/conversation_service/models/service_contracts.py
@@ -188,6 +188,11 @@ class SearchFilters(BaseModel):
         description="Amount filter with 'gte' and 'lte' keys"
     )
 
+    amount_abs: Optional[Dict[str, float]] = Field(
+        default=None,
+        description="Absolute amount filter with 'gte' and 'lte' keys"
+    )
+
     category_name: Optional[List[str]] = Field(
         default=None,
         description="List of transaction categories to include",

--- a/tests/test_search_end_to_end.py
+++ b/tests/test_search_end_to_end.py
@@ -84,6 +84,40 @@ class DummyElasticsearchClientCount:
     async def count(self, index, body):
         return {"count": 5}
 
+
+class DummyElasticsearchClientAmountAbs:
+    async def search(self, index, body, size, from_):
+        has_filter = False
+        for clause in body.get("query", {}).get("bool", {}).get("must", []):
+            if "range" in clause and "amount_abs" in clause["range"]:
+                gte = clause["range"]["amount_abs"].get("gte", 0)
+                if gte <= 150:
+                    has_filter = True
+        if has_filter:
+            return {
+                "hits": {
+                    "total": {"value": 1},
+                    "hits": [
+                        {
+                            "_score": 1.0,
+                            "_source": {
+                                "transaction_id": "t1",
+                                "user_id": 1,
+                                "amount": -150.0,
+                                "amount_abs": 150.0,
+                                "currency_code": "EUR",
+                                "transaction_type": "debit",
+                                "date": "2025-02-01",
+                                "primary_description": "Paiement carte",
+                                "category_name": "Divers",
+                                "operation_type": "card",
+                            },
+                        }
+                    ],
+                }
+            }
+        return {"hits": {"total": {"value": 0}, "hits": []}}
+
 @pytest.mark.skipif(SearchEngine is None, reason="search_service not available")
 def test_netflix_month_question_returns_transactions():
     agent = SearchQueryAgent(
@@ -159,4 +193,37 @@ def test_count_transactions_returns_correct_count():
     request = SearchRequest(user_id=1, query="", filters={})
     count = asyncio.run(engine.count(request))
     assert count == 5
+
+
+@pytest.mark.skipif(SearchEngine is None, reason="search_service not available")
+def test_amount_abs_filter_matches_negative_amount():
+    agent = SearchQueryAgent(
+        deepseek_client=DummyDeepSeekClient(),
+        search_service_url="http://search.example.com",
+    )
+    intent_result = IntentResult(
+        intent_type="TRANSACTION_SEARCH",
+        intent_category=IntentCategory.TRANSACTION_SEARCH,
+        confidence=0.9,
+        entities=[
+            FinancialEntity(
+                entity_type=EntityType.AMOUNT,
+                raw_value="100",
+                normalized_value=100,
+                confidence=0.9,
+            )
+        ],
+        method=DetectionMethod.LLM_BASED,
+        processing_time_ms=1.0,
+        suggested_actions=["filter_by_amount_greater"],
+    )
+    user_message = "transactions supérieures à 100€"
+    search_contract = asyncio.run(
+        agent._generate_search_contract(intent_result, user_message, user_id=1)
+    )
+    request_dict = search_contract.to_search_request()
+    assert request_dict["filters"].get("amount_abs", {}).get("gte") == 100
+    engine = SearchEngine(elasticsearch_client=DummyElasticsearchClientAmountAbs())
+    response = asyncio.run(engine.search(SearchRequest(**request_dict)))
+    assert response["results"] and response["results"][0]["amount"] == -150.0
 

--- a/tests/test_search_query_agent.py
+++ b/tests/test_search_query_agent.py
@@ -186,7 +186,7 @@ def test_amount_filter_without_date():
         )
     )
     request = search_query.to_search_request()
-    assert "amount" in request["filters"]
+    assert "amount_abs" in request["filters"]
     assert "date" not in request["filters"]
 
 def test_extract_amount_filters_gte_only():
@@ -205,6 +205,12 @@ def test_extract_amount_filters_range():
     intent_result = make_amount_intent({"gte": 50, "lte": 100})
     filters = QueryOptimizer.extract_amount_filters(intent_result)
     assert filters == {"amount": {"gte": 50.0, "lte": 100.0}}
+
+
+def test_extract_amount_filters_absolute_comparison():
+    intent_result = make_amount_intent(100, actions=["filter_by_amount_greater"])
+    filters = QueryOptimizer.extract_amount_filters(intent_result)
+    assert filters == {"amount_abs": {"gte": 100.0}}
 
 
 def test_execute_search_query_converts_fields():


### PR DESCRIPTION
## Summary
- Use `amount_abs` filter when comparing transaction amounts by absolute value
- Support `amount_abs` in search filters
- Test absolute amount filtering and retrieval

## Testing
- `pytest tests/test_search_query_agent.py::test_extract_amount_filters_absolute_comparison`
- `pytest tests/test_search_query_agent.py tests/test_search_end_to_end.py`

------
https://chatgpt.com/codex/tasks/task_e_68a1b80ce36c83209538ec31ef285263