### PR TITLE
Document allowed transaction types in prompts and tests

### DIFF
--- a/conversation_service/agents/llm_intent_agent.py
+++ b/conversation_service/agents/llm_intent_agent.py
@@ -41,6 +41,7 @@ from ..prompts.intent_prompts import (
     INTENT_SYSTEM_PROMPT,
     INTENT_EXAMPLES_FEW_SHOT,
 )
+from ..constants import TRANSACTION_TYPES
 
 # Mapping to harmonise categories with internal enums
 CATEGORY_MAP: Dict[str, str] = {
@@ -135,9 +136,10 @@ class LLMIntentAgent(BaseFinancialAgent):
     @staticmethod
     def _build_system_message() -> str:
         """Construct the system prompt given to the LLM."""
-
+        allowed = " ou ".join(TRANSACTION_TYPES)
         return (
-            f"{INTENT_SYSTEM_PROMPT}\n\n{INTENT_EXAMPLES_FEW_SHOT}"
+            f"{INTENT_SYSTEM_PROMPT}\nLes valeurs autorisées pour transaction_type sont : {allowed}."
+            f"\n\n{INTENT_EXAMPLES_FEW_SHOT}"
             "\n\nRéponds uniquement avec un JSON strict."
         )
 

--- a/conversation_service/agents/response_agent.py
+++ b/conversation_service/agents/response_agent.py
@@ -24,6 +24,7 @@ from ..models.agent_models import AgentConfig, AgentResponse
 from ..models.service_contracts import SearchServiceResponse
 from ..models.conversation_models import ConversationContext
 from ..core.deepseek_client import DeepSeekClient, DeepSeekResponse
+from ..constants import TRANSACTION_TYPES
 
 logger = logging.getLogger(__name__)
 
@@ -553,7 +554,8 @@ Génère une réponse naturelle et utile qui:
     
     def _get_system_message(self) -> str:
         """Get system message for the agent."""
-        return """Tu es un assistant financier spécialisé dans la génération de réponses contextuelles.
+        allowed = " ou ".join(TRANSACTION_TYPES)
+        return f"""Tu es un assistant financier spécialisé dans la génération de réponses contextuelles.
 
 Ton rôle est de:
 1. Analyser les résultats de recherche financière
@@ -570,11 +572,14 @@ Principes de réponse:
 - Suggère des actions de suivi quand c'est pertinent
 - Adapte ton niveau de détail selon le contexte
 
+Les valeurs autorisées pour transaction_type sont : {allowed}
+
 Toujours prioriser la clarté et l'utilité pour l'utilisateur."""
     
     def _get_response_generation_prompt(self) -> str:
         """Get response generation prompt for DeepSeek."""
-        return """Tu es un assistant financier expert qui génère des réponses contextuelles basées sur des données de transactions.
+        allowed = " ou ".join(TRANSACTION_TYPES)
+        return f"""Tu es un assistant financier expert qui génère des réponses contextuelles basées sur des données de transactions.
 
 Instructions:
 1. Analyse la question utilisateur et les résultats de recherche
@@ -583,6 +588,8 @@ Instructions:
 4. Ajoute des insights pertinents basés sur les données
 5. Propose des actions de suivi si approprié
 6. Adapte ton ton selon le contexte conversationnel
+
+Les valeurs autorisées pour transaction_type sont : {allowed}
 
 Format de réponse:
 - Commence par répondre directement à la question

--- a/conversation_service/constants.py
+++ b/conversation_service/constants.py
@@ -1,0 +1,3 @@
+"""Common constants for conversation service agents."""
+
+TRANSACTION_TYPES = ["debit", "credit"]

--- a/tests/test_llm_intent_agent.py
+++ b/tests/test_llm_intent_agent.py
@@ -8,6 +8,7 @@ base_financial_agent.AUTOGEN_AVAILABLE = True
 from conversation_service.agents.llm_intent_agent import LLMIntentAgent
 from conversation_service.agents.search_query_agent import QueryOptimizer
 from conversation_service.models.financial_models import EntityType, IntentCategory
+from conversation_service.constants import TRANSACTION_TYPES
 
 
 class DummyDeepSeekClient:
@@ -92,6 +93,7 @@ def test_transaction_type_post_processing(message, expected):
     intent_result = result["metadata"]["intent_result"]
     tx = next(e for e in intent_result.entities if e.entity_type == EntityType.TRANSACTION_TYPE)
     assert tx.normalized_value == expected
+    assert tx.normalized_value in TRANSACTION_TYPES
 
 
 @pytest.mark.parametrize(

--- a/tests/test_response_agent.py
+++ b/tests/test_response_agent.py
@@ -10,6 +10,7 @@ from conversation_service.models.service_contracts import (
     ResponseMetadata,
     TransactionResult,
 )
+from conversation_service.constants import TRANSACTION_TYPES
 
 
 class DummyDeepSeekClient:
@@ -50,6 +51,7 @@ def test_response_agent_handles_full_search_results():
         ],
         success=True,
     )
+    assert search_response.results[0].transaction_type in TRANSACTION_TYPES
 
     search_results = {"metadata": {"search_response": search_response}}
 
@@ -111,6 +113,7 @@ def test_response_agent_summarizes_large_result_set():
         )
         for i in range(25)
     ]
+    assert all(r.transaction_type in TRANSACTION_TYPES for r in results)
 
     search_response = SearchServiceResponse(
         response_metadata=ResponseMetadata(
@@ -159,6 +162,8 @@ def test_response_agent_displays_aggregated_amounts():
         },
         success=True,
     )
+    for bucket in search_response.aggregations["transaction_type_terms"]["buckets"]:
+        assert bucket["key"] in TRANSACTION_TYPES
 
     search_results = {"metadata": {"search_response": search_response}}
 


### PR DESCRIPTION
## Summary
- Centralize allowed transaction types in a new constants module
- Inject explicit transaction type constraints into LLM agent system prompts
- Validate transaction type outputs against allowed values in tests

## Testing
- `pytest tests/test_llm_intent_agent.py`
- `pytest tests/test_llm_intent_agent.py tests/test_search_query_agent.py tests/test_response_agent.py` *(fails: AttributeError: '_DummySettings' object has no attribute 'SEARCH_SERVICE_URL')*

------
https://chatgpt.com/codex/tasks/task_e_68a5ebdf55bc832096fc83f751b8dd62