### PR TITLE
Log bcrypt version with fallback to __about__

### DIFF
--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,29 @@
+import sys
+import importlib
+import types
+
+
+def test_bcrypt_version_without_about(monkeypatch):
+    """Assure que l'import de security fonctionne même sans __about__."""
+    import bcrypt
+
+    # Supprimer l'attribut __about__ pour simuler les anciennes versions
+    monkeypatch.delattr(bcrypt, "__about__", raising=False)
+
+    # Injecter un module de configuration minimal pour éviter les dépendances
+    dummy_cfg = types.ModuleType("config_service.config")
+    dummy_cfg.settings = types.SimpleNamespace(
+        ACCESS_TOKEN_EXPIRE_MINUTES=15,
+        SECRET_KEY="test",
+    )
+    pkg = types.ModuleType("config_service")
+    pkg.config = dummy_cfg
+    sys.modules["config_service"] = pkg
+    sys.modules["config_service.config"] = dummy_cfg
+
+    # Réimporter le module de sécurité avec le module bcrypt modifié
+    sys.modules.pop("user_service.core.security", None)
+    security = importlib.import_module("user_service.core.security")
+
+    assert security.bcrypt_version == bcrypt.__version__
+

--- a/user_service/core/security.py
+++ b/user_service/core/security.py
@@ -12,20 +12,16 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Vérification de la disponibilité de bcrypt
+bcrypt_version = "unknown"
 try:
     import bcrypt
-    # Gestion des différentes versions de bcrypt
-    try:
-        # Anciennes versions
-        bcrypt_version = bcrypt.__about__.__version__
-    except AttributeError:
-        try:
-            # Nouvelles versions
-            bcrypt_version = bcrypt.__version__
-        except AttributeError:
-            # Version non disponible
-            bcrypt_version = "unknown"
-    
+
+    # Préférence pour bcrypt.__version__ avec repli sur __about__
+    bcrypt_version = getattr(bcrypt, "__version__", None)
+    if not bcrypt_version:
+        about = getattr(bcrypt, "__about__", {})
+        bcrypt_version = getattr(about, "__version__", getattr(about, "get", lambda *a: "unknown")("__version__"))
+
     logger.info(f"bcrypt version: {bcrypt_version}")
 except ImportError:
     logger.error("bcrypt module not found. Please install it with 'pip install bcrypt'")


### PR DESCRIPTION
## Summary
- ensure bcrypt version is logged using `bcrypt.__version__` with a fallback to `__about__`
- add regression test verifying version detection when `__about__` is missing

## Testing
- `pytest tests/test_security.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5943cb8c88320b324b752b4c7e529