### PR TITLE
Make conversation_service subpackage imports optional

### DIFF
--- a/conversation_service/__init__.py
+++ b/conversation_service/__init__.py
@@ -13,10 +13,18 @@ from . import agents
 
 # Expose commonly used subpackages when available
 __all__ = ["__version__", "__author__", "agents"]
-for _mod in ["api", "core", "models", "services", "utils"]:
-    try:
-        globals()[_mod] = __import__(f"{__name__}.{_mod}", fromlist=["*"])
-    except Exception:
-        continue
-    else:
-        __all__.append(_mod)
+
+# Automatic import of subpackages can lead to unexpected side effects
+# (e.g., loading configuration) when simply importing this package. To
+# avoid this, the behaviour is now opt-in via the environment variable
+# ``CS_AUTO_IMPORT_SUBPACKAGES``.
+import os
+
+if os.getenv("CS_AUTO_IMPORT_SUBPACKAGES") == "1":
+    for _mod in ["api", "core", "models", "services", "utils"]:
+        try:
+            globals()[_mod] = __import__(f"{__name__}.{_mod}", fromlist=["*"])
+        except Exception:
+            continue
+        else:
+            __all__.append(_mod)


### PR DESCRIPTION
## Summary
- prevent side effects when importing `conversation_service` by making subpackage auto-import opt-in

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a42f4084c08320bf6c4b316beef68b