### PR TITLE
test: ensure no date filter without time constraint

### DIFF
--- a/tests/test_search_query_agent.py
+++ b/tests/test_search_query_agent.py
@@ -122,6 +122,36 @@ def test_generate_search_contract_deduplicates_terms():
     assert request["user_id"] == 1
 
 
+def test_no_date_filter_without_time_constraint():
+    agent = SearchQueryAgent(
+        deepseek_client=DummyDeepSeekClient(),
+        search_service_url="http://search.example.com",
+    )
+    intent_result = IntentResult(
+        intent_type="TRANSACTION_SEARCH",
+        intent_category=IntentCategory.TRANSACTION_SEARCH,
+        confidence=0.9,
+        entities=[
+            FinancialEntity(
+                entity_type=EntityType.MERCHANT,
+                raw_value="Amazon",
+                normalized_value="amazon",
+                confidence=0.9,
+            )
+        ],
+        method=DetectionMethod.LLM_BASED,
+        processing_time_ms=1.0,
+    )
+
+    search_query = asyncio.run(
+        agent._generate_search_contract(
+            intent_result, "dépenses chez Amazon", user_id=1
+        )
+    )
+    request = search_query.to_search_request()
+    assert "date" not in request["filters"]
+
+
 def test_relative_date_current_month():
     agent = SearchQueryAgent(
         deepseek_client=DummyDeepSeekClient(),


### PR DESCRIPTION
## Summary
- add test verifying SearchQueryAgent doesn't create date filter when no time constraint is provided

## Testing
- `pytest tests/test_search_query_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1bed6e8a48320b22277cdafcec4cc