### PR TITLE
Add Enum import in quick intent test

### DIFF
--- a/scripts/quick_intent_test.py
+++ b/scripts/quick_intent_test.py
@@ -7,9 +7,11 @@ import json
 import time
 import asyncio
 import os
+from enum import Enum
 from typing import Dict, List, Any, Optional, Tuple, Literal
 from pathlib import Path
 from datetime import datetime
+from pydantic import BaseModel, Field, model_validator, field_validator
 import openai
 from openai import OpenAI, AsyncOpenAI
 from dotenv import load_dotenv


### PR DESCRIPTION
## Summary
- import Enum and required pydantic validators at the top of quick_intent_test script

## Testing
- `python scripts/intent_benchmark.py` *(fails: connection error)*

------
https://chatgpt.com/codex/tasks/task_e_68a429404e408320b32d1797600c55c2