### PR TITLE
feat: replace deepseek with openai

### DIFF
--- a/conversation_service/agents/__init__.py
+++ b/conversation_service/agents/__init__.py
@@ -3,11 +3,11 @@ AutoGen Agents Package for Conversation Service MVP.
 
 This package contains specialized AutoGen v0.4 agents for financial conversation
 processing, including intent detection, search query generation, and response
-generation. All agents are optimized for DeepSeek LLM integration.
+generation. All agents are optimized for OpenAI LLM integration.
 
 Agents:
     - BaseFinancialAgent: Base class for all financial agents
-    - LLMIntentAgent: Intent detection powered by DeepSeek LLM
+    - LLMIntentAgent: Intent detection powered by OpenAI LLM
     - SearchQueryAgent: Search service interface + entity extraction
     - ResponseAgent: Contextual response generation
     - OrchestratorAgent: Multi-agent workflow coordination

--- a/conversation_service/agents/advanced_llm_intent_agent.py
+++ b/conversation_service/agents/advanced_llm_intent_agent.py
@@ -1,4 +1,4 @@
-"""Advanced LLM intent agent with few-shot prompts, caching, and retries."""
+"""Advanced OpenAI LLM intent agent with few-shot prompts, caching, and retries."""
 
 from __future__ import annotations
 
@@ -28,7 +28,7 @@ FEW_SHOT_EXAMPLES: Tuple[Tuple[str, str], ...] = (
 
 
 class AdvancedLLMIntentAgent(LLMIntentAgent):
-    """Extended intent agent with prompt engineering, retry, and caching."""
+    """Extended OpenAI intent agent with prompt engineering, retry, and caching."""
 
     def __init__(
         self,

--- a/conversation_service/agents/base_financial_agent.py
+++ b/conversation_service/agents/base_financial_agent.py
@@ -3,8 +3,9 @@ Base Financial Agent class for AutoGen v0.4 integration.
 
 This module provides the foundational class for all specialized financial agents
 in the conversation service. It includes common functionality like metrics tracking
-and error handling. Performance monitoring now tracks percentile distributions
-(p95, p99) and uses a 30-second threshold for health checks.
+and error handling for agents leveraging OpenAI's LLM API. Performance monitoring
+now tracks percentile distributions (p95, p99) and uses a 30-second threshold for
+health checks.
 
 Classes:
     - BaseFinancialAgent: Base class extending AutoGen AssistantAgent
@@ -12,7 +13,7 @@ Classes:
 
 Author: Conversation Service Team
 Created: 2025-01-31
-Version: 1.0.0 MVP - AutoGen v0.4 + DeepSeek
+Version: 1.0.0 MVP - AutoGen v0.4 + OpenAI
 """
 
 import time
@@ -194,7 +195,7 @@ class BaseFinancialAgent(AssistantAgent):
     Base class for all financial agents in the conversation service.
     
     This class extends AutoGen's AssistantAgent with financial domain-specific
-    functionality, including DeepSeek integration, metrics tracking, and
+    functionality, including OpenAI integration, metrics tracking, and
     standardized error handling.
     
     Attributes:

--- a/conversation_service/agents/enhanced_llm_intent_agent.py
+++ b/conversation_service/agents/enhanced_llm_intent_agent.py
@@ -1,10 +1,11 @@
-"""Enhanced LLM Intent Agent.
+"""Enhanced OpenAI LLM Intent Agent.
 
 This module introduces :class:`EnhancedLLMIntentAgent`, an extension of
 :class:`LLMIntentAgent` adding robust error handling and latency
-measurement. The agent wraps the base implementation with a fallback
-mechanism so that the system can gracefully recover from LLM failures.
-The measured latency is stored in the returned :class:`IntentResult`.
+measurement for OpenAI-based intent detection. The agent wraps the base
+implementation with a fallback mechanism so that the system can gracefully
+recover from LLM failures. The measured latency is stored in the returned
+:class:`IntentResult`.
 """
 
 from __future__ import annotations
@@ -27,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 
 class EnhancedLLMIntentAgent(LLMIntentAgent):
-    """LLM intent agent with fallback and latency tracking."""
+    """OpenAI intent agent with fallback and latency tracking."""
 
     def __init__(
         self,

--- a/conversation_service/agents/llm_intent_agent.py
+++ b/conversation_service/agents/llm_intent_agent.py
@@ -272,7 +272,7 @@ class LLMIntentAgent(BaseFinancialAgent):
     ) -> Dict[str, Any]:
         """Detect the intent of ``user_message``.
 
-        The DeepSeek client returns a JSON document describing the intent and any
+        The OpenAI client returns a JSON document describing the intent and any
         extracted entities.  This method converts that JSON into an
         :class:`IntentResult` and wraps it in the structure used by the rest of
         the service.

--- a/conversation_service/agents/mock_intent_agent.py
+++ b/conversation_service/agents/mock_intent_agent.py
@@ -1,6 +1,6 @@
 """Mock intent detection agent for workflow validation.
 
-This agent bypasses any LLM calls and returns pre-defined intent
+This agent bypasses any OpenAI LLM calls and returns pre-defined intent
 classification results for a fixed set of user questions.  It enables the
 rest of the conversation workflow to be validated independently of the
 actual intent detection model.

--- a/conversation_service/agents/orchestrator_agent.py
+++ b/conversation_service/agents/orchestrator_agent.py
@@ -1,9 +1,10 @@
 """
-Orchestrator Agent for coordinating multi-agent workflows.
+Orchestrator Agent for coordinating OpenAI-powered multi-agent workflows.
 
 This agent coordinates the execution of the three specialized agents
 (Intent, Search Query, and Response) to provide a complete conversation
-processing pipeline with error handling and fallback mechanisms.
+processing pipeline with error handling and fallback mechanisms built
+around OpenAI LLM services.
 
 Classes:
     - OrchestratorAgent: Main workflow coordination agent

--- a/conversation_service/agents/response_agent.py
+++ b/conversation_service/agents/response_agent.py
@@ -1,9 +1,9 @@
 """
 Response Generation Agent for contextual financial conversations.
 
-This agent generates natural, contextual responses based on search results
-and conversation history. It formats financial data in user-friendly ways
-and maintains conversation continuity.
+This agent uses OpenAI's language models to generate natural, contextual
+responses based on search results and conversation history. It formats
+financial data in user-friendly ways and maintains conversation continuity.
 
 Classes:
     - ResponseAgent: Main response generation agent

--- a/conversation_service/agents/search_query_agent.py
+++ b/conversation_service/agents/search_query_agent.py
@@ -1,9 +1,9 @@
 """
 Search Query Agent for interfacing with Search Service.
 
-This agent generates optimized search queries for the Search Service based on
-detected intents and user messages. It includes entity extraction, query
-optimization, and standardized search service communication.
+This agent leverages OpenAI LLMs to generate optimized search queries for the
+Search Service based on detected intents and user messages. It includes entity
+extraction, query optimization, and standardized search service communication.
 
 See README.md#entites-de-recherche-et-filtres-elasticsearch for the mapping
 between entities, their canonical values and the Elasticsearch filters used.

--- a/conversation_service/prompts/__init__.py
+++ b/conversation_service/prompts/__init__.py
@@ -1,7 +1,7 @@
 """
 🎭 Prompts Package - Conversation Service
 
-Ce package contient tous les prompts optimisés pour DeepSeek dans le contexte
+Ce package contient tous les prompts optimisés pour OpenAI dans le contexte
 d'agents AutoGen financiers. Chaque module expose des prompts spécialisés
 et des fonctions de formatage pour maximiser la précision des réponses.
 
@@ -89,4 +89,4 @@ __all__ = [
 # Métadonnées du package
 __version__ = "1.0.0"
 __author__ = "Conversation Service Team"
-__description__ = "Prompts optimisés DeepSeek pour agents AutoGen financiers"
+__description__ = "Prompts optimisés OpenAI pour agents AutoGen financiers"

--- a/conversation_service/prompts/intent_prompts.py
+++ b/conversation_service/prompts/intent_prompts.py
@@ -1,14 +1,14 @@
 """
 🧠 Intent Detection Prompts - IA Principale pour Classification
 
-Ce module contient les prompts optimisés DeepSeek pour la détection d'intention
+Ce module contient les prompts optimisés OpenAI pour la détection d'intention
 en mode LLM principal sans recours au pattern matching.
 
 Responsabilité :
 - Classification précise des intentions utilisateur
 - Extraction des entités financières associées
 - Gestion du contexte conversationnel
-- Format de sortie strict pour les agents DeepSeek
+- Format de sortie strict pour les agents OpenAI
 """
 
 from typing import Dict, List, Optional, Any
@@ -143,11 +143,11 @@ def format_intent_prompt(user_message: str, context: str = "") -> str:
         context: Contexte conversationnel optionnel
         
     Returns:
-        Prompt formaté prêt pour DeepSeek
+        Prompt formaté prêt pour OpenAI
         
     Example:
         >>> prompt = format_intent_prompt("Mes achats Amazon", "L'utilisateur cherchait ses factures")
-        >>> # Utilisation avec DeepSeek client
+        >>> # Utilisation avec un client OpenAI
     """
     if not user_message or not user_message.strip():
         raise ValueError("user_message ne peut pas être vide")
@@ -217,10 +217,10 @@ def build_context_summary(conversation_history: List[Dict[str, Any]], max_tokens
 
 def parse_intent_response(response: str) -> Dict[str, Any]:
     """
-    Parse la réponse formatée de DeepSeek pour extraire les composants structurés.
+    Parse la réponse formatée de l'API OpenAI pour extraire les composants structurés.
     
     Args:
-        response: Réponse brute de DeepSeek
+        response: Réponse brute de l'API OpenAI
         
     Returns:
         Dict avec intent, confidence, entities, reasoning
@@ -234,7 +234,7 @@ def parse_intent_response(response: str) -> Dict[str, Any]:
         >>> print(parsed["intent"])  # "transaction_query"
     """
     if not response or not response.strip():
-        raise ValueError("Réponse vide de DeepSeek")
+        raise ValueError("Réponse vide de l'API OpenAI")
     
     try:
         lines = response.strip().split('\n')

--- a/conversation_service/prompts/orchestrator_prompts.py
+++ b/conversation_service/prompts/orchestrator_prompts.py
@@ -1,7 +1,7 @@
 """
 🎭 Orchestrator Prompts - Coordination Agents AutoGen
 
-Ce module contient les prompts optimisés DeepSeek pour l'orchestrateur principal
+Ce module contient les prompts optimisés OpenAI pour l'orchestrateur principal
 qui coordonne les agents spécialisés dans le pipeline conversationnel.
 
 Responsabilité :
@@ -56,7 +56,7 @@ Coordonner intelligemment une équipe d'agents spécialisés pour traiter les de
 
 1. **LLMIntentAgent** - Détection d'intention via LLM
    - Spécialité : Classification intentions + extraction entités
-   - Mode : DeepSeek LLM uniquement
+   - Mode : OpenAI LLM uniquement
    - Performance : <200ms (IA)
    - Fiabilité : 95%+ sur intentions financières courantes
 
@@ -186,7 +186,7 @@ def format_orchestrator_prompt(
         constraints: Contraintes de temps/budget/qualité
         
     Returns:
-        Prompt formaté prêt pour DeepSeek
+        Prompt formaté prêt pour OpenAI
         
     Example:
         >>> prompt = format_orchestrator_prompt(
@@ -345,10 +345,10 @@ def build_workflow_state(
 
 def parse_orchestrator_decision(response: str) -> Dict[str, Any]:
     """
-    Parse la décision JSON de l'orchestrateur DeepSeek.
+    Parse la décision JSON de l'orchestrateur OpenAI.
     
     Args:
-        response: Réponse brute de DeepSeek
+        response: Réponse brute de l'API OpenAI
         
     Returns:
         Décision parsée et validée

--- a/conversation_service/prompts/response_prompts.py
+++ b/conversation_service/prompts/response_prompts.py
@@ -1,7 +1,7 @@
 """
 💬 Response Generation Prompts - Génération Réponses Contextuelles
 
-Ce module contient les prompts optimisés DeepSeek pour générer des réponses
+Ce module contient les prompts optimisés OpenAI pour générer des réponses
 finales enrichies, contextuelles et naturelles à partir des résultats du Search Service.
 """
 

--- a/conversation_service/prompts/search_prompts.py
+++ b/conversation_service/prompts/search_prompts.py
@@ -1,7 +1,7 @@
 """
 🔍 Search Query Generation Prompts - Génération Requêtes Search Service
 
-Ce module contient les prompts optimisés DeepSeek pour transformer les intentions
+Ce module contient les prompts optimisés OpenAI pour transformer les intentions
 et entités utilisateur en requêtes structurées pour le Search Service.
 
 Responsabilité :
@@ -142,7 +142,7 @@ def format_search_prompt(
         context: Contexte conversationnel optionnel
         
     Returns:
-        Prompt formaté prêt pour DeepSeek
+        Prompt formaté prêt pour OpenAI
         
     Raises:
         ValueError: Si intent_result invalide
@@ -362,10 +362,10 @@ def extract_amount_range(amount_entities: List[str]) -> Dict[str, float]:
 
 def parse_search_response(response: str, user_id: str) -> Dict[str, Any]:
     """
-    Parse la réponse JSON de DeepSeek et injecte l'user_id obligatoire.
+    Parse la réponse JSON de l'API OpenAI et injecte l'user_id obligatoire.
     
     Args:
-        response: Réponse brute JSON de DeepSeek
+        response: Réponse brute JSON de l'API OpenAI
         user_id: ID utilisateur à injecter dans les filtres
         
     Returns:
@@ -379,7 +379,7 @@ def parse_search_response(response: str, user_id: str) -> Dict[str, Any]:
         >>> # query["filters"]["user_id"] == "user123"
     """
     if not response or not response.strip():
-        raise ValueError("Réponse vide de DeepSeek")
+        raise ValueError("Réponse vide de l'API OpenAI")
     
     if not user_id:
         raise ValueError("user_id est obligatoire")


### PR DESCRIPTION
## Summary
- swap DeepSeek for OpenAI across conversation prompts
- refresh agent docstrings to mention OpenAI integration
- ensure prompt examples and formats align with OpenAI API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a629305bcc8320b56bcc4677233453