### PR TITLE
Limit search query to a single request

### DIFF
--- a/tests/test_search_end_to_end.py
+++ b/tests/test_search_end_to_end.py
@@ -403,23 +403,28 @@ def test_agent_aggregates_paginated_results(monkeypatch):
     async def dummy_extract(message, intent_result, user_id):
         return []
 
-    async def dummy_generate(intent_result, user_message, user_id, enhanced_entities=None):
+    async def dummy_generate(
+        intent_result, user_message, user_id, enhanced_entities=None, limit=None, offset=0
+    ):
         return SearchServiceQuery(
             query_metadata=QueryMetadata(
                 conversation_id="c1", user_id=user_id, intent_type="TEST"
             ),
-            search_parameters=SearchParameters(max_results=1, offset=0),
+            search_parameters=SearchParameters(max_results=1, offset=offset),
             filters=SearchFilters(),
         )
 
+    calls = []
+
     async def dummy_execute(query):
         offset = query.search_parameters.offset
+        calls.append(offset)
         meta = ResponseMetadata(
             query_id="q1",
             processing_time_ms=1.0,
             total_results=3,
             returned_results=1,
-            has_more_results=offset < 2,
+            has_more_results=True,
             search_strategy_used="semantic",
         )
         return SearchServiceResponse(
@@ -443,5 +448,6 @@ def test_agent_aggregates_paginated_results(monkeypatch):
 
     response = asyncio.run(agent.process_search_request(intent_result, "msg", user_id=1))
     results = response["metadata"]["search_response"]["results"]
-    assert len(results) == 3
+    assert len(results) == 1
+    assert calls == [0]
 


### PR DESCRIPTION
## Summary
- avoid multiple search service requests by adding a configurable result limit and offset
- simplify SearchQueryAgent to make only one search request
- add tests ensuring only one call is made during search_query stage

## Testing
- `pytest tests/test_search_query_agent.py tests/test_search_end_to_end.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5860ed04483208dac2f51b7653a4a