### PR TITLE
refactor: remove mock intent env toggle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Example environment configuration for Harena
+DEEPSEEK_API_KEY=your_api_key_here
+OPENAI_API_KEY=
+SEARCH_SERVICE_URL=http://localhost:8000/api/v1/search
+
+# The mock intent agent must now be injected explicitly.
+# The former USE_MOCK_INTENT_AGENT toggle has been removed.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ detection. If not set, the agent falls back to the DeepSeek key.
 `http://localhost:8000/api/v1/search` and the service automatically appends
 `/search` when issuing queries.
 
+The `USE_MOCK_INTENT_AGENT` toggle has been removed. To exercise the
+`MockIntentAgent` (for example during tests), inject it explicitly instead of
+setting an environment variable.
+
 ## `metadata.workflow_data`
 
 The conversation API (`/conversation/chat`) includes a `metadata` object in its

--- a/conversation_service/core/mvp_team_manager.py
+++ b/conversation_service/core/mvp_team_manager.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass
 
 from ..core.deepseek_client import DeepSeekClient
 from ..agents.llm_intent_agent import LLMIntentAgent
-from ..agents.mock_intent_agent import MockIntentAgent
+from ..agents.mock_intent_agent import MockIntentAgent  # noqa: F401 - kept for manual injection
 from ..agents.search_query_agent import SearchQueryAgent
 from ..agents.response_agent import ResponseAgent
 from .conversation_manager import ConversationManager
@@ -445,10 +445,7 @@ class MVPTeamManager:
         """Initialize all specialized agents."""
         try:
             # Intent detection agent
-            intent_cls = LLMIntentAgent
-            if os.getenv("USE_MOCK_INTENT_AGENT", "false").lower() == "true":
-                intent_cls = MockIntentAgent
-            self.agents["intent_agent"] = intent_cls(
+            self.agents["intent_agent"] = LLMIntentAgent(
                 deepseek_client=self.deepseek_client
             )
             


### PR DESCRIPTION
## Summary
- remove USE_MOCK_INTENT_AGENT env toggle and always use LLMIntentAgent
- document manual injection of MockIntentAgent and update example `.env`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a58ff10eb88320a025d403408ef2ae