### PR TITLE
chore: align quick intent enums and entity model

### DIFF
--- a/scripts/quick_intent_test.py
+++ b/scripts/quick_intent_test.py
@@ -7,7 +7,7 @@ import json
 import time
 import asyncio
 import os
-from typing import Dict, List, Any, Optional, Tuple
+from typing import Dict, List, Any, Optional, Tuple, Literal
 from pathlib import Path
 from datetime import datetime
 from enum import Enum
@@ -35,30 +35,70 @@ CATEGORY_MAP = {
 class IntentCategory(str, Enum):
     """Catégories d'intentions consultatives."""
     FINANCIAL_QUERY = "FINANCIAL_QUERY"
-    SPENDING_ANALYSIS = "SPENDING_ANALYSIS"
-    TREND_ANALYSIS = "TREND_ANALYSIS"
+    TRANSACTION_SEARCH = "TRANSACTION_SEARCH"
     BALANCE_INQUIRY = "BALANCE_INQUIRY"
     ACCOUNT_INFORMATION = "ACCOUNT_INFORMATION"
+
+    SPENDING_ANALYSIS = "SPENDING_ANALYSIS"
     BUDGET_ANALYSIS = "BUDGET_ANALYSIS"
+    TREND_ANALYSIS = "TREND_ANALYSIS"
+
     GREETING = "GREETING"
-    CONFIRMATION = "CONFIRMATION"
     CLARIFICATION = "CLARIFICATION"
-    UNCLEAR_INTENT = "UNCLEAR_INTENT"
-    UNKNOWN = "UNKNOWN"
+    CONFIRMATION = "CONFIRMATION"
+    GENERAL_QUESTION = "GENERAL_QUESTION"
+
+    EXPORT_REQUEST = "EXPORT_REQUEST"
     FILTER_REQUEST = "FILTER_REQUEST"
+    SORT_REQUEST = "SORT_REQUEST"
+    GOAL_TRACKING = "GOAL_TRACKING"
+
+    UNCLEAR_INTENT = "UNCLEAR_INTENT"
+    OUT_OF_SCOPE = "OUT_OF_SCOPE"
+
+    # Valeur supplémentaire spécifique au script
+    UNKNOWN = "UNKNOWN"
 
 class EntityType(str, Enum):
     """Types d'entités financières."""
+    # Monetary entities
     AMOUNT = "AMOUNT"
+    CURRENCY = "CURRENCY"
+    PERCENTAGE = "PERCENTAGE"
+
+    # Temporal entities
     DATE = "DATE"
     DATE_RANGE = "DATE_RANGE"
-    CATEGORY = "CATEGORY"
-    MERCHANT = "MERCHANT"
-    ACCOUNT = "ACCOUNT"
-    CURRENCY = "CURRENCY"
-    RECIPIENT = "RECIPIENT"
     RELATIVE_DATE = "RELATIVE_DATE"
+
+    # Account entities
+    ACCOUNT_TYPE = "ACCOUNT_TYPE"
+    ACCOUNT_NUMBER = "ACCOUNT_NUMBER"
+    IBAN = "IBAN"
+
+    # Transaction entities
     TRANSACTION_TYPE = "TRANSACTION_TYPE"
+    OPERATION_TYPE = "OPERATION_TYPE"
+    MERCHANT = "MERCHANT"
+    CATEGORY = "CATEGORY"
+    DESCRIPTION = "DESCRIPTION"
+
+    # Person/Organization entities
+    PERSON = "PERSON"
+    ORGANIZATION = "ORGANIZATION"
+    BANK = "BANK"
+
+    # Location entities
+    LOCATION = "LOCATION"
+    COUNTRY = "COUNTRY"
+
+    # Financial instruments
+    CARD_TYPE = "CARD_TYPE"
+    PAYMENT_METHOD = "PAYMENT_METHOD"
+
+    # Other
+    REFERENCE_NUMBER = "REFERENCE_NUMBER"
+    OTHER = "OTHER"
 
 class DetectionMethod(str, Enum):
     """Méthode de détection."""
@@ -72,19 +112,35 @@ class FinancialEntity(BaseModel):
     raw_value: str
     normalized_value: Any
     confidence: float = Field(ge=0.0, le=1.0)
+    start_position: Optional[int] = Field(default=None, ge=0)
+    end_position: Optional[int] = Field(default=None, ge=0)
     detection_method: DetectionMethod = DetectionMethod.LLM_BASED
-    position: Optional[Dict[str, int]] = None
-    validation_status: str = "valid"
-    
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    validation_status: Literal["valid", "invalid", "uncertain", "not_validated"] = "not_validated"
+    alternative_values: Optional[List[Any]] = None
+
+    @model_validator(mode='after')
+    def validate_positions(self) -> 'FinancialEntity':
+        if (self.start_position is not None and
+                self.end_position is not None and
+                self.end_position <= self.start_position):
+            raise ValueError("end_position must be greater than start_position")
+        return self
+
     def to_search_filter(self) -> Optional[Dict[str, Any]]:
         """Convertit l'entité en filtre de recherche."""
         if self.validation_status == "invalid":
             return None
-        return {
-            "type": self.entity_type.value,
-            "value": self.normalized_value,
-            "operator": "equals"
+        filter_map = {
+            EntityType.AMOUNT: {"field": "amount", "value": self.normalized_value},
+            EntityType.DATE: {"field": "date", "value": self.normalized_value},
+            EntityType.DATE_RANGE: {"field": "date", "value": self.normalized_value},
+            EntityType.CATEGORY: {"field": "category", "value": self.normalized_value},
+            EntityType.MERCHANT: {"field": "merchant", "value": self.normalized_value},
+            EntityType.TRANSACTION_TYPE: {"field": "transaction_type", "value": self.normalized_value},
+            EntityType.OPERATION_TYPE: {"field": "operation_type", "value": self.normalized_value},
         }
+        return filter_map.get(self.entity_type)
 
 class IntentResult(BaseModel):
     """Résultat complet de classification d'intention."""


### PR DESCRIPTION
## Summary
- expand IntentCategory and EntityType enums in quick_intent_test to include all values from canonical financial models
- extend FinancialEntity with start/end positions, metadata, and alternative values
- update to_search_filter to return field/value mapping

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a41158d47c83209a0688c79bf4038a