### PR TITLE
Handle unsupported intents in benchmark

### DIFF
--- a/scripts/intent_benchmark.py
+++ b/scripts/intent_benchmark.py
@@ -64,6 +64,20 @@ INTENT_QUERIES: Dict[str, str] = {
 }
 
 
+# Intents that are not yet supported by the system. If the model predicts
+# ``UNSUPPORTED`` for any of these intents (with a matching category), the
+# prediction is still considered correct.
+UNSUPPORTED_INTENTS = {
+    "TRANSFER_REQUEST",
+    "PAYMENT_REQUEST",
+    "CARD_BLOCK",
+    "BUDGET_INQUIRY",
+    "GOAL_TRACKING",
+    "EXPORT_REQUEST",
+    "OUT_OF_SCOPE",
+}
+
+
 async def run_benchmark() -> None:
     intents = parse_intents_md(Path("INTENTS.md"))
 
@@ -91,8 +105,14 @@ async def run_benchmark() -> None:
     success = sum(
         1
         for r in results
-        if r["intent"] == r["predicted_intent"]
-        and r["expected_category"] == r["predicted_category"]
+        if r["expected_category"] == r["predicted_category"]
+        and (
+            r["intent"] == r["predicted_intent"]
+            or (
+                r["predicted_intent"] == "UNSUPPORTED"
+                and r["intent"] in UNSUPPORTED_INTENTS
+            )
+        )
     )
     avg_conf = sum(r["confidence"] for r in results) / total
     latencies = [r["latency_ms"] for r in results]


### PR DESCRIPTION
## Summary
- Define `UNSUPPORTED_INTENTS` for intents not handled by the system
- Count `UNSUPPORTED` predictions as correct when the expected intent is unsupported and categories match

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a3213c7ab8832096bb0dad2004c2b7