### PR TITLE
Handle fallback result in EnhancedLLMIntentAgent

### DIFF
--- a/conversation_service/agents/enhanced_llm_intent_agent.py
+++ b/conversation_service/agents/enhanced_llm_intent_agent.py
@@ -46,43 +46,24 @@ class EnhancedLLMIntentAgent(LLMIntentAgent):
         start_time = time.perf_counter()
         try:
             result = await super().detect_intent(user_message, user_id)
-            intent_result: IntentResult = result["metadata"]["intent_result"]
-            intent_result.processing_time_ms = (
-                time.perf_counter() - start_time
-            ) * 1000
-            # If LLM failed and fallback is available, use fallback result
             if (
                 self.fallback_agent
-                and intent_result.intent_type == "OUT_OF_SCOPE"
-                and intent_result.confidence == 0.0
-            ):
-                raise RuntimeError("LLM intent detection failed")
-            if (
-                intent_result.intent_type == "OUT_OF_SCOPE"
-                and self.fallback_agent is not None
+                and result["metadata"].get("detection_method")
+                == DetectionMethod.FALLBACK
             ):
                 fallback = await self.fallback_agent.detect_intent(
                     user_message, user_id
                 )
                 intent_result = fallback["metadata"]["intent_result"]
-                intent_result.method = DetectionMethod.FALLBACK
                 intent_result.processing_time_ms = (
                     time.perf_counter() - start_time
                 ) * 1000
-                fallback["metadata"].update(
-                    {
-                        "detection_method": DetectionMethod.FALLBACK,
-                        "intent_result": intent_result,
-                        "confidence": intent_result.confidence,
-                        "intent_type": intent_result.intent_type,
-                        "entities": [
-                            e.model_dump() if hasattr(e, "model_dump") else e.__dict__
-                            for e in intent_result.entities
-                        ],
-                    }
-                )
-                fallback["confidence_score"] = intent_result.confidence
                 return fallback
+
+            intent_result: IntentResult = result["metadata"]["intent_result"]
+            intent_result.processing_time_ms = (
+                time.perf_counter() - start_time
+            ) * 1000
             return result
         except Exception as exc:  # pragma: no cover - tested via fallback
             logger.warning("LLM call failed, falling back: %s", exc)


### PR DESCRIPTION
## Summary
- Trigger fallback agent when base intent agent returns a fallback result
- Preserve existing fallback behavior for runtime failures

## Testing
- `pytest tests/test_enhanced_llm_intent_agent.py::test_fallback_when_llm_errors -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5c6a89e9c8320bc3139576aa637f7