### PR TITLE
Handle search errors in workflow

### DIFF
--- a/conversation_service/agents/orchestrator_agent.py
+++ b/conversation_service/agents/orchestrator_agent.py
@@ -284,7 +284,13 @@ class WorkflowExecutor:
                         },
                         user_id,
                     )
-                    if response_response.success:
+                    if workflow_data.get("search_error"):
+                        # Propagate search failure to the workflow and avoid normal response
+                        workflow_data["final_response"] = response_response.content
+                        response_step.status = WorkflowStepStatus.FAILED
+                        response_step.result = response_response
+                        response_step.error = "Search query failed"
+                    elif response_response.success:
                         workflow_data["final_response"] = response_response.content
                         response_step.status = WorkflowStepStatus.COMPLETED
                         response_step.result = response_response

--- a/conversation_service/agents/response_agent.py
+++ b/conversation_service/agents/response_agent.py
@@ -27,6 +27,9 @@ from ..core.deepseek_client import DeepSeekClient, DeepSeekResponse
 
 logger = logging.getLogger(__name__)
 
+# Message returned to the user when the search step fails
+SEARCH_ERROR_MESSAGE = "La recherche n'a pas pu être effectuée."
+
 
 class ResponseFormatter:
     """Helper class for formatting financial data in responses."""
@@ -178,7 +181,7 @@ class ResponseAgent(BaseFinancialAgent):
         context = input_data.get("context")
         if input_data.get("search_error"):
             return {
-                "content": "La recherche n'a pas pu être effectuée.",
+                "content": SEARCH_ERROR_MESSAGE,
                 "metadata": {"error": "search_failed", "fallback_used": True},
                 "confidence_score": 0.0,
             }

--- a/tests/test_orchestrator_fallback.py
+++ b/tests/test_orchestrator_fallback.py
@@ -1,7 +1,7 @@
 import asyncio
 import conversation_service.agents.orchestrator_agent as oa
 from conversation_service.agents.orchestrator_agent import WorkflowExecutor
-from conversation_service.agents.response_agent import ResponseAgent
+from conversation_service.agents.response_agent import ResponseAgent, SEARCH_ERROR_MESSAGE
 from conversation_service.models.agent_models import AgentResponse
 from conversation_service.models.financial_models import DetectionMethod
 from types import SimpleNamespace
@@ -105,4 +105,8 @@ def test_search_error_informs_user():
     result = asyncio.run(executor.execute_workflow("hello", "c2", 1))
 
     assert result["workflow_data"]["search_error"] is True
-    assert "n'a pas pu être effectuée" in result["final_response"]
+    assert result["final_response"] == SEARCH_ERROR_MESSAGE
+    response_step = next(
+        step for step in result["execution_details"]["steps"] if step["name"] == "response_generation"
+    )
+    assert response_step["status"] == "failed"


### PR DESCRIPTION
## Summary
- Propagate search failures to the response step and keep the `search_error` flag
- Return a clear search error message from `ResponseAgent`
- Test that orchestrator reports search failures and emits error message

## Testing
- `pytest tests/test_orchestrator_fallback.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1bed59f448320a4ddd9393d74a36c