### PR TITLE
Add team orchestrator and financial team registry

### DIFF
--- a/teams/__init__.py
+++ b/teams/__init__.py
@@ -1,0 +1,17 @@
+"""Utilities for managing agent teams."""
+
+from .team_orchestrator import (
+    TeamOrchestrator,
+    register_team,
+    get_team,
+    available_teams,
+    orchestrator,
+)
+
+__all__ = [
+    "TeamOrchestrator",
+    "register_team",
+    "get_team",
+    "available_teams",
+    "orchestrator",
+]

--- a/teams/financial_team.py
+++ b/teams/financial_team.py
@@ -1,0 +1,52 @@
+"""Example financial analysis team.
+
+The financial team demonstrates how specialized agents can be coordinated
+through the :class:`~teams.team_orchestrator.TeamOrchestrator`. The team
+uses two simple placeholder agents: one performs an "analysis" step and
+the other generates a final report based on that analysis.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass
+class SimpleAgent:
+    """Minimal agent placeholder used for demonstration."""
+
+    name: str
+
+    def run(self, message: str) -> str:  # pragma: no cover - trivial
+        return f"{self.name}: {message}"
+
+
+class AnalystAgent(SimpleAgent):
+    def run(self, message: str) -> str:
+        return f"analysis of {message}"
+
+
+class ReportAgent(SimpleAgent):
+    def run(self, message: str) -> str:
+        return f"report based on {message}"
+
+
+class FinancialTeam:
+    """Simple financial team chaining two agents."""
+
+    def __init__(self) -> None:
+        self.analyst = AnalystAgent("financial_analyst")
+        self.reporter = ReportAgent("report_generator")
+
+    def process(self, message: str) -> Dict[str, str]:
+        """Run the message through the analysis and reporting agents."""
+        analysis = self.analyst.run(message)
+        report = self.reporter.run(analysis)
+        return {"analysis": analysis, "report": report}
+
+
+# Register this team with the global orchestrator on import
+from .team_orchestrator import register_team
+
+register_team("financial", FinancialTeam)

--- a/teams/team_orchestrator.py
+++ b/teams/team_orchestrator.py
@@ -1,0 +1,87 @@
+"""Core team orchestration utilities.
+
+This module provides a lightweight orchestrator that keeps a registry of
+available teams and can route messages to them. Teams are registered
+by name and lazily instantiated on first use. This design allows new
+teams to be added dynamically at runtime.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Type
+
+
+class TeamOrchestrator:
+    """Registry and router for agent teams."""
+
+    def __init__(self) -> None:
+        self._registry: Dict[str, Type] = {}
+        self._instances: Dict[str, Any] = {}
+
+    def register_team(self, name: str, team_cls: Type) -> None:
+        """Register a new team class.
+
+        Args:
+            name: Identifier for the team.
+            team_cls: Class implementing the team.
+
+        Raises:
+            ValueError: If the name is already registered.
+        """
+        if name in self._registry:
+            raise ValueError(f"Team '{name}' already registered")
+        self._registry[name] = team_cls
+
+    def available_teams(self) -> List[str]:
+        """Return the list of registered team names."""
+        return list(self._registry.keys())
+
+    def get_team(self, name: str) -> Any:
+        """Return an instance of the requested team.
+
+        Instances are created lazily and cached for subsequent calls.
+
+        Args:
+            name: Team identifier.
+
+        Returns:
+            Instantiated team object.
+
+        Raises:
+            KeyError: If the team has not been registered.
+        """
+        if name not in self._registry:
+            raise KeyError(f"Team '{name}' is not registered")
+        if name not in self._instances:
+            self._instances[name] = self._registry[name]()
+        return self._instances[name]
+
+    def process(self, team_name: str, message: str) -> Any:
+        """Process a message using the specified team."""
+        team = self.get_team(team_name)
+        if not hasattr(team, "process"):
+            raise AttributeError(f"Team '{team_name}' has no 'process' method")
+        return team.process(message)
+
+
+# Global orchestrator instance for convenience
+_orchestrator = TeamOrchestrator()
+
+
+def register_team(name: str, team_cls: Type) -> None:
+    """Register a team on the global orchestrator."""
+    _orchestrator.register_team(name, team_cls)
+
+
+def get_team(name: str) -> Any:
+    """Retrieve a team from the global orchestrator."""
+    return _orchestrator.get_team(name)
+
+
+def available_teams() -> List[str]:
+    """List team names registered on the global orchestrator."""
+    return _orchestrator.available_teams()
+
+
+# Public alias for the global orchestrator
+orchestrator = _orchestrator

--- a/tests/test_team_orchestrator.py
+++ b/tests/test_team_orchestrator.py
@@ -1,0 +1,26 @@
+import pytest
+from teams.team_orchestrator import TeamOrchestrator, orchestrator
+from teams.financial_team import FinancialTeam  # triggers registration
+
+
+def test_register_and_process_financial_team():
+    orchestrator = TeamOrchestrator()
+    orchestrator.register_team("financial", FinancialTeam)
+    assert "financial" in orchestrator.available_teams()
+    team = orchestrator.get_team("financial")
+    result = team.process("stock prices")
+    assert result["analysis"] == "analysis of stock prices"
+    assert result["report"] == "report based on analysis of stock prices"
+
+
+def test_duplicate_registration_raises():
+    orchestrator = TeamOrchestrator()
+    orchestrator.register_team("financial", FinancialTeam)
+    with pytest.raises(ValueError):
+        orchestrator.register_team("financial", FinancialTeam)
+
+
+def test_global_registration():
+    assert "financial" in orchestrator.available_teams()
+    team = orchestrator.get_team("financial")
+    assert team.process("budget")["analysis"].startswith("analysis")


### PR DESCRIPTION
## Summary
- add lightweight `TeamOrchestrator` with runtime team registry
- implement demo `FinancialTeam` with analyst and report agents
- support registering teams dynamically and cover with tests

## Testing
- `pytest tests/test_team_orchestrator.py`
- `pytest` *(fails: '_DummySettings' object has no attribute 'USE_LLM_QUERY'; missing bcrypt module, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a611493da08320ae43828aebfae931