### PR TITLE
Update fallback intent test greeting

### DIFF
--- a/tests/test_enhanced_llm_intent_agent.py
+++ b/tests/test_enhanced_llm_intent_agent.py
@@ -105,7 +105,7 @@ def test_fallback_when_llm_errors():
         fallback_agent=FallbackAgent(),
     )
     assert agent.config.model_client_config["api_key"] == "openai-test-key"
-    result = asyncio.run(agent.detect_intent("Bonjour", 1))
+    result = asyncio.run(agent.detect_intent("Salut", 1))
     intent_result = result["metadata"]["intent_result"]
     assert intent_result.intent_type == "FALLBACK_INTENT"
     assert intent_result.method == DetectionMethod.FALLBACK


### PR DESCRIPTION
## Summary
- use a neutral greeting in fallback intent test to avoid month or keyword matches

## Testing
- `pytest tests/test_enhanced_llm_intent_agent.py::test_fallback_when_llm_errors -q` *(fails: assert 'GENERAL_QUESTION' == 'FALLBACK_INTENT')*

------
https://chatgpt.com/codex/tasks/task_e_68a5c6a963c0832081a41f2e2a1cb2f0