### PR TITLE
feat: add websocket chat endpoint

### DIFF
--- a/conversation_service/api/__init__.py
+++ b/conversation_service/api/__init__.py
@@ -47,7 +47,8 @@ from .dependencies import (
 from .routes import (
     chat_router,
     health_router,
-    router as main_router
+    router as main_router,
+    ws_router
 )
 
 # API Models for external use
@@ -79,8 +80,9 @@ __all__ = [
     
     # Routers
     "chat_router",
-    "health_router", 
+    "health_router",
     "main_router",
+    "ws_router",
     
     # API Models
     "ConversationRequest",
@@ -99,9 +101,10 @@ API_PREFIX = f"/api/{API_VERSION}"
 ENDPOINTS_SUMMARY = {
     "POST /chat": "Main conversation endpoint with AutoGen multi-agent processing",
     "GET /health": "Service health check with component status",
-    "GET /metrics": "Performance metrics and agent statistics", 
+    "GET /metrics": "Performance metrics and agent statistics",
     "GET /docs": "Interactive API documentation",
-    "GET /redoc": "Alternative API documentation"
+    "GET /redoc": "Alternative API documentation",
+    "WS /ws/chat": "WebSocket chat endpoint with incremental agent messages"
 }
 
 # Rate limiting configuration

--- a/conversation_service/api/routes.py
+++ b/conversation_service/api/routes.py
@@ -34,6 +34,7 @@ from .dependencies import (
     get_conversation_service,
     get_conversation_read_service,
 )
+from .websocket import ws_router
 from ..core.conversation_manager import ConversationManager
 from ..models.conversation_models import (
     ConversationRequest,
@@ -626,3 +627,4 @@ async def store_conversation_turn(
 router.include_router(chat_router)
 router.include_router(health_router)
 router.include_router(conversations_router)
+router.include_router(ws_router)

--- a/conversation_service/api/websocket.py
+++ b/conversation_service/api/websocket.py
@@ -1,0 +1,107 @@
+import asyncio
+import logging
+import time
+from typing import Any, AsyncGenerator, Dict, Optional, Annotated
+
+from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
+
+from .dependencies import get_team_manager, get_conversation_manager
+from ..core.conversation_manager import ConversationManager
+from ..core.mvp_team_manager import MVPTeamManager
+
+logger = logging.getLogger(__name__)
+
+ws_router = APIRouter()
+
+
+async def agent_stream(
+    team_manager: MVPTeamManager,
+    conversation_manager: ConversationManager,
+    user_id: int,
+    conversation_id: str,
+    user_message: str,
+) -> AsyncGenerator[Dict[str, Any], None]:
+    """Run agents sequentially and yield incremental results."""
+    start = time.perf_counter()
+
+    intent_agent = team_manager.agents.get("intent_agent")
+    search_agent = team_manager.agents.get("search_query_agent")
+    response_agent = team_manager.agents.get("response_agent")
+
+    await conversation_manager.update_user_context(conversation_id, user_id, user_message)
+
+    intent_response = await intent_agent.execute_with_metrics(
+        {"user_message": user_message}, user_id
+    )
+    intent_result = intent_response.metadata.get("intent_result") if intent_response.metadata else None
+    yield {"event": "intent", "data": intent_response.metadata}
+
+    search_response = None
+    if intent_result and getattr(intent_result, "search_required", True):
+        search_response = await search_agent.execute_with_metrics(
+            {"intent_result": intent_result, "user_message": user_message}, user_id
+        )
+        yield {"event": "search", "data": search_response.metadata}
+
+    context = await conversation_manager.get_context(conversation_id)
+    response_payload = {
+        "user_message": user_message,
+        "search_results": search_response,
+        "context": context,
+        "search_error": False if search_response is None else not search_response.success,
+    }
+    response_response = await response_agent.execute_with_metrics(response_payload, user_id)
+    yield {
+        "event": "response",
+        "message": response_response.content,
+        "metadata": response_response.metadata,
+    }
+
+    total_time = (time.perf_counter() - start) * 1000
+    try:
+        await conversation_manager.add_turn(
+            conversation_id,
+            user_id,
+            user_message,
+            response_response.content,
+            intent_result=intent_result,
+            processing_time_ms=total_time,
+            agent_chain=["intent_agent", "search_query_agent", "response_agent"],
+            search_results_count=(
+                search_response.metadata.get("search_results_count")
+                if search_response and search_response.metadata
+                else None
+            ),
+            confidence_score=response_response.confidence_score,
+        )
+    except Exception as e:
+        logger.error(f"Failed to store conversation turn: {e}")
+
+
+@ws_router.websocket("/ws/chat")
+async def chat_websocket(
+    websocket: WebSocket,
+    team_manager: Annotated[MVPTeamManager, Depends(get_team_manager)],
+    conversation_manager: Annotated[ConversationManager, Depends(get_conversation_manager)],
+):
+    await websocket.accept()
+    logger.info("WebSocket connection accepted")
+    try:
+        while True:
+            data = await websocket.receive_json()
+            message: str = data.get("message", "")
+            conversation_id: str = data.get("conversation_id", "default")
+            user_id: int = int(data.get("user_id", 0))
+
+            async for event in agent_stream(
+                team_manager, conversation_manager, user_id, conversation_id, message
+            ):
+                await websocket.send_json(event)
+    except WebSocketDisconnect:
+        logger.info("WebSocket client disconnected")
+    except Exception as e:
+        logger.error(f"WebSocket error: {e}")
+        await websocket.send_json({"event": "error", "message": str(e)})
+    finally:
+        await websocket.close()
+        logger.info("WebSocket connection closed")


### PR DESCRIPTION
## Summary
- add `/ws/chat` WebSocket endpoint streaming incremental agent results
- register WebSocket router with API and document endpoint

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68a61169df0483208a790edb2b820bfb