### PR TITLE
Align intent category parsing via shared mapping

### DIFF
--- a/scripts/intent_benchmark.py
+++ b/scripts/intent_benchmark.py
@@ -4,7 +4,7 @@ import time
 from pathlib import Path
 from typing import Dict
 
-from quick_intent_test import HarenaIntentAgent
+from quick_intent_test import HarenaIntentAgent, CATEGORY_MAP
 
 
 def parse_intents_md(path: Path) -> Dict[str, str]:
@@ -20,6 +20,7 @@ def parse_intents_md(path: Path) -> Dict[str, str]:
         intent, category = parts[0], parts[1]
         if category.startswith("UNSUPPORTED"):
             category = "UNCLEAR_INTENT"
+        category = CATEGORY_MAP.get(category, category)
         intents[intent] = category
     return intents
 

--- a/scripts/quick_intent_test.py
+++ b/scripts/quick_intent_test.py
@@ -24,6 +24,12 @@ load_dotenv()
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+# Mapping to harmonize categories between INTENTS.md and the agent
+CATEGORY_MAP = {
+    "ACCOUNT_BALANCE": "BALANCE_INQUIRY",
+    "GENERAL_QUESTION": "UNCLEAR_INTENT",
+}
+
 # ==================== MODÈLES PYDANTIC (IntentResult) ====================
 
 class IntentCategory(str, Enum):
@@ -164,10 +170,6 @@ class HarenaIntentAgent:
         intents: List[Tuple[str, str, str]] = []
         repo_root = Path(__file__).resolve().parents[1]
         path = repo_root / "INTENTS.md"
-        category_map = {
-            "ACCOUNT_BALANCE": "BALANCE_INQUIRY",
-            "GENERAL_QUESTION": "UNCLEAR_INTENT",
-        }
         with path.open(encoding="utf-8") as f:
             for line in f:
                 line = line.strip()
@@ -179,7 +181,7 @@ class HarenaIntentAgent:
                 intent, category, description = parts[:3]
                 if category.startswith("UNSUPPORTED"):
                     category = "UNCLEAR_INTENT"
-                category = category_map.get(category, category)
+                category = CATEGORY_MAP.get(category, category)
                 intents.append((intent, category, description))
 
         example_queries: Dict[str, str] = {

--- a/tests/test_intents_full.py
+++ b/tests/test_intents_full.py
@@ -19,7 +19,7 @@ sys.modules["openai"] = types.SimpleNamespace(
 )
 sys.modules["dotenv"] = types.SimpleNamespace(load_dotenv=lambda *args, **kwargs: None)
 
-from scripts.quick_intent_test import HarenaIntentAgent
+from scripts.quick_intent_test import HarenaIntentAgent, CATEGORY_MAP
 
 THRESHOLD = 0.8
 
@@ -38,6 +38,7 @@ def parse_intents_md(path: Path) -> Dict[str, str]:
         # Harmonize unsupported categories with enum
         if category.startswith("UNSUPPORTED"):
             category = "UNCLEAR_INTENT"
+        category = CATEGORY_MAP.get(category, category)
         intents[intent] = category
     return intents
 


### PR DESCRIPTION
## Summary
- Introduce shared `CATEGORY_MAP` to harmonize intent categories
- Apply mapping when parsing `INTENTS.md` in benchmark script
- Use same mapping in tests to mirror agent expectations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a32136ba548320968ef2e62802f7c4