### PR TITLE
feat(intent): rely on LLM for comparative amount actions

### DIFF
--- a/conversation_service/agents/llm_intent_agent.py
+++ b/conversation_service/agents/llm_intent_agent.py
@@ -144,37 +144,6 @@ class LLMIntentAgent(BaseFinancialAgent):
         )
 
     @staticmethod
-    def _detect_amount_actions(message: str) -> Optional[List[str]]:
-        """Detect comparative keywords to suggest amount filters."""
-        normalized = unicodedata.normalize("NFD", message).encode(
-            "ascii", "ignore"
-        ).decode("utf-8").lower()
-
-        greater = [
-            "superieur",
-            "superieure",
-            "superieurs",
-            "superieures",
-            "plus de",
-            "plus que",
-        ]
-        less = [
-            "inferieur",
-            "inferieure",
-            "inferieurs",
-            "inferieures",
-            "moins de",
-            "moins que",
-        ]
-
-        actions: List[str] = []
-        if any(k in normalized for k in greater):
-            actions.append("filter_by_amount_greater")
-        if any(k in normalized for k in less):
-            actions.append("filter_by_amount_less")
-        return actions or None
-
-    @staticmethod
     def _detect_transaction_type(message: str) -> Optional[List[str]]:
         """Detect basic keywords implying transaction type.
 
@@ -406,10 +375,6 @@ class LLMIntentAgent(BaseFinancialAgent):
         suggested_actions = data.get("suggested_actions")
         if isinstance(suggested_actions, str):
             suggested_actions = [suggested_actions]
-        if not suggested_actions:
-            # When the LLM omits the field or returns an empty list we try to
-            # infer the action heuristically from the user message.
-            suggested_actions = self._detect_amount_actions(user_message)
 
         intent_type = data.get("intent_type", "OUT_OF_SCOPE")
         raw_category = data.get("intent_category", "GENERAL_QUESTION").upper()

--- a/conversation_service/prompts/llm_intent_agent_examples.yaml
+++ b/conversation_service/prompts/llm_intent_agent_examples.yaml
@@ -14,3 +14,23 @@
       "intent_category": "ACCOUNT_BALANCE",
       "entities": []
     }
+
+- description: "Comparatif supérieur"
+  input: "Montre-moi les transactions plus de 100 €"
+  output: |
+    {
+      "intent_type": "TRANSACTION_SEARCH",
+      "intent_category": "TRANSACTION_SEARCH",
+      "entities": [{"entity_type": "AMOUNT", "value": "100 €"}],
+      "suggested_actions": ["filter_by_amount_greater"]
+    }
+
+- description: "Comparatif inférieur"
+  input: "Montre-moi les transactions moins que 50 €"
+  output: |
+    {
+      "intent_type": "TRANSACTION_SEARCH",
+      "intent_category": "TRANSACTION_SEARCH",
+      "entities": [{"entity_type": "AMOUNT", "value": "50 €"}],
+      "suggested_actions": ["filter_by_amount_less"]
+    }

--- a/tests/test_search_end_to_end.py
+++ b/tests/test_search_end_to_end.py
@@ -543,6 +543,7 @@ def test_amount_detection_filters_transactions():
                         "confidence": 0.9,
                     }
                 ],
+                "suggested_actions": ["filter_by_amount_greater"],
             }
         )
     )
@@ -554,6 +555,8 @@ def test_amount_detection_filters_transactions():
     )
     intent_result = intent_data["metadata"]["intent_result"]
     assert intent_result.suggested_actions == ["filter_by_amount_greater"]
+    import conversation_service.agents.search_query_agent as sq
+    sq.settings.USE_LLM_QUERY = False
 
     search_agent = SearchQueryAgent(
         deepseek_client=DummyDeepSeekClient(),


### PR DESCRIPTION
## Summary
- remove heuristic amount action detection from intent agent
- add few-shot examples for comparative amounts
- ensure tests validate LLM suggested actions

## Testing
- `pytest tests/test_llm_intent_agent.py tests/test_search_end_to_end.py::test_amount_detection_filters_transactions -q`


------
https://chatgpt.com/codex/tasks/task_e_68a605428bf88320a34d4f69fe141be5