### PR TITLE
Add repo root to sys.path in intent benchmark

### DIFF
--- a/scripts/intent_benchmark.py
+++ b/scripts/intent_benchmark.py
@@ -1,12 +1,15 @@
+import sys
+from pathlib import Path
+
+repo_root = Path(__file__).resolve().parents[1]
+sys.path.append(str(repo_root))
+
 import asyncio
 import os
 import time
-from pathlib import Path
 from typing import Dict
 
 from quick_intent_test import HarenaIntentAgent, CATEGORY_MAP
-
-repo_root = Path(__file__).resolve().parents[1]
 
 try:  # Allow running as script or module
     from scripts.intent_utils import parse_intents_md


### PR DESCRIPTION
## Summary
- Ensure intent benchmark script appends repository root to `sys.path` for direct imports

## Testing
- `python scripts/intent_benchmark.py` *(fails: NameError: name 'Enum' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a4251cfba4832087aae4d3c64d1ae4