### PR TITLE
Improve query token filtering and add guard test

### DIFF
--- a/conversation_service/agents/search_query_agent.py
+++ b/conversation_service/agents/search_query_agent.py
@@ -142,17 +142,25 @@ class QueryOptimizer:
             "inferieure",
             "inferieurs",
             "inferieures",
+            "plus",
+            "moins",
+            "egal",
+            "egale",
+            "egaux",
+            "egales",
             # Monetary symbols and currency tokens
             "€",
             "$",
             "£",
             "¥",
-            "euro",
-            "euros",
             "dollar",
             "dollars",
             "yen",
             "yens",
+            "usd",
+            "eur",
+            "gbp",
+            "chf",
             # Numeric tokens
             "0",
             "1",
@@ -201,10 +209,12 @@ class QueryOptimizer:
         for word in words:
             if word not in unique_words:
                 unique_words.append(word)
+        if not unique_words:
+            return None
 
         optimized_text = " ".join(unique_words)[:200]
         logger.debug("Normalized search text: %s", optimized_text)
-        return optimized_text or None  # Limit search text length
+        return optimized_text  # Limit search text length
 
     @staticmethod
     def extract_date_filters(intent_result: IntentResult) -> Dict[str, Any]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,12 +45,13 @@ def create_pydantic_stub():
     def _create_model(name, **fields):
         """Stub pour create_model"""
         return type(name, (_BaseModel,), fields)
-    
+
     pydantic_stub.BaseModel = _BaseModel
     pydantic_stub.Field = _Field
     pydantic_stub.field_validator = _field_validator
     pydantic_stub.model_validator = _model_validator
     pydantic_stub.create_model = _create_model
+    pydantic_stub.ConfigDict = dict
     pydantic_stub.ValidationError = type("ValidationError", (Exception,), {})
     
     return pydantic_stub

--- a/tests/test_search_query_agent.py
+++ b/tests/test_search_query_agent.py
@@ -23,10 +23,15 @@ from datetime import datetime, timedelta
 
 try:
     from search_service.core.search_engine import SearchEngine
-    from search_service.models.request import SearchRequest
 except Exception:  # pragma: no cover - skip if deps missing
     SearchEngine = None
+
+try:
+    from search_service.models.request import SearchRequest
+    from search_service.core.query_builder import QueryBuilder
+except Exception:  # pragma: no cover - skip if deps missing
     SearchRequest = None
+    QueryBuilder = None
 
 
 class DummyDeepSeekClient:
@@ -189,6 +194,44 @@ def test_amount_filter_without_date():
     assert "amount_abs" in request["filters"]
     assert "date" not in request["filters"]
     assert request["query"] == ""
+
+
+def test_no_multimatch_for_amount_phrase():
+    if QueryBuilder is None or SearchRequest is None:
+        pytest.skip("search_service not available")
+
+    agent = SearchQueryAgent(
+        deepseek_client=DummyDeepSeekClient(),
+        search_service_url="http://search.example.com",
+    )
+    intent_result = IntentResult(
+        intent_type="TRANSACTION_SEARCH",
+        intent_category=IntentCategory.TRANSACTION_SEARCH,
+        confidence=0.9,
+        entities=[
+            FinancialEntity(
+                entity_type=EntityType.AMOUNT,
+                raw_value="100",
+                normalized_value=100,
+                confidence=0.9,
+            )
+        ],
+        method=DetectionMethod.LLM_BASED,
+        processing_time_ms=1.0,
+        suggested_actions=["filter_by_amount_greater"],
+    )
+
+    search_query = asyncio.run(
+        agent._generate_search_contract(
+            intent_result, "transactions supérieures à 100 euros", user_id=1
+        )
+    )
+    request = search_query.to_search_request()
+
+    qb = QueryBuilder()
+    es_query = qb.build_query(SearchRequest(**request))
+
+    assert all("multi_match" not in clause for clause in es_query["query"]["bool"]["must"])
 
 def test_extract_amount_filters_gte_only():
     intent_result = make_amount_intent({"gte": 50})


### PR DESCRIPTION
## Summary
- broaden stop word list with comparison terms, currency symbols and digit tokens
- return `None` when no useful search terms remain
- add test ensuring "transactions supérieures à 100 euros" yields no `multi_match`
- extend testing stubs to include `ConfigDict`

## Testing
- `pytest tests/test_search_query_agent.py::test_no_multimatch_for_amount_phrase -q`
- `pytest tests/test_search_query_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1becd23348320ae63bd9276db68b0