### PR TITLE
Fix path to INTENTS.md in intent agent

### DIFF
--- a/scripts/quick_intent_test.py
+++ b/scripts/quick_intent_test.py
@@ -162,7 +162,8 @@ class HarenaIntentAgent:
         """Crée le prompt système avec la liste complète des intentions et exemples."""
 
         intents: List[Tuple[str, str, str]] = []
-        path = Path(__file__).with_name("INTENTS.md")
+        repo_root = Path(__file__).resolve().parents[1]
+        path = repo_root / "INTENTS.md"
         category_map = {
             "ACCOUNT_BALANCE": "BALANCE_INQUIRY",
             "GENERAL_QUESTION": "UNCLEAR_INTENT",


### PR DESCRIPTION
## Summary
- ensure quick_intent_test reads INTENTS.md from repo root

## Testing
- `python scripts/intent_benchmark.py` *(fails: Connection error)*

------
https://chatgpt.com/codex/tasks/task_e_68a31e7792e48320bddbf9c7b9f094a7