### PR TITLE
feat: expand french month regex and transaction vocabulary

### DIFF
--- a/conversation_service/agents/llm_intent_agent.py
+++ b/conversation_service/agents/llm_intent_agent.py
@@ -67,9 +67,10 @@ FRENCH_MONTHS = [
     "décembre",
     "decembre",
 ]
-# Regex capturing expressions like "en juin", "au mois de mai", optionally followed by a year
+# Regex capturing expressions like "en juin", "au mois de mai" or "pendant mars",
+# optionally followed by a year
 MONTH_PHRASE_REGEX = re.compile(
-    r"(?:\b(?:en|au\s+mois\s+de|mois\s+de)\s+)?\b(" + "|".join(FRENCH_MONTHS) + r")\b(?:\s+(\d{4}))?",
+    r"(?:\b(?:en|au\s+mois\s+de|mois\s+de|durant|pendant)\s+)?\b(" + "|".join(FRENCH_MONTHS) + r")\b(?:\s+(\d{4}))?",
     re.IGNORECASE,
 )
 
@@ -179,12 +180,29 @@ class LLMIntentAgent(BaseFinancialAgent):
             "ascii", "ignore"
         ).decode("utf-8").lower()
 
-        if any(k in normalized for k in ["depense", "depens", "sortie", "sorties"]):
+        debit_keywords = [
+            "depense",
+            "depenses",
+            "depensees",
+            "depenser",
+            "sortie",
+            "sorties",
+            "debit",
+            "debits",
+        ]
+        credit_keywords = [
+            "entree",
+            "entrees",
+            "entree d argent",
+            "entree d'argent",
+            "gains",
+            "gain",
+            "credit",
+            "credits",
+        ]
+        if any(k in normalized for k in debit_keywords):
             return "debit"
-        if any(
-            k in normalized
-            for k in ["entree d argent", "entree d'argent", "gains", "gain"]
-        ):
+        if any(k in normalized for k in credit_keywords):
             return "credit"
         return None
 

--- a/conversation_service/prompts/intent_prompts.py
+++ b/conversation_service/prompts/intent_prompts.py
@@ -210,6 +210,22 @@ INTENT_CATEGORY: FINANCIAL_QUERY
 CONFIDENCE: 0.91
 ENTITIES: {"dates": ["mai 2025"]}
 SUGGESTED_ACTIONS: []
+
+**Exemple 11 - Transactions en sorties (débits) :**
+MESSAGE: "Montre mes sorties"
+INTENT_TYPE: SEARCH_BY_OPERATION_TYPE
+INTENT_CATEGORY: FINANCIAL_QUERY
+CONFIDENCE: 0.90
+ENTITIES: {"transaction_type": ["debit"]}
+SUGGESTED_ACTIONS: []
+
+**Exemple 12 - Transactions en entrées (crédits) :**
+MESSAGE: "Liste mes gains"
+INTENT_TYPE: SEARCH_BY_OPERATION_TYPE
+INTENT_CATEGORY: FINANCIAL_QUERY
+CONFIDENCE: 0.90
+ENTITIES: {"transaction_type": ["credit"]}
+SUGGESTED_ACTIONS: []
 """
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- extend French month fallback regex to handle more phrases
- map common spending/income vocabulary to debit/credit transaction types
- add few-shot examples for transaction type wording in prompts

## Testing
- `pytest tests/test_intents_full.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5e39f1ca483209550ae2198ba53ab