### PR TITLE
use dedicated OpenAI key for intent detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ initialization so that every call is properly authenticated.
 
 ## Environment Variables
 
+`OPENAI_API_KEY` provides the API key used by the `LLMIntentAgent` for intent
+detection. If not set, the agent falls back to the DeepSeek key.
+
 `SEARCH_SERVICE_URL` sets the base URL for the Search Service. It defaults to
 `http://localhost:8000/api/v1/search` and the service automatically appends
 `/search` when issuing queries.

--- a/config_service/config.py
+++ b/config_service/config.py
@@ -135,7 +135,7 @@ class GlobalSettings(BaseSettings):
     DEEPSEEK_EXPECTED_LATENCY_MS: int = int(os.environ.get("DEEPSEEK_EXPECTED_LATENCY_MS", "1500"))
     
     # ==========================================
-    # CONFIGURATION OPENAI POUR LES EMBEDDINGS
+    # CONFIGURATION OPENAI POUR LES EMBEDDINGS ET L'INTENT DETECTION
     # ==========================================
     OPENAI_API_KEY: str = os.environ.get("OPENAI_API_KEY", "")
     EMBEDDING_MODEL: str = os.environ.get("EMBEDDING_MODEL", "text-embedding-3-small")

--- a/conversation_service/agents/llm_intent_agent.py
+++ b/conversation_service/agents/llm_intent_agent.py
@@ -15,6 +15,7 @@ import asyncio
 import json
 import time
 import logging
+import os
 from typing import Any, Dict, List, Optional
 
 try:  # pragma: no cover - library may be absent in tests
@@ -60,12 +61,13 @@ class LLMIntentAgent(BaseFinancialAgent):
         config: Optional[AgentConfig] = None,
         openai_client: Optional[Any] = None,
     ) -> None:
+        api_key = os.getenv("OPENAI_API_KEY") or deepseek_client.api_key
         if config is None:
             config = AgentConfig(
                 name="llm_intent_agent",
                 model_client_config={
                     "model": "gpt-4o-mini",
-                    "api_key": deepseek_client.api_key,
+                    "api_key": api_key,
                     "base_url": "https://api.openai.com/v1",
                 },
                 system_message=self._build_system_message(),
@@ -75,6 +77,8 @@ class LLMIntentAgent(BaseFinancialAgent):
                 max_tokens=200,
                 timeout_seconds=8,
             )
+        else:
+            config.model_client_config["api_key"] = api_key
 
         super().__init__(name=config.name, config=config, deepseek_client=deepseek_client)
         self._intent_cache = IntentResultCache(max_size=100)

--- a/tests/test_llm_intent_agent.py
+++ b/tests/test_llm_intent_agent.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import conversation_service.agents.base_financial_agent as base_financial_agent
 base_financial_agent.AUTOGEN_AVAILABLE = True
 
@@ -30,12 +31,14 @@ class DummyOpenAIClient:
 
 
 def test_llm_intent_agent_parses_output_correctly():
+    os.environ["OPENAI_API_KEY"] = "openai-test-key"
     openai_client = DummyOpenAIClient(
         '{"intent_type": "SEARCH_BY_MERCHANT", "intent_category": "TRANSACTION_SEARCH", "confidence": 0.77, "entities": [{"entity_type": "MERCHANT", "value": "Netflix"}]}'
     )
     agent = LLMIntentAgent(
         deepseek_client=DummyDeepSeekClient(), openai_client=openai_client
     )
+    assert agent.config.model_client_config["api_key"] == "openai-test-key"
     result = asyncio.run(
         agent.detect_intent("Combien j’ai dépensé pour Netflix ce mois ?", user_id=1)
     )
@@ -50,12 +53,14 @@ def test_llm_intent_agent_parses_output_correctly():
 
 
 def test_category_mapping_applied():
+    os.environ["OPENAI_API_KEY"] = "openai-test-key"
     openai_client = DummyOpenAIClient(
         '{"intent_type": "BALANCE_CHECK", "intent_category": "ACCOUNT_BALANCE", "confidence": 0.9, "entities": []}'
     )
     agent = LLMIntentAgent(
         deepseek_client=DummyDeepSeekClient(), openai_client=openai_client
     )
+    assert agent.config.model_client_config["api_key"] == "openai-test-key"
     result = asyncio.run(agent.detect_intent("Quel est mon solde ?", user_id=1))
     intent_result = result["metadata"]["intent_result"]
     assert intent_result.intent_type == "BALANCE_CHECK"


### PR DESCRIPTION
## Summary
- read `OPENAI_API_KEY` for `LLMIntentAgent`, falling back to DeepSeek key
- document `OPENAI_API_KEY` in configuration and README
- ensure tests assert that a dedicated OpenAI key is used

## Testing
- `pytest tests/test_llm_intent_agent.py tests/test_enhanced_llm_intent_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_68a5815595248320aa2d2a3eb5097e02