### PR TITLE
Add amount comparison action detection

### DIFF
--- a/conversation_service/agents/llm_intent_agent.py
+++ b/conversation_service/agents/llm_intent_agent.py
@@ -245,10 +245,12 @@ class LLMIntentAgent(BaseFinancialAgent):
         except Exception as err:  # pragma: no cover - parsing errors
             raise LLMOutputParsingError(f"Invalid JSON in LLM response: {err}") from err
         suggested_actions = data.get("suggested_actions")
-        if suggested_actions is None:
-            suggested_actions = self._detect_amount_actions(user_message)
-        elif isinstance(suggested_actions, str):
+        if isinstance(suggested_actions, str):
             suggested_actions = [suggested_actions]
+        if not suggested_actions:
+            # When the LLM omits the field or returns an empty list we try to
+            # infer the action heuristically from the user message.
+            suggested_actions = self._detect_amount_actions(user_message)
 
         intent_type = data.get("intent_type", "OUT_OF_SCOPE")
         raw_category = data.get("intent_category", "GENERAL_QUESTION").upper()

--- a/conversation_service/prompts/intent_prompts.py
+++ b/conversation_service/prompts/intent_prompts.py
@@ -88,7 +88,8 @@ Réponds uniquement avec un JSON ayant la structure suivante :
 Chaque entité doit contenir les champs ``entity_type``, ``value`` et ``confidence``.
 
 Inclure le champ optionnel ``suggested_actions`` lorsque le message contient des
-comparatifs de montant ("supérieur", "plus de", "inférieur", "moins de").
+comparatifs de montant ("supérieur", "plus de", "inférieur", "moins de") en
+utilisant ``filter_by_amount_greater`` ou ``filter_by_amount_less`` selon le cas.
 
 **Exemple avec montant** :
 ```
@@ -185,6 +186,14 @@ INTENT_CATEGORY: FINANCIAL_QUERY
 CONFIDENCE: 0.96
 ENTITIES: {"amounts": ["100 €"]}
 SUGGESTED_ACTIONS: ["filter_by_amount_greater"]
+
+**Exemple 8 - Comparatif montant inférieur :**
+MESSAGE: "Transactions inférieures à 50 €"
+INTENT_TYPE: SEARCH_BY_AMOUNT
+INTENT_CATEGORY: FINANCIAL_QUERY
+CONFIDENCE: 0.95
+ENTITIES: {"amounts": ["50 €"]}
+SUGGESTED_ACTIONS: ["filter_by_amount_less"]
 """
 
 # =============================================================================

--- a/tests/test_search_end_to_end.py
+++ b/tests/test_search_end_to_end.py
@@ -499,7 +499,7 @@ def test_amount_detection_filters_transactions():
         intent_agent.detect_intent("transactions supérieures à 100 €", user_id=1)
     )
     intent_result = intent_data["metadata"]["intent_result"]
-    intent_result.suggested_actions = ["filter_by_amount_greater"]
+    assert intent_result.suggested_actions == ["filter_by_amount_greater"]
 
     search_agent = SearchQueryAgent(
         deepseek_client=DummyDeepSeekClient(),
@@ -511,11 +511,12 @@ def test_amount_detection_filters_transactions():
         )
     )
     request_dict = search_contract.to_search_request()
+    assert request_dict["filters"].get("amount_abs", {}).get("gte") == 100
     engine = SearchEngine(
-        cache_enabled=False, elasticsearch_client=DummyElasticsearchClientHighAmount()
+        cache_enabled=False, elasticsearch_client=DummyElasticsearchClientHighAmountMany()
     )
     response = asyncio.run(engine.search(SearchRequest(**request_dict)))
-    assert len(response["results"]) == 2
+    assert len(response["results"]) == 58
 
 
 def test_agent_aggregates_paginated_results(monkeypatch):


### PR DESCRIPTION
## Summary
- infer greater/less-than amount actions when LLM omits them
- document amount comparison actions in intent prompts
- test that queries over 100€ map to `amount_abs.gte` and return 58 hits

## Testing
- `pytest tests/test_llm_intent_agent.py tests/test_search_end_to_end.py::test_amount_detection_filters_transactions -q`
- `pytest tests/test_search_query_agent.py -q`
- `pytest tests/test_search_end_to_end.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a59c1ee5e883208cf9e38afbbd3b97