### PR TITLE
Add search pagination handling and tests

### DIFF
--- a/conversation_service/models/service_contracts.py
+++ b/conversation_service/models/service_contracts.py
@@ -417,6 +417,27 @@ class SearchServiceQuery(BaseModel):
             },
         }
 
+    def with_offset(self, offset: int) -> "SearchServiceQuery":
+        """Return a copy of this query with an updated offset.
+
+        Args:
+            offset: New offset value for pagination.
+
+        Returns:
+            A cloned ``SearchServiceQuery`` with ``search_parameters.offset``
+            set to the provided value.
+        """
+
+        params_dict = self.search_parameters.dict()
+        params_dict["offset"] = offset
+        new_params = SearchParameters(**params_dict)
+        return SearchServiceQuery(
+            query_metadata=self.query_metadata,
+            search_parameters=new_params,
+            filters=self.filters,
+            aggregations=self.aggregations,
+        )
+
 
 class ResponseMetadata(BaseModel):
     """


### PR DESCRIPTION
## Summary
- handle paginated search responses by looping until no more results and aggregating pages
- add `with_offset` helper to `SearchServiceQuery` for cloning query with new offset
- add tests for offset pagination and multi-page aggregation

## Testing
- `pytest tests/test_search_query_agent.py::test_pagination_updates_offset tests/test_search_end_to_end.py::test_agent_aggregates_paginated_results -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a22516ac3083208ee8c64b2d33e55c