### PR TITLE
feat: add LLM-based query generation with fallback

### DIFF
--- a/config_service/config.py
+++ b/config_service/config.py
@@ -468,6 +468,7 @@ class GlobalSettings(BaseSettings):
     CACHE_TTL_QUERY: int = int(os.environ.get("CACHE_TTL_QUERY", "120"))
     CACHE_TTL_RESPONSE: int = int(os.environ.get("CACHE_TTL_RESPONSE", "60"))
     CACHE_TTL_SECONDS: int = int(os.environ.get("CACHE_TTL_SECONDS", "300"))
+    USE_LLM_QUERY: bool = os.environ.get("USE_LLM_QUERY", "false").lower() == "true"
     
     # Cache L0 - Patterns pré-calculés
     PRECOMPUTED_PATTERNS_ENABLED: bool = os.environ.get("PRECOMPUTED_PATTERNS_ENABLED", "true").lower() == "true"


### PR DESCRIPTION
## Summary
- enable optional LLM search query generation via DeepSeek
- fall back to heuristic query builder when LLM fails
- cover LLM and fallback paths with unit tests

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic._internal'; 'pydantic' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e8b35e1c8320ba8d41fbd240808b