### PR TITLE
Compute search results length in direct chat test

### DIFF
--- a/test_harena_chat_direct.py
+++ b/test_harena_chat_direct.py
@@ -95,7 +95,29 @@ def main() -> None:
     print("🔍 ANALYSE DE LA RECHERCHE :")
     
     # Extraire les informations de recherche depuis les métadonnées
-    search_results_count = chat_data["metadata"].get("search_results_count", 0)
+    # Nouvel affichage : utiliser la taille réelle des résultats de recherche
+    metadata = chat_data.get("metadata", {})
+    workflow_data = metadata.get("workflow_data", {})
+
+    search_results = []
+    if isinstance(workflow_data, dict):
+        sr = workflow_data.get("search_results")
+        if isinstance(sr, dict):
+            # Structure attendue : {"metadata": {"search_response": {"results": [...]}}}
+            search_response = sr.get("metadata", {}).get("search_response", {})
+            results = search_response.get("results") if isinstance(search_response, dict) else None
+            if isinstance(results, list):
+                search_results = results
+        elif isinstance(sr, list):
+            # Certains scénarios peuvent fournir directement une liste
+            search_results = sr
+
+    if search_results:
+        search_results_count = len(search_results)
+    else:
+        # Retour arrière si les résultats ne sont pas disponibles dans workflow_data
+        search_results_count = metadata.get("search_results_count", 0)
+
     print(f"   📊 Résultats trouvés par l'agent : {search_results_count}")
     
     # Analyser les entités pour comprendre la requête générée


### PR DESCRIPTION
## Summary
- compute search results count from workflow data in `test_harena_chat_direct.py`

## Testing
- `pytest tests/test_orchestrator_fallback.py -q`
- `python test_harena_chat_direct.py` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a22053bdec8320988391e142602bfd