### PR TITLE
Display search results count using len() in direct chat test

### DIFF
--- a/test_harena_chat_direct.py
+++ b/test_harena_chat_direct.py
@@ -112,12 +112,7 @@ def main() -> None:
             # Certains scénarios peuvent fournir directement une liste
             search_results = sr
 
-    if search_results:
-        search_results_count = len(search_results)
-    else:
-        # Retour arrière si les résultats ne sont pas disponibles dans workflow_data
-        search_results_count = metadata.get("search_results_count", 0)
-
+    search_results_count = len(search_results)
     print(f"   📊 Résultats trouvés par l'agent : {search_results_count}")
     
     # Analyser les entités pour comprendre la requête générée


### PR DESCRIPTION
## Summary
- Compute search results count using `len(search_results)` and display it directly in the direct chat test.

## Testing
- `pytest -q`
- `python test_harena_chat_direct.py` *(fails: ConnectionRefusedError - required API server not running)*

------
https://chatgpt.com/codex/tasks/task_e_68a2cd4a079c8320acf6770c5c1514c0