### PR TITLE
Add sample transaction seed and dev init script

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ The conversation service now performs a full agent health check during
 startup. If any agent reports an unhealthy status, initialization fails and
 the process exits instead of running in a degraded state.
 
+## Local data seed
+
+For development, populate the `harena_transactions` Elasticsearch index with a
+few sample debit and credit transactions for 2025:
+
+```bash
+./scripts/dev_init.sh
+```
+
+This script runs `search_service/scripts/seed_transactions.py` and requires an
+Elasticsearch instance accessible via the `BONSAI_URL` environment variable
+or a local node at `http://localhost:9200`.
+
 ## Authentication
 
 Most endpoints, including `/conversation/chat`, require an OAuth2 Bearer token.

--- a/scripts/dev_init.sh
+++ b/scripts/dev_init.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Seed example transactions into Elasticsearch
+python search_service/scripts/seed_transactions.py

--- a/search_service/scripts/seed_transactions.py
+++ b/search_service/scripts/seed_transactions.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+"""Seed sample transactions into the `harena_transactions` index.
+
+This script populates the Elasticsearch index with a handful of debit and
+credit transactions spread across several months of 2025. It is intended for
+local development and testing so that search queries return meaningful results
+out of the box.
+"""
+
+import asyncio
+from datetime import datetime
+import os
+
+# Ensure an Elasticsearch endpoint is configured for local runs
+os.environ.setdefault("BONSAI_URL", "http://localhost:9200")
+
+from enrichment_service.storage.elasticsearch_client import ElasticsearchClient
+from enrichment_service.models import TransactionInput, StructuredTransaction
+
+
+async def seed_transactions() -> None:
+    """Create the index (if needed) and insert sample transactions."""
+    client = ElasticsearchClient()
+    await client.initialize()
+
+    sample_inputs = [
+        TransactionInput(
+            bridge_transaction_id=1,
+            user_id=1,
+            account_id=1,
+            amount=-50.0,
+            date=datetime(2025, 1, 15),
+            currency_code="EUR",
+            clean_description="Courses supermarché",
+            operation_type="card",
+        ),
+        TransactionInput(
+            bridge_transaction_id=2,
+            user_id=1,
+            account_id=1,
+            amount=2000.0,
+            date=datetime(2025, 1, 31),
+            currency_code="EUR",
+            clean_description="Salaire",
+            operation_type="transfer",
+        ),
+        TransactionInput(
+            bridge_transaction_id=3,
+            user_id=1,
+            account_id=1,
+            amount=-70.5,
+            date=datetime(2025, 2, 10),
+            currency_code="EUR",
+            clean_description="Restaurant",
+            operation_type="card",
+        ),
+        TransactionInput(
+            bridge_transaction_id=4,
+            user_id=1,
+            account_id=1,
+            amount=-120.0,
+            date=datetime(2025, 3, 5),
+            currency_code="EUR",
+            clean_description="Électricité",
+            operation_type="transfer",
+        ),
+        TransactionInput(
+            bridge_transaction_id=5,
+            user_id=1,
+            account_id=1,
+            amount=150.0,
+            date=datetime(2025, 4, 20),
+            currency_code="EUR",
+            clean_description="Remboursement",
+            operation_type="transfer",
+        ),
+        TransactionInput(
+            bridge_transaction_id=6,
+            user_id=1,
+            account_id=1,
+            amount=-35.0,
+            date=datetime(2025, 5, 18),
+            currency_code="EUR",
+            clean_description="Cinéma",
+            operation_type="card",
+        ),
+    ]
+
+    structured = [StructuredTransaction.from_transaction_input(tx) for tx in sample_inputs]
+    summary = await client.index_transactions_batch(structured)
+    print(f"Indexed {summary['indexed']}/{summary['total']} transactions")
+
+    await client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(seed_transactions())


### PR DESCRIPTION
## Summary
- add script to seed example 2025 debit/credit transactions into Elasticsearch
- add `scripts/dev_init.sh` to run the seeding at local startup
- document the seed process in README

## Testing
- `pytest` *(fails: 14 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a6022f956483209e40e7973f07ca76