### PR TITLE
Increase default search limit to 100

### DIFF
--- a/config_service/config.py
+++ b/config_service/config.py
@@ -291,7 +291,7 @@ class GlobalSettings(BaseSettings):
     EMBEDDING_MAX_RETRIES: int = int(os.environ.get("EMBEDDING_MAX_RETRIES", "3"))
     
     # Configuration de pagination
-    DEFAULT_SEARCH_LIMIT: int = int(os.environ.get("DEFAULT_SEARCH_LIMIT", "20"))
+    DEFAULT_SEARCH_LIMIT: int = int(os.environ.get("DEFAULT_SEARCH_LIMIT", "100"))
     DEFAULT_LIMIT: int = int(os.environ.get("DEFAULT_LIMIT", "20"))
     
     # Configuration des timeouts de recherche

--- a/conversation_service/agents/search_query_agent.py
+++ b/conversation_service/agents/search_query_agent.py
@@ -566,7 +566,7 @@ class SearchQueryAgent(BaseFinancialAgent):
         # Create search parameters based on intent
         search_params = SearchParameters(
             search_text=search_text,
-            max_results=20 if intent_result.intent_type == "TRANSACTION_SEARCH" else 10,
+            max_results=100 if intent_result.intent_type == "TRANSACTION_SEARCH" else 10,
             include_highlights=True,
             boost_recent=intent_result.intent_type
             in [

--- a/search_service/models/request.py
+++ b/search_service/models/request.py
@@ -15,7 +15,7 @@ class SearchRequest(BaseModel):
     )
     
     # Optionnel - Paramètres de pagination
-    limit: int = Field(default=20, description="Nombre de résultats max", ge=1, le=100)
+    limit: int = Field(default=100, description="Nombre de résultats max", ge=1, le=100)
     offset: int = Field(default=0, description="Décalage pour pagination", ge=0)
     
     # Optionnel - Métadonnées

--- a/tests/test_search_end_to_end.py
+++ b/tests/test_search_end_to_end.py
@@ -34,7 +34,7 @@ except Exception:  # pragma: no cover - fallback to simple stubs
         user_id: int
         query: str = ""
         filters: Dict[str, Any] = field(default_factory=dict)
-        limit: int = 20
+        limit: int = 100
         offset: int = 0
         metadata: Dict[str, Any] = field(default_factory=dict)
 


### PR DESCRIPTION
## Summary
- raise default search page size from 20 to 100
- update transaction search agent to request up to 100 results per call
- adjust tests and config for new limit

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1b2b8def08320bdd9dd37c8c07b74