### PR TITLE
Remove UNKNOWN intent category and map unknown intents

### DIFF
--- a/INTENTS.md
+++ b/INTENTS.md
@@ -63,8 +63,8 @@ This document lists all intents recognized by Harena's MVP and their associated 
 
 | Intent Type | Category | Description | Suggested actions |
 | --- | --- | --- | --- |
-| UNCLEAR_INTENT | UNKNOWN | Intention ambiguë ou non reconnue | ["ask_to_rephrase"] |
-| UNKNOWN | UNKNOWN | Phrase inintelligible | ["ask_to_rephrase"] |
-| TEST_INTENT | UNKNOWN | Message de test («[TEST] ping») | ["no_action"] |
-| ERROR | UNKNOWN | Entrée corrompue | ["retry_or_contact_support"] |
+| UNCLEAR_INTENT | UNCLEAR_INTENT | Intention ambiguë ou non reconnue | ["ask_to_rephrase"] |
+| UNKNOWN | UNCLEAR_INTENT | Phrase inintelligible | ["ask_to_rephrase"] |
+| TEST_INTENT | UNCLEAR_INTENT | Message de test («[TEST] ping») | ["no_action"] |
+| ERROR | UNCLEAR_INTENT | Entrée corrompue | ["retry_or_contact_support"] |
 

--- a/scripts/quick_intent_test.py
+++ b/scripts/quick_intent_test.py
@@ -65,9 +65,6 @@ class IntentCategory(str, Enum):
     UNCLEAR_INTENT = "UNCLEAR_INTENT"
     OUT_OF_SCOPE = "OUT_OF_SCOPE"
 
-    # Valeur supplémentaire spécifique au script
-    UNKNOWN = "UNKNOWN"
-
 class EntityType(str, Enum):
     """Types d'entités financières."""
     # Monetary entities
@@ -485,10 +482,13 @@ class HarenaIntentAgent:
             IntentResult structuré et validé
         """
         start_time = time.time()
-        
+        allowed_categories = {cat.value for cat in IntentCategory}
+
         # Vérifier le cache
         if self.cache_enabled and user_message in self.cache:
             cached_result = self.cache[user_message].copy()
+            if cached_result.get("intent_category") not in allowed_categories:
+                cached_result["intent_category"] = IntentCategory.UNCLEAR_INTENT.value
             cached_result["processing_time_ms"] = 0.5  # Cache hit
             result = IntentResult(**cached_result)
             errors = validate_intent_result_contract(result.model_dump())
@@ -516,6 +516,8 @@ class HarenaIntentAgent:
             
             # Parser la réponse JSON
             result_dict = json.loads(response.choices[0].message.content)
+            if result_dict.get("intent_category") not in allowed_categories:
+                result_dict["intent_category"] = IntentCategory.UNCLEAR_INTENT.value
             
             # Ajouter métadonnées
             processing_time = (time.time() - start_time) * 1000


### PR DESCRIPTION
## Summary
- remove `UNKNOWN` from `IntentCategory` and schema
- normalize unexpected intent categories to `UNCLEAR_INTENT`
- align INTENTS table with new category

## Testing
- `pytest -q`
- `OPENAI_API_KEY=test python scripts/intent_benchmark.py` *(fails: Connection error)*

------
https://chatgpt.com/codex/tasks/task_e_68a42f3d03c0832089052752970373c0