### PR TITLE
Add shared utils for logging and decorators

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility package providing shared helpers and decorators."""

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -1,0 +1,80 @@
+"""Generic decorators used across the project."""
+
+from __future__ import annotations
+
+import functools
+import logging
+import time
+from collections import deque
+from typing import Any, Callable, Tuple, Type
+
+Logger = logging.Logger
+
+
+def retry(
+    max_attempts: int = 3,
+    exceptions: Tuple[Type[BaseException], ...] = (Exception,),
+    delay: float = 0.0,
+    backoff: float = 1.0,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Retry a function call in case of specified exceptions."""
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            sleep = delay
+            for attempt in range(1, max_attempts + 1):
+                try:
+                    return func(*args, **kwargs)
+                except exceptions:
+                    if attempt == max_attempts:
+                        raise
+                    if sleep:
+                        time.sleep(sleep)
+                        sleep *= backoff
+        return wrapper
+
+    return decorator
+
+
+def timing(logger: Logger | None = None) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Measure and log the execution time of the wrapped function."""
+
+    logger = logger or logging.getLogger(__name__)
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            start = time.perf_counter()
+            try:
+                return func(*args, **kwargs)
+            finally:
+                duration = time.perf_counter() - start
+                logger.info("%s took %.4f seconds", func.__name__, duration)
+
+        return wrapper
+
+    return decorator
+
+
+def rate_limit(calls: int, period: float) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Limit the number of calls to *calls* within *period* seconds."""
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        timestamps: deque[float] = deque()
+
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            now = time.time()
+            while timestamps and timestamps[0] <= now - period:
+                timestamps.popleft()
+            if len(timestamps) >= calls:
+                sleep_time = period - (now - timestamps[0])
+                time.sleep(sleep_time)
+            result = func(*args, **kwargs)
+            timestamps.append(time.time())
+            return result
+
+        return wrapper
+
+    return decorator

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -1,0 +1,42 @@
+"""Common helper functions used across services."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Generator, Iterable, List, TypeVar
+
+T = TypeVar("T")
+
+
+def chunked(iterable: Iterable[T], size: int) -> Generator[List[T], None, None]:
+    """Yield successive chunks from *iterable* of length *size*.
+
+    Args:
+        iterable: Iterable to split.
+        size: Desired chunk size.
+
+    Yields:
+        Lists of items from *iterable* with length up to *size*.
+    """
+    if size <= 0:
+        raise ValueError("size must be a positive integer")
+
+    chunk: List[T] = []
+    for item in iterable:
+        chunk.append(item)
+        if len(chunk) == size:
+            yield chunk
+            chunk = []
+    if chunk:
+        yield chunk
+
+
+def get_env(name: str, default: str | None = None) -> str | None:
+    """Retrieve an environment variable with an optional default."""
+    return os.getenv(name, default)
+
+
+def generate_uuid() -> str:
+    """Return a new random UUID4 string."""
+    return str(uuid.uuid4())

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -1,0 +1,50 @@
+"""JSON logging configuration with correlation IDs."""
+
+from __future__ import annotations
+
+import logging
+import contextvars
+from typing import Optional
+
+from pythonjsonlogger import jsonlogger
+
+from .helpers import generate_uuid
+
+correlation_id_var: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "correlation_id", default=None
+)
+
+
+class CorrelationIdFilter(logging.Filter):
+    """Inject the correlation ID into log records."""
+
+    def filter(self, record: logging.LogRecord) -> bool:  # type: ignore[override]
+        record.correlation_id = correlation_id_var.get()
+        return True
+
+
+def set_correlation_id(correlation_id: Optional[str] = None) -> str:
+    """Set the correlation ID for the current context."""
+    if correlation_id is None:
+        correlation_id = generate_uuid()
+    correlation_id_var.set(correlation_id)
+    return correlation_id
+
+
+def get_correlation_id() -> Optional[str]:
+    """Return the current correlation ID."""
+    return correlation_id_var.get()
+
+
+def configure_logging(level: int = logging.INFO) -> None:
+    """Configure root logger to emit JSON logs including correlation IDs."""
+    handler = logging.StreamHandler()
+    formatter = jsonlogger.JsonFormatter(
+        "%(asctime)s %(levelname)s %(name)s %(message)s %(correlation_id)s"
+    )
+    handler.setFormatter(formatter)
+    handler.addFilter(CorrelationIdFilter())
+
+    root = logging.getLogger()
+    root.setLevel(level)
+    root.handlers = [handler]


### PR DESCRIPTION
## Summary
- add JSON logging configuration with correlation IDs
- provide common decorators (retry, timing, rate limit)
- centralize helper utilities

## Testing
- `pytest` *(fails: Interrupted: 14 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a6116143908320bb57e8e913da050d