### PR TITLE
feat: allow gpt models in agent config

### DIFF
--- a/conversation_service/models/agent_models.py
+++ b/conversation_service/models/agent_models.py
@@ -2,8 +2,9 @@
 Agent models for AutoGen v0.4 integration in Conversation Service MVP.
 
 This module defines the core data models for AutoGen agents, including
-configuration, responses, and team workflow management. These models
-are optimized for the financial conversation use case with DeepSeek LLM.
+configuration, responses, and team workflow management. While initially
+optimized for the financial conversation use case with DeepSeek LLM, the
+models now support additional LLM providers such as OpenAI's GPT family.
 
 Classes:
     - AgentConfig: Configuration model for AutoGen agents
@@ -28,11 +29,12 @@ class AgentConfig(BaseModel):
     
     This model defines the complete configuration for an AutoGen agent,
     including model client settings, system messages, and behavioral parameters.
-    Optimized for DeepSeek integration and financial domain specialization.
+    Optimized for financial domain specialization and compatible with multiple
+    LLM providers (e.g., DeepSeek, OpenAI GPT).
     
     Attributes:
         name: Unique identifier for the agent
-        model_client_config: DeepSeek model configuration
+        model_client_config: LLM model configuration (DeepSeek, OpenAI, etc.)
         system_message: System prompt for the agent's behavior
         max_consecutive_auto_reply: Maximum consecutive auto-replies
         description: Optional description of agent's purpose
@@ -52,7 +54,7 @@ class AgentConfig(BaseModel):
     
     model_client_config: Dict[str, Any] = Field(
         ...,
-        description="DeepSeek model client configuration"
+        description="LLM model client configuration"
     )
     
     system_message: str = Field(
@@ -110,15 +112,19 @@ class AgentConfig(BaseModel):
     @field_validator("model_client_config")
     @classmethod
     def validate_model_config(cls, v: Dict[str, Any]) -> Dict[str, Any]:
-        """Validate DeepSeek model configuration."""
+        """Validate model configuration for supported LLM providers."""
         required_keys = ["model", "api_key", "base_url"]
         for key in required_keys:
             if key not in v:
                 raise ValueError(f"Missing required key '{key}' in model_client_config")
         
-        # Validate DeepSeek model format
-        if not v["model"].startswith("deepseek-"):
-            raise ValueError("Model must be a DeepSeek model (start with 'deepseek-')")
+        # Validate model format for known providers
+        supported_prefixes = ("deepseek-", "gpt-")
+        if not any(v["model"].startswith(prefix) for prefix in supported_prefixes):
+            raise ValueError(
+                "Model must start with a supported prefix: "
+                + ", ".join(supported_prefixes)
+            )
             
         return v
     
@@ -135,9 +141,9 @@ class AgentConfig(BaseModel):
             "example": {
                 "name": "intent_classifier_agent",
                 "model_client_config": {
-                    "model": "deepseek-chat",
+                    "model": "gpt-4o-mini",
                     "api_key": "sk-xxx",
-                    "base_url": "https://api.deepseek.com"
+                    "base_url": "https://api.openai.com/v1"
                 },
                 "system_message": "You are a financial intent classification agent...",
                 "max_consecutive_auto_reply": 3,

--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -1,0 +1,32 @@
+import pytest
+
+from conversation_service.models.agent_models import AgentConfig
+
+
+def test_agent_config_accepts_deepseek_model():
+    config = AgentConfig(
+        name="test-deepseek",
+        model_client_config={
+            "model": "deepseek-chat",
+            "api_key": "sk-test",
+            "base_url": "https://api.deepseek.com",
+        },
+        system_message="You are a test agent for DeepSeek models.",
+    )
+
+    assert config.model_client_config["model"] == "deepseek-chat"
+
+
+def test_agent_config_accepts_gpt_model():
+    config = AgentConfig(
+        name="test-gpt",
+        model_client_config={
+            "model": "gpt-4o-mini",
+            "api_key": "sk-test",
+            "base_url": "https://api.openai.com/v1",
+        },
+        system_message="You are a test agent for GPT models.",
+    )
+
+    assert config.model_client_config["model"].startswith("gpt-")
+


### PR DESCRIPTION
## Summary
- extend AgentConfig validation to support GPT models in addition to DeepSeek
- document multi-LLM compatibility with GPT-based example
- test AgentConfig initialization with a gpt model

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4e87f296483208243c9746556affa