### PR TITLE
Align intent prompts and agent with benchmark taxonomy

### DIFF
--- a/scripts/test_harena_chat_direct.py
+++ b/scripts/test_harena_chat_direct.py
@@ -177,7 +177,7 @@ def main() -> None:
 
     # ----- RÉSUMÉ EXÉCUTIF ---------------------------------------------------
     print("📋 RÉSUMÉ EXÉCUTIF :")
-    print(f"   🎯 Intention correctement détectée : {'✅' if intent_result['intent_type'] == 'TRANSACTION_SEARCH' else '❌'}")
+    print(f"   🎯 Intention correctement détectée : {'✅' if intent_result['intent_type'] == 'SEARCH_BY_AMOUNT' else '❌'}")
     print(f"   🧩 Entités extraites : {'✅' if len(entities) > 0 else '❌'}")
     print(f"   🔍 Recherche exécutée : {'✅' if 'search_results_count' in chat_data['metadata'] else '❌'}")
     print(f"   💬 Réponse générée : {'✅' if len(response_text) > 50 else '❌'}")
@@ -185,7 +185,7 @@ def main() -> None:
     
     # Cohérence globale
     coherence_score = sum([
-        intent_result['intent_type'] == 'TRANSACTION_SEARCH',
+        intent_result['intent_type'] == 'SEARCH_BY_AMOUNT',
         len(entities) > 0,
         'search_results_count' in chat_data['metadata'],
         len(response_text) > 50,


### PR DESCRIPTION
## Summary
- Replace legacy intent list with benchmark taxonomy and refresh few-shot examples
- Expect `intent_type` and `intent_category` in `LLMIntentAgent` and cache
- Update direct chat test validation for new SEARCH_BY_AMOUNT intent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a58601d1d48320a358bc65a39a0b89