### PR TITLE
Handle June end date dynamically in search test

### DIFF
--- a/tests/test_search_end_to_end.py
+++ b/tests/test_search_end_to_end.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+from calendar import monthrange
 from datetime import datetime
 
 from conversation_service.agents import base_financial_agent
@@ -644,9 +645,10 @@ def test_sum_debits_and_credits_in_june():
     )
     request_dict = search_contract.to_search_request()
     year = datetime.utcnow().strftime("%Y")
+    last_day = monthrange(int(year), 6)[1]
     assert request_dict["filters"]["date"] == {
         "gte": f"{year}-06-01",
-        "lte": f"{year}-06-31",
+        "lte": f"{year}-06-{last_day:02d}",
     }
     assert request_dict["aggregations"] == {
         "metrics": ["sum"],


### PR DESCRIPTION
## Summary
- Derive last day of June dynamically in `test_sum_debits_and_credits_in_june`
- Import `monthrange` utility for calculating month length

## Testing
- `pytest tests/test_search_end_to_end.py::test_sum_debits_and_credits_in_june -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5dde7c2c083209089e704336eb027