### PR TITLE
Handle search agent errors via response agent

### DIFF
--- a/conversation_service/agents/response_agent.py
+++ b/conversation_service/agents/response_agent.py
@@ -185,8 +185,12 @@ class ResponseAgent(BaseFinancialAgent):
         user_message = input_data.get("user_message", "")
         context = input_data.get("context")
         if input_data.get("search_error"):
+            message = SEARCH_ERROR_MESSAGE
+            error_detail = input_data.get("error_message")
+            if error_detail:
+                message = f"{message} Raison: {error_detail}"
             return {
-                "content": SEARCH_ERROR_MESSAGE,
+                "content": message,
                 "metadata": {"error": "search_failed", "fallback_used": True},
                 "confidence_score": 0.0,
             }

--- a/tests/test_orchestrator_fallback.py
+++ b/tests/test_orchestrator_fallback.py
@@ -83,7 +83,7 @@ class FailingSearchAgent:
     name = "search_agent"
 
     async def execute_with_metrics(self, input_data, user_id):
-        raise Exception("search failed")
+        raise Exception("période invalide")
 
 
 class DummyDeepSeekClient:
@@ -105,7 +105,10 @@ def test_search_error_informs_user():
     result = asyncio.run(executor.execute_workflow("hello", "c2", 1))
 
     assert result["workflow_data"]["search_error"] is True
-    assert result["final_response"] == SEARCH_ERROR_MESSAGE
+    assert (
+        result["final_response"]
+        == f"{SEARCH_ERROR_MESSAGE} Raison: période invalide"
+    )
     response_step = next(
         step for step in result["execution_details"]["steps"] if step["name"] == "response_generation"
     )


### PR DESCRIPTION
## Summary
- intercept search query failures in the orchestrator and delegate user-facing error generation to the ResponseAgent
- allow ResponseAgent to include underlying search error details
- test the orchestrator's fallback when search agent raises an exception

## Testing
- `python -m pytest tests/test_orchestrator_fallback.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5d7c9e2a48320a5c3d95e2defcefc