### PR TITLE
Expose search results count in workflow metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,26 @@ detection. If not set, the agent falls back to the DeepSeek key.
 `http://localhost:8000/api/v1/search` and the service automatically appends
 `/search` when issuing queries.
 
+## `metadata.workflow_data`
+
+The conversation API (`/conversation/chat`) includes a `metadata` object in its
+response. A nested `workflow_data` dictionary exposes details collected during
+the multi‑agent workflow:
+
+| Key | Type | Description |
+| --- | --- | --- |
+| `user_message` | `str` | Original message provided by the user |
+| `conversation_id` | `str` | Identifier of the conversation |
+| `intent_result` | `IntentResult` | Structured intent detection output |
+| `search_results` | `AgentResponse \| list \| None` | Raw search results returned by the `SearchQueryAgent` (optional) |
+| `final_response` | `str \| None` | Final text returned to the user |
+| `search_error` | `bool` | Indicates whether the search step failed |
+| `search_results_count` | `int` | Number of items found by the search agent |
+
+The key `search_results_count` is always present and can be used to quickly know
+how many results were returned without inspecting the full `search_results`
+payload.
+
 ## Intentions supportées
 
 Le `LLMIntentAgent` répond toujours avec un objet JSON structuré et ne produit

--- a/conversation_service/agents/orchestrator_agent.py
+++ b/conversation_service/agents/orchestrator_agent.py
@@ -643,6 +643,10 @@ class OrchestratorAgent(BaseFinancialAgent):
                     "intent_result": intent_result_dump,
                     "agent_chain": agent_chain,
                     "search_results_count": search_results_count,
+                    "workflow_data": {
+                        "search_results_count": search_results_count,
+                        "search_results": workflow_data.get("search_results"),
+                    },
                 },
                 "confidence_score": self._calculate_workflow_confidence(workflow_result),
                 "token_usage": self._aggregate_token_usage(workflow_result),
@@ -664,6 +668,10 @@ class OrchestratorAgent(BaseFinancialAgent):
                     "intent_result": None,
                     "agent_chain": ["orchestrator_agent"],
                     "search_results_count": 0,
+                    "workflow_data": {
+                        "search_results_count": 0,
+                        "search_results": None,
+                    },
                 },
                 "confidence_score": 0.1
             }

--- a/scripts/test_harena_chat_direct.py
+++ b/scripts/test_harena_chat_direct.py
@@ -95,24 +95,25 @@ def main() -> None:
     print("🔍 ANALYSE DE LA RECHERCHE :")
     
     # Extraire les informations de recherche depuis les métadonnées
-    # Nouvel affichage : utiliser la taille réelle des résultats de recherche
     metadata = chat_data.get("metadata", {})
     workflow_data = metadata.get("workflow_data", {})
 
-    search_results = []
+    search_results_count = 0
     if isinstance(workflow_data, dict):
-        sr = workflow_data.get("search_results")
-        if isinstance(sr, dict):
-            # Structure attendue : {"metadata": {"search_response": {"results": [...]}}}
-            search_response = sr.get("metadata", {}).get("search_response", {})
-            results = search_response.get("results") if isinstance(search_response, dict) else None
-            if isinstance(results, list):
-                search_results = results
-        elif isinstance(sr, list):
-            # Certains scénarios peuvent fournir directement une liste
-            search_results = sr
+        # Priorité à la clé directe fournie par l'orchestrateur
+        if isinstance(workflow_data.get("search_results_count"), int):
+            search_results_count = workflow_data["search_results_count"]
+        else:
+            # Rétrocompatibilité : calculer à partir de la structure détaillée
+            sr = workflow_data.get("search_results")
+            if isinstance(sr, dict):
+                search_response = sr.get("metadata", {}).get("search_response", {})
+                results = search_response.get("results") if isinstance(search_response, dict) else None
+                if isinstance(results, list):
+                    search_results_count = len(results)
+            elif isinstance(sr, list):
+                search_results_count = len(sr)
 
-    search_results_count = len(search_results)
     print(f"   📊 Résultats trouvés par l'agent : {search_results_count}")
     
     # Analyser les entités pour comprendre la requête générée


### PR DESCRIPTION
## Summary
- include search results count and payload in orchestrator metadata
- read new workflow_data.search_results_count in chat analysis script
- document metadata.workflow_data schema

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5860a3a7083208db3a27c7d0ae5ae