### PR TITLE
Handle operation type filter without transaction types

### DIFF
--- a/conversation_service/agents/search_query_agent.py
+++ b/conversation_service/agents/search_query_agent.py
@@ -611,13 +611,15 @@ class SearchQueryAgent(BaseFinancialAgent):
         if categories:
             search_filters["category_name"] = categories
 
-        operation_types = [
-            _apply_synonym(str(e.normalized_value))
-            for e in all_entities
-            if e.entity_type in {EntityType.OPERATION_TYPE, "OPERATION_TYPE"} and e.normalized_value
-        ]
-        if operation_types:
-            search_filters["operation_type"] = operation_types[0]
+        for entity in all_entities:
+            if (
+                entity.entity_type in {EntityType.OPERATION_TYPE, "OPERATION_TYPE"}
+                and entity.normalized_value
+            ):
+                search_filters["operation_type"] = _apply_synonym(
+                    str(entity.normalized_value)
+                )
+                break
 
         transaction_types = [
             _apply_synonym(str(e.normalized_value))

--- a/tests/test_search_query_agent.py
+++ b/tests/test_search_query_agent.py
@@ -159,6 +159,35 @@ def test_transaction_type_synonym_applied():
     assert request["filters"]["transaction_types"] == ["transfer"]
 
 
+def test_operation_type_synonym_applied_without_transaction_types():
+    agent = SearchQueryAgent(
+        deepseek_client=DummyDeepSeekClient(),
+        search_service_url="http://search.example.com",
+    )
+    intent_result = IntentResult(
+        intent_type="TRANSACTION_SEARCH",
+        intent_category=IntentCategory.TRANSACTION_SEARCH,
+        confidence=0.9,
+        entities=[
+            FinancialEntity(
+                entity_type=EntityType.OPERATION_TYPE,
+                raw_value="virements",
+                normalized_value="virements",
+                confidence=0.9,
+            )
+        ],
+        method=DetectionMethod.LLM_BASED,
+        processing_time_ms=1.0,
+    )
+
+    search_query = asyncio.run(
+        agent._generate_search_contract(intent_result, "virements", user_id=1)
+    )
+    request = search_query.to_search_request()
+    assert request["filters"]["operation_type"] == "transfer"
+    assert "transaction_types" not in request["filters"]
+
+
 def test_default_limit_capped_to_100(monkeypatch):
     monkeypatch.setenv("SEARCH_QUERY_DEFAULT_LIMIT", "150")
     agent = SearchQueryAgent(


### PR DESCRIPTION
## Summary
- refine filter generation to directly apply synonyms for operation types
- ensure transaction types are only set when explicitly provided
- test operation type filtering to confirm no default transaction type filter

## Testing
- `pytest tests/test_search_query_agent.py::test_operation_type_synonym_applied_without_transaction_types -q`
- `pytest tests/test_search_query_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5d7bc35e083208cb1da72daf04fd9