### PR TITLE
Handle generic-only search text and keep action keywords

### DIFF
--- a/tests/test_search_query_agent.py
+++ b/tests/test_search_query_agent.py
@@ -83,6 +83,35 @@ def make_amount_intent(normalized_value, actions=None):
     )
 
 
+def test_action_keywords_preserved_in_search_text():
+    intent_result = IntentResult(
+        intent_type="TRANSACTION_SEARCH",
+        intent_category=IntentCategory.TRANSACTION_SEARCH,
+        confidence=0.9,
+        entities=[],
+        method=DetectionMethod.LLM_BASED,
+        processing_time_ms=1.0,
+    )
+    search_text = QueryOptimizer.optimize_search_text(
+        "Combien ai-je dépensé en juin ?", intent_result
+    )
+    assert search_text != "en juin"
+    assert "depense" in search_text
+
+
+def test_month_only_query_uses_filters_only():
+    intent_result = IntentResult(
+        intent_type="TRANSACTION_SEARCH",
+        intent_category=IntentCategory.TRANSACTION_SEARCH,
+        confidence=0.9,
+        entities=[],
+        method=DetectionMethod.LLM_BASED,
+        processing_time_ms=1.0,
+    )
+    search_text = QueryOptimizer.optimize_search_text("en juin", intent_result)
+    assert search_text is None
+
+
 def test_prepare_entity_context_with_string_entity_type():
     agent = SearchQueryAgent(
         deepseek_client=DummyDeepSeekClient(),


### PR DESCRIPTION
## Summary
- keep action keywords like "depense" and "virement" in search text
- skip search text when only month names or generic words remain
- document rule and test that month-only queries rely on filters

## Testing
- `pytest` *(fails: e.g., ModuleNotFoundError: No module named 'jose', pydantic validation errors, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a6023594fc8320aeaf9bda5fdd1197