### PR TITLE
Use dedicated OpenAI key with fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ initialization so that every call is properly authenticated.
 
 ## Environment Variables
 
-`OPENAI_API_KEY` provides the API key used by the `LLMIntentAgent` for intent
-detection. If not set, the agent falls back to the DeepSeek key.
+`OPENAI_API_KEY` provides the dedicated API key used by the `LLMIntentAgent`
+for intent detection. If this variable is missing, the agent reuses the
+`DEEPSEEK_API_KEY` value as a fallback.
 
 `SEARCH_SERVICE_URL` sets the base URL for the Search Service. It defaults to
 `http://localhost:8000/api/v1/search` and the service automatically appends

--- a/config_service/config.py
+++ b/config_service/config.py
@@ -136,6 +136,8 @@ class GlobalSettings(BaseSettings):
     
     # ==========================================
     # CONFIGURATION OPENAI POUR LES EMBEDDINGS ET L'INTENT DETECTION
+    # Clé API dédiée à OpenAI (llm_intent_agent). Si elle est absente,
+    # la clé DeepSeek est utilisée en repli.
     # ==========================================
     OPENAI_API_KEY: str = os.environ.get("OPENAI_API_KEY", "")
     EMBEDDING_MODEL: str = os.environ.get("EMBEDDING_MODEL", "text-embedding-3-small")

--- a/conversation_service/agents/llm_intent_agent.py
+++ b/conversation_service/agents/llm_intent_agent.py
@@ -61,7 +61,11 @@ class LLMIntentAgent(BaseFinancialAgent):
         config: Optional[AgentConfig] = None,
         openai_client: Optional[Any] = None,
     ) -> None:
-        api_key = os.getenv("OPENAI_API_KEY") or deepseek_client.api_key
+        # Prefer a dedicated OpenAI key if provided; otherwise reuse the
+        # DeepSeek key as a fallback for backward compatibility.
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            api_key = deepseek_client.api_key
         if config is None:
             config = AgentConfig(
                 name="llm_intent_agent",

--- a/tests/test_openai_key_loading.py
+++ b/tests/test_openai_key_loading.py
@@ -1,0 +1,37 @@
+from conversation_service.agents.llm_intent_agent import LLMIntentAgent
+
+
+class DummyDeepSeekClient:
+    api_key = "deepseek-fallback"
+    base_url = "https://api.openai.com/v1"
+
+
+class DummyOpenAIClient:
+    def __init__(self):
+        class _Completions:
+            async def create(_self, *args, **kwargs):
+                class Choice:
+                    message = type("Msg", (), {"content": "{}"})
+                return type("Resp", (), {"choices": [Choice()]})
+
+        class _Chat:
+            def __init__(self):
+                self.completions = _Completions()
+
+        self.chat = _Chat()
+
+
+def test_llm_intent_agent_prefers_openai_key(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-test-key")
+    agent = LLMIntentAgent(
+        deepseek_client=DummyDeepSeekClient(), openai_client=DummyOpenAIClient()
+    )
+    assert agent.config.model_client_config["api_key"] == "openai-test-key"
+
+
+def test_llm_intent_agent_falls_back_to_deepseek_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    agent = LLMIntentAgent(
+        deepseek_client=DummyDeepSeekClient(), openai_client=DummyOpenAIClient()
+    )
+    assert agent.config.model_client_config["api_key"] == "deepseek-fallback"


### PR DESCRIPTION
## Summary
- read `OPENAI_API_KEY` from the environment in `LLMIntentAgent` and fall back to the DeepSeek key
- document `OPENAI_API_KEY` in configuration and README
- test key loading and fallback behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a58fee72bc832093278a09eb000675