### PR TITLE
Use OpenAI structured outputs for intent detection

### DIFF
--- a/conversation_service/agents/enhanced_llm_intent_agent.py
+++ b/conversation_service/agents/enhanced_llm_intent_agent.py
@@ -35,8 +35,9 @@ class EnhancedLLMIntentAgent(LLMIntentAgent):
         deepseek_client: DeepSeekClient,
         fallback_agent: Optional[BaseFinancialAgent] = None,
         config: Optional[AgentConfig] = None,
+        openai_client: Optional[Any] = None,
     ) -> None:
-        super().__init__(deepseek_client=deepseek_client, config=config)
+        super().__init__(deepseek_client=deepseek_client, config=config, openai_client=openai_client)
         self.fallback_agent = fallback_agent
 
     async def detect_intent(self, user_message: str, user_id: int) -> Dict[str, Any]:

--- a/tests/test_llm_intent_agent.py
+++ b/tests/test_llm_intent_agent.py
@@ -3,49 +3,60 @@ import conversation_service.agents.base_financial_agent as base_financial_agent
 base_financial_agent.AUTOGEN_AVAILABLE = True
 
 from conversation_service.agents.llm_intent_agent import LLMIntentAgent
-from conversation_service.models.financial_models import EntityType
+from conversation_service.models.financial_models import EntityType, IntentCategory
 
 
 class DummyDeepSeekClient:
     api_key = "test-key"
-    base_url = "http://api.example.com"
+    base_url = "https://api.openai.com/v1"
 
-    async def generate_response(self, messages, temperature, max_tokens, user, use_cache):
-        class Response:
-            content = (
-                '{"intent": "SEARCH_BY_MERCHANT", '
-                '"entities": [{"type": "MERCHANT", "value": "Netflix"}]}'
-            )
 
-        return Response()
+class DummyOpenAIClient:
+    def __init__(self, content: str):
+        self._content = content
+
+        class _Completions:
+            async def create(_self, *args, **kwargs):
+                class Choice:
+                    message = type("Msg", (), {"content": content})
+
+                return type("Resp", (), {"choices": [Choice()]})
+
+        class _Chat:
+            def __init__(self):
+                self.completions = _Completions()
+
+        self.chat = _Chat()
 
 
 def test_llm_intent_agent_parses_output_correctly():
-    agent = LLMIntentAgent(deepseek_client=DummyDeepSeekClient())
+    openai_client = DummyOpenAIClient(
+        '{"intent_type": "SEARCH_BY_MERCHANT", "intent_category": "TRANSACTION_SEARCH", "confidence": 0.77, "entities": [{"entity_type": "MERCHANT", "value": "Netflix"}]}'
+    )
+    agent = LLMIntentAgent(
+        deepseek_client=DummyDeepSeekClient(), openai_client=openai_client
+    )
     result = asyncio.run(
         agent.detect_intent("Combien j’ai dépensé pour Netflix ce mois ?", user_id=1)
     )
     intent_result = result["metadata"]["intent_result"]
     assert intent_result.intent_type == "SEARCH_BY_MERCHANT"
+    assert intent_result.confidence == 0.77
     merchant = next(
         e for e in intent_result.entities if e.entity_type == EntityType.MERCHANT
     )
     assert merchant.normalized_value == "Netflix"
+    assert merchant.confidence == 0.77
 
 
-class DummyDeepSeekClientSearchByText:
-    api_key = "test-key"
-    base_url = "http://api.example.com"
-
-    async def generate_response(self, messages, temperature, max_tokens, user, use_cache):
-        class Response:
-            content = '{"intent": "SEARCH_BY_TEXT", "entities": []}'
-
-        return Response()
-
-
-def test_llm_intent_agent_parses_search_by_text():
-    agent = LLMIntentAgent(deepseek_client=DummyDeepSeekClientSearchByText())
-    result = asyncio.run(agent.detect_intent("Recherche textuelle", user_id=1))
+def test_category_mapping_applied():
+    openai_client = DummyOpenAIClient(
+        '{"intent_type": "BALANCE_CHECK", "intent_category": "ACCOUNT_BALANCE", "confidence": 0.9, "entities": []}'
+    )
+    agent = LLMIntentAgent(
+        deepseek_client=DummyDeepSeekClient(), openai_client=openai_client
+    )
+    result = asyncio.run(agent.detect_intent("Quel est mon solde ?", user_id=1))
     intent_result = result["metadata"]["intent_result"]
-    assert intent_result.intent_type == "SEARCH_BY_TEXT"
+    assert intent_result.intent_type == "BALANCE_CHECK"
+    assert intent_result.intent_category == IntentCategory.BALANCE_INQUIRY


### PR DESCRIPTION
## Summary
- switch `LLMIntentAgent` to OpenAI's `gpt-4o-mini` with structured outputs
- add category mapping and confidence propagation for intent entities
- extend `EnhancedLLMIntentAgent` and tests for OpenAI based detection

## Testing
- `pytest tests/test_llm_intent_agent.py tests/test_enhanced_llm_intent_agent.py -q`
- `pip install python-dotenv -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4561b7fa88320b75d4e0a248ac576