### PR TITLE
docs: document entity filters and link from search agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,25 @@ Example response:
 }
 ```
 
+## Entités de recherche et filtres Elasticsearch
+
+Le `SearchQueryAgent` normalise certaines entités afin de construire des filtres
+Elasticsearch. Le tableau suivant décrit la valeur canonique produite pour
+chaque entité reconnue et le filtre appliqué :
+
+| Entité (`EntityType`) | Valeur canonique | Filtre ES |
+| --- | --- | --- |
+| `CATEGORY` | terme anglais normalisé (`virement(s)` → `transfer`) | `category_name` |
+| `OPERATION_TYPE` | terme anglais normalisé | `operation_type` |
+| `TRANSACTION_TYPE` | termes anglais normalisés (liste unique) | `transaction_types` |
+| `DATE_RANGE` | `{ "gte": "...", "lte": "..." }` | `date` |
+| `DATE` | convertie en `YYYY-MM` ou `YYYY-MM-DD` puis en plage | `date` |
+| `RELATIVE_DATE` | résolue via mots‑clés (`current_month`, `current_week`…) | `date` |
+| `AMOUNT` | nombre avec marge de ±10 % ou comparaison absolue | `amount` / `amount_abs` |
+
+> Les entités non listées ne créent pas de filtres et servent uniquement à
+> enrichir la recherche textuelle.
+
 ## Restes à faire
 
 - Trouver une solution efficace pour la détection d'intentions.

--- a/conversation_service/agents/search_query_agent.py
+++ b/conversation_service/agents/search_query_agent.py
@@ -5,6 +5,9 @@ This agent generates optimized search queries for the Search Service based on
 detected intents and user messages. It includes entity extraction, query
 optimization, and standardized search service communication.
 
+See README.md#entites-de-recherche-et-filtres-elasticsearch for the mapping
+between entities, their canonical values and the Elasticsearch filters used.
+
 Classes:
     - SearchQueryAgent: Main search query generation agent
     - QueryOptimizer: Helper class for query optimization


### PR DESCRIPTION
## Summary
- document mapping between entities, canonical values and Elasticsearch filters
- reference entity mapping doc from `SearchQueryAgent`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5d7dc92308320b5007c8b1c20c077