### PR TITLE
chore: ignore common binary file types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,16 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Fichiers binaires
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.pdf
+*.mp3
+*.mp4
+*.wav
+*.zip
+*.tar
+*.gz


### PR DESCRIPTION
## Summary
- avoid tracking common binary assets by listing their extensions in .gitignore

## Testing
- `pytest` (fails: 16 errors during collection)


------
https://chatgpt.com/codex/tasks/task_e_68a61bdac3908320bdcd500be4834b4a