### PR TITLE
feat: add generic prompt modules

### DIFF
--- a/prompts/__init__.py
+++ b/prompts/__init__.py
@@ -1,0 +1,14 @@
+"""Package de prompts génériques.
+
+Ce package fournit des modules simples pour gérer différents types de prompts
+(intentions, entités, requêtes et réponses). Chaque module expose des
+fonctionnalités pour charger dynamiquement un prompt et manipuler des exemples
+few‑shot.
+"""
+
+__all__ = [
+    "intent_prompts",
+    "entity_prompts",
+    "query_prompts",
+    "response_prompts",
+]

--- a/prompts/entity_prompts.py
+++ b/prompts/entity_prompts.py
@@ -1,0 +1,39 @@
+"""Prompts pour l'extraction d'entités.
+
+Ce module propose un prompt par défaut et une gestion simplifiée des exemples
+few‑shot pour extraire des entités d'un texte utilisateur. Les prompts peuvent
+être chargés depuis un fichier externe ou récupérés depuis un cache.
+"""
+
+from pathlib import Path
+from typing import Dict, List, Optional
+
+DEFAULT_PROMPT = "Identifie les entités présentes dans le message utilisateur."
+
+_EXAMPLES: List[Dict[str, str]] = [
+    {"input": "J'ai dépensé 50€ chez Amazon", "output": "AMOUNT:50, MERCHANT:Amazon"},
+]
+
+_PROMPT_CACHE: Dict[str, str] = {}
+
+def load_prompt(path: Optional[str] = None, *, cache: Optional[Dict[str, str]] = None, cache_key: str = "default") -> str:
+    """Charger le prompt depuis un fichier ou un cache."""
+    cache = _PROMPT_CACHE if cache is None else cache
+    if cache_key in cache:
+        return cache[cache_key]
+    if path:
+        prompt = Path(path).read_text(encoding="utf-8")
+        cache[cache_key] = prompt
+        return prompt
+    return DEFAULT_PROMPT
+
+
+def get_examples() -> List[Dict[str, str]]:
+    """Récupérer les exemples actuels."""
+    return list(_EXAMPLES)
+
+
+def update_examples(examples: List[Dict[str, str]]) -> None:
+    """Mettre à jour les exemples few‑shot."""
+    _EXAMPLES.clear()
+    _EXAMPLES.extend(examples)

--- a/prompts/intent_prompts.py
+++ b/prompts/intent_prompts.py
@@ -1,0 +1,48 @@
+"""Prompts pour la détection d'intention.
+
+Ce module gère un prompt par défaut et des exemples few‑shot pour la
+classification d'intentions. Il offre des utilitaires pour charger un prompt
+depuis un fichier externe ou un cache en mémoire, ainsi que pour consulter ou
+mettre à jour les exemples utilisés.
+"""
+
+from pathlib import Path
+from typing import Dict, List, Optional
+
+DEFAULT_PROMPT = "Analyse l'intention du message utilisateur."
+
+_EXAMPLES: List[Dict[str, str]] = [
+    {"input": "Bonjour", "output": "GREETING"},
+]
+
+_PROMPT_CACHE: Dict[str, str] = {}
+
+def load_prompt(path: Optional[str] = None, *, cache: Optional[Dict[str, str]] = None, cache_key: str = "default") -> str:
+    """Charger le prompt depuis un fichier ou un cache.
+
+    Args:
+        path: chemin optionnel vers un fichier contenant le prompt.
+        cache: dictionnaire utilisé comme cache en mémoire.
+        cache_key: clé sous laquelle stocker/récupérer le prompt.
+    Returns:
+        Le texte du prompt.
+    """
+    cache = _PROMPT_CACHE if cache is None else cache
+    if cache_key in cache:
+        return cache[cache_key]
+    if path:
+        prompt = Path(path).read_text(encoding="utf-8")
+        cache[cache_key] = prompt
+        return prompt
+    return DEFAULT_PROMPT
+
+
+def get_examples() -> List[Dict[str, str]]:
+    """Récupérer la liste actuelle des exemples few‑shot."""
+    return list(_EXAMPLES)
+
+
+def update_examples(examples: List[Dict[str, str]]) -> None:
+    """Remplacer les exemples few‑shot par une nouvelle liste."""
+    _EXAMPLES.clear()
+    _EXAMPLES.extend(examples)

--- a/prompts/query_prompts.py
+++ b/prompts/query_prompts.py
@@ -1,0 +1,39 @@
+"""Prompts pour la génération de requêtes.
+
+Utilitaires minimalistes permettant de charger un prompt de génération de
+requêtes depuis un fichier ou un cache et de gérer les exemples few‑shot
+associés.
+"""
+
+from pathlib import Path
+from typing import Dict, List, Optional
+
+DEFAULT_PROMPT = "Génère une requête basée sur l'intention détectée."
+
+_EXAMPLES: List[Dict[str, str]] = [
+    {"input": "transactions supérieures à 100€", "output": "amount>100"},
+]
+
+_PROMPT_CACHE: Dict[str, str] = {}
+
+def load_prompt(path: Optional[str] = None, *, cache: Optional[Dict[str, str]] = None, cache_key: str = "default") -> str:
+    """Charger le prompt depuis un fichier ou un cache."""
+    cache = _PROMPT_CACHE if cache is None else cache
+    if cache_key in cache:
+        return cache[cache_key]
+    if path:
+        prompt = Path(path).read_text(encoding="utf-8")
+        cache[cache_key] = prompt
+        return prompt
+    return DEFAULT_PROMPT
+
+
+def get_examples() -> List[Dict[str, str]]:
+    """Obtenir les exemples few‑shot utilisés pour la génération de requêtes."""
+    return list(_EXAMPLES)
+
+
+def update_examples(examples: List[Dict[str, str]]) -> None:
+    """Mettre à jour les exemples few‑shot."""
+    _EXAMPLES.clear()
+    _EXAMPLES.extend(examples)

--- a/prompts/response_prompts.py
+++ b/prompts/response_prompts.py
@@ -1,0 +1,41 @@
+"""Prompts pour la génération de réponses.
+
+Ce module fournit un prompt de réponse par défaut ainsi que des fonctions pour
+charger un prompt personnalisé depuis un fichier ou un cache. Les exemples
+few‑shot peuvent être consultés ou modifiés afin d'ajuster le style de réponse.
+"""
+
+from pathlib import Path
+from typing import Dict, List, Optional
+
+DEFAULT_PROMPT = "Formule une réponse utilisateur à partir des données fournies."
+
+_EXAMPLES: List[Dict[str, str]] = [
+    {
+        "input": "transactions Amazon du mois dernier",
+        "output": "Vous avez 3 transactions chez Amazon en avril."},
+]
+
+_PROMPT_CACHE: Dict[str, str] = {}
+
+def load_prompt(path: Optional[str] = None, *, cache: Optional[Dict[str, str]] = None, cache_key: str = "default") -> str:
+    """Charger le prompt depuis un fichier ou un cache."""
+    cache = _PROMPT_CACHE if cache is None else cache
+    if cache_key in cache:
+        return cache[cache_key]
+    if path:
+        prompt = Path(path).read_text(encoding="utf-8")
+        cache[cache_key] = prompt
+        return prompt
+    return DEFAULT_PROMPT
+
+
+def get_examples() -> List[Dict[str, str]]:
+    """Retourner les exemples actuels de génération de réponses."""
+    return list(_EXAMPLES)
+
+
+def update_examples(examples: List[Dict[str, str]]) -> None:
+    """Mettre à jour la liste des exemples few‑shot."""
+    _EXAMPLES.clear()
+    _EXAMPLES.extend(examples)


### PR DESCRIPTION
## Summary
- add new prompts package with intent, entity, query and response handlers
- support loading prompts from files or in-memory cache
- expose helper functions to fetch and update few-shot examples

## Testing
- `pytest -q` *(fails: AttributeError: '_DummySettings' object has no attribute 'USE_LLM_QUERY')*
- `pytest tests/test_security.py::test_bcrypt_version_without_about -q` *(fails: ModuleNotFoundError: No module named 'jose')*

------
https://chatgpt.com/codex/tasks/task_e_68a61151b964832086c25373a5de69a9