### PR TITLE
Align account entity name with supported enum

### DIFF
--- a/scripts/quick_intent_test.py
+++ b/scripts/quick_intent_test.py
@@ -323,7 +323,7 @@ class HarenaIntentAgent:
             "- DATE/DATE_RANGE: Dates (janvier 2024) → format ISO",
             "- MERCHANT: Marchands (Carrefour, Netflix) → lowercase",
             "- CATEGORY: Catégories (alimentation, transport) → termes canoniques",
-            "- ACCOUNT: Comptes (livret A, compte courant) → identifiants standards",
+            "- ACCOUNT_TYPE: Types de comptes (livret A, compte courant) → identifiants standards",
             "",
             "RÈGLES IMPORTANTES:",
             "1. Toujours retourner un IntentResult complet avec tous les champs",
@@ -490,6 +490,10 @@ class HarenaIntentAgent:
         if self.cache_enabled and user_message in self.cache:
             cached_result = self.cache[user_message].copy()
             cached_result["processing_time_ms"] = 0.5  # Cache hit
+            # Harmoniser les anciens types d'entités
+            for ent in cached_result.get("entities", []):
+                if ent.get("entity_type") == "ACCOUNT":
+                    ent["entity_type"] = EntityType.ACCOUNT_TYPE.value
             result = IntentResult(**cached_result)
             errors = validate_intent_result_contract(result.model_dump())
             if errors:
@@ -516,7 +520,12 @@ class HarenaIntentAgent:
             
             # Parser la réponse JSON
             result_dict = json.loads(response.choices[0].message.content)
-            
+
+            # Harmoniser les types d'entités non supportés
+            for ent in result_dict.get("entities", []):
+                if ent.get("entity_type") == "ACCOUNT":
+                    ent["entity_type"] = EntityType.ACCOUNT_TYPE.value
+
             # Ajouter métadonnées
             processing_time = (time.time() - start_time) * 1000
             result_dict["processing_time_ms"] = processing_time


### PR DESCRIPTION
## Summary
- use `ACCOUNT_TYPE` in system prompt instead of unsupported `ACCOUNT`
- normalize legacy `ACCOUNT` entities from cache or model output to `ACCOUNT_TYPE`

## Testing
- `python - <<'PY'
from scripts.quick_intent_test import FinancialEntity, EntityType, IntentResult, IntentCategory, DetectionMethod
from conversation_service.utils.validators import validate_intent_result_contract

entity = FinancialEntity(
    entity_type=EntityType.ACCOUNT_TYPE,
    raw_value="compte courant",
    normalized_value="compte courant",
    confidence=0.95
)
result = IntentResult(
    intent_type="ACCOUNT_BALANCE_SPECIFIC",
    intent_category=IntentCategory.ACCOUNT_INFORMATION,
    confidence=0.9,
    entities=[entity],
    method=DetectionMethod.LLM_BASED,
    processing_time_ms=123.4,
)

print(result)
print('Validation errors:', validate_intent_result_contract(result.model_dump()))
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a42f35f3ac8320adb10c66014faec0