### PR TITLE
fix intent benchmark import

### DIFF
--- a/scripts/intent_benchmark.py
+++ b/scripts/intent_benchmark.py
@@ -4,7 +4,7 @@ import time
 from pathlib import Path
 from typing import Dict
 
-from scripts.quick_intent_test import HarenaIntentAgent
+from quick_intent_test import HarenaIntentAgent
 
 
 def parse_intents_md(path: Path) -> Dict[str, str]:


### PR DESCRIPTION
## Summary
- fix relative import in intent_benchmark script so it can be run directly from the scripts directory

## Testing
- `python scripts/intent_benchmark.py`
- `python -m scripts.intent_benchmark` *(fails: ModuleNotFoundError: No module named 'quick_intent_test')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a31c22c8b883208e5ce48ccf08af15