### PR TITLE
Add detailed example for ACCOUNT_BALANCE_SPECIFIC intent

### DIFF
--- a/scripts/quick_intent_test.py
+++ b/scripts/quick_intent_test.py
@@ -312,9 +312,14 @@ class HarenaIntentAgent:
             example_intent = "UNSUPPORTED" if intent in unsupported else intent
             lines.append(f"- {intent} ({category}): {description}")
             if user_example:
-                lines.append(
-                    f"  Ex: \"{user_example}\" -> intent_type={example_intent}, intent_category={category}, entities=[]"
-                )
+                if intent == "ACCOUNT_BALANCE_SPECIFIC":
+                    lines.append(
+                        f"  Ex: \"{user_example}\" -> intent_type={example_intent}, intent_category={category}, entities=[{{entity_type:ACCOUNT_TYPE, raw_value:\"compte courant\", normalized_value:\"compte courant\"}}]"
+                    )
+                else:
+                    lines.append(
+                        f"  Ex: \"{user_example}\" -> intent_type={example_intent}, intent_category={category}, entities=[]"
+                    )
 
         lines += [
             "",
@@ -323,7 +328,7 @@ class HarenaIntentAgent:
             "- DATE/DATE_RANGE: Dates (janvier 2024) → format ISO",
             "- MERCHANT: Marchands (Carrefour, Netflix) → lowercase",
             "- CATEGORY: Catégories (alimentation, transport) → termes canoniques",
-            "- ACCOUNT: Comptes (livret A, compte courant) → identifiants standards",
+            "- ACCOUNT_TYPE: Comptes (livret A, compte courant) → identifiants standards",
             "",
             "RÈGLES IMPORTANTES:",
             "1. Toujours retourner un IntentResult complet avec tous les champs",


### PR DESCRIPTION
## Summary
- add detailed ACCOUNT_BALANCE_SPECIFIC example including ACCOUNT_TYPE entity
- clarify entities section to use ACCOUNT_TYPE

## Testing
- `python -m py_compile scripts/quick_intent_test.py`
- `pytest tests/test_intents_full.py::test_intents_full -q`
- `python scripts/intent_benchmark.py` *(fails: ProxyError 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a42f3edfd083208df8e6cb96bfda6a