### PR TITLE
feat: enrich month regex fallback

### DIFF
--- a/conversation_service/prompts/intent_prompts.py
+++ b/conversation_service/prompts/intent_prompts.py
@@ -200,7 +200,7 @@ MESSAGE: "Transactions en juin"
 INTENT_TYPE: SEARCH_BY_DATE
 INTENT_CATEGORY: FINANCIAL_QUERY
 CONFIDENCE: 0.91
-ENTITIES: {"dates": ["juin"]}
+ENTITIES: {"dates": ["juin 2025"]}
 SUGGESTED_ACTIONS: []
 
 **Exemple 10 - Recherche par mois (mai) :**
@@ -208,7 +208,7 @@ MESSAGE: "Transactions au mois de mai"
 INTENT_TYPE: SEARCH_BY_DATE
 INTENT_CATEGORY: FINANCIAL_QUERY
 CONFIDENCE: 0.91
-ENTITIES: {"dates": ["mai"]}
+ENTITIES: {"dates": ["mai 2025"]}
 SUGGESTED_ACTIONS: []
 """
 


### PR DESCRIPTION
## Summary
- support French month phrases like "en juin" and "au mois de mai" with optional year
- default to current year when year is omitted
- expand few-shot examples and tests for month parsing

## Testing
- `pytest tests/test_llm_intent_agent.py::test_month_regex_fallback_and_injection -q`
- `pytest tests/test_intents_full.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5d7d20a208320b5cdf02058a0b46a