### PR TITLE
Remove DeepSeek references and migrate to OpenAI

### DIFF
--- a/config/autogen_config.py
+++ b/config/autogen_config.py
@@ -18,7 +18,7 @@ class AutoGenSettings(BaseSettings):
     BONSAI_URL: str = ""
     BRIDGE_CLIENT_ID: str = ""
     BRIDGE_CLIENT_SECRET: str = ""
-    DEEPSEEK_API_KEY: str = ""
+    OPENAI_API_KEY: str = ""
 
     WORKFLOW_TIMEOUT_SECONDS: int = 45
     HEALTH_CHECK_INTERVAL_SECONDS: int = 300
@@ -29,8 +29,8 @@ class AutoGenSettings(BaseSettings):
     ORCHESTRATOR_PERFORMANCE_THRESHOLD_MS: int = 30000
     AGENT_REACTIVATION_COOLDOWN_SECONDS: int = 60
 
-    DEEPSEEK_BASE_URL: str = "https://api.deepseek.com"
-    DEEPSEEK_TIMEOUT: int = 30
+    OPENAI_BASE_URL: str = "https://api.openai.com/v1"
+    OPENAI_TIMEOUT: int = 30
     SEARCH_SERVICE_URL: str = "http://localhost:8000/api/v1/search"
     MAX_CONVERSATION_HISTORY: int = 100
 

--- a/config_service/config.py
+++ b/config_service/config.py
@@ -136,6 +136,9 @@ class GlobalSettings(BaseSettings):
     LLM_CACHE_MAX_SIZE: int = int(os.environ.get("LLM_CACHE_MAX_SIZE", "1000"))
     LLM_TEMPERATURE: float = float(os.environ.get("LLM_TEMPERATURE", "0.1"))
     LLM_TOP_P: float = float(os.environ.get("LLM_TOP_P", os.environ.get("TOP_P", "0.95")))
+    INTENT_TIMEOUT_SECONDS: int = int(os.environ.get("INTENT_TIMEOUT_SECONDS", "10"))
+    INTENT_MAX_RETRIES: int = int(os.environ.get("INTENT_MAX_RETRIES", "3"))
+    INTENT_BACKOFF_BASE: float = float(os.environ.get("INTENT_BACKOFF_BASE", "1"))
     
     # ==========================================
     # CONFIGURATION OPENAI POUR LES EMBEDDINGS

--- a/conversation_service/__init__.py
+++ b/conversation_service/__init__.py
@@ -1,9 +1,7 @@
 """
 Conversation Service MVP Package
 
-Service de conversation intelligent basé sur AutoGen v0.4 et DeepSeek
-pour le domaine financier avec détection d'intentions entièrement LLM.
-pour le domaine financier avec détection d'intentions LLM-only.
+Service de conversation intelligent basé sur AutoGen v0.4 et OpenAI
 pour le domaine financier avec détection d'intentions assistée par LLM.
 """
 
@@ -19,7 +17,7 @@ __all__ = ["__version__", "__author__", "agents"]
 # avoid this, the behaviour is now opt-in via a configuration flag.
 from config.settings import settings
 
-if settings.CS_AUTO_IMPORT_SUBPACKAGES == 1:
+if getattr(settings, "CS_AUTO_IMPORT_SUBPACKAGES", 0) == 1:
     for _mod in ["api", "core", "models", "services", "utils"]:
         try:
             globals()[_mod] = __import__(f"{__name__}.{_mod}", fromlist=["*"])

--- a/conversation_service/agents/search_query_agent.py
+++ b/conversation_service/agents/search_query_agent.py
@@ -660,9 +660,9 @@ class SearchQueryAgent(BaseFinancialAgent):
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": prompt},
             ],
-            temperature=settings.DEEPSEEK_QUERY_TEMPERATURE,
-            max_tokens=settings.DEEPSEEK_QUERY_MAX_TOKENS,
-            top_p=settings.DEEPSEEK_QUERY_TOP_P,
+            temperature=settings.OPENAI_QUERY_TEMPERATURE,
+            max_tokens=settings.OPENAI_QUERY_MAX_TOKENS,
+            top_p=settings.OPENAI_QUERY_TOP_P,
             user=str(user_id),
             use_cache=True,
         )

--- a/conversation_service/core/__init__.py
+++ b/conversation_service/core/__init__.py
@@ -2,8 +2,7 @@
 
 This package exposes the main components required by the conversation
 service and provides helper functions for validating the runtime
-environment.  DeepSeek specific code has been removed in favour of a
-generic OpenAI configuration using :class:`~config.openai_config.OpenAISettings`.
+environment using :class:`~config.openai_config.OpenAISettings`.
 """
 
 from __future__ import annotations
@@ -204,19 +203,7 @@ def validate_core_setup() -> dict:
     if config["team_workflow_timeout"] < 30:
         results["warnings"].append("Team workflow timeout low - complex workflows may fail")
     
-    # Environment variable checks
-    import os
-    required_env_vars = ["DEEPSEEK_API_KEY"]
-    for var in required_env_vars:
-        if not getattr(settings, var, None):
-            results["errors"].append(f"Required environment variable missing: {var}")
-            results["valid"] = False
-    
     # Info messages
-        results["warnings"].append(
-            "Team workflow timeout low - complex workflows may fail"
-        )
-
     results["info"].append(f"Core package version: {__version__}")
     results["info"].append(
         f"Available components: {len(get_available_components())}"

--- a/conversation_service/core/mvp_team_manager.py
+++ b/conversation_service/core/mvp_team_manager.py
@@ -416,9 +416,9 @@ class MVPTeamManager:
     def _load_config_from_env(self) -> Dict[str, Any]:
         """Load configuration from environment variables."""
         return {
-            'DEEPSEEK_API_KEY': settings.DEEPSEEK_API_KEY,
-            'DEEPSEEK_BASE_URL': settings.DEEPSEEK_BASE_URL,
-            'DEEPSEEK_TIMEOUT': settings.DEEPSEEK_TIMEOUT,
+            'OPENAI_API_KEY': settings.OPENAI_API_KEY,
+            'OPENAI_BASE_URL': settings.OPENAI_BASE_URL,
+            'OPENAI_TIMEOUT': settings.OPENAI_TIMEOUT,
             'SEARCH_SERVICE_URL': settings.SEARCH_SERVICE_URL,
             'MAX_CONVERSATION_HISTORY': settings.MAX_CONVERSATION_HISTORY,
             'WORKFLOW_TIMEOUT_SECONDS': settings.WORKFLOW_TIMEOUT_SECONDS,

--- a/conversation_service/models/agent_models.py
+++ b/conversation_service/models/agent_models.py
@@ -39,11 +39,11 @@ class AgentConfig(BaseModel):
     This model defines the complete configuration for an AutoGen agent,
     including model client settings, system messages, and behavioral parameters.
     Optimized for financial domain specialization and compatible with multiple
-    LLM providers (e.g., DeepSeek, OpenAI's GPT models).
+    LLM providers such as OpenAI's GPT models.
     
     Attributes:
         name: Unique identifier for the agent
-        model_client_config: LLM model configuration (DeepSeek, OpenAI GPT, etc.)
+        model_client_config: LLM model configuration (e.g., OpenAI GPT)
         system_message: System prompt for the agent's behavior
         max_consecutive_auto_reply: Maximum consecutive auto-replies
         description: Optional description of agent's purpose

--- a/conversation_service/models/service_contracts.py
+++ b/conversation_service/models/service_contracts.py
@@ -2,7 +2,7 @@
 Service contracts for standardized communication between Conversation Service and Search Service.
 
 This module defines the interface contracts that ensure consistent and reliable
-communication between the Conversation Service (AutoGen + DeepSeek) and the
+communication between the Conversation Service (AutoGen + OpenAI) and the
 Search Service (Elasticsearch). These contracts provide type safety and clear
 API specifications.
 

--- a/heroku_app.py
+++ b/heroku_app.py
@@ -99,42 +99,35 @@ class ServiceLoader:
             return False
     
     async def initialize_conversation_service(self, app: FastAPI):
-        """Initialise le conversation_service avec DeepSeek."""
+        """Initialise le conversation_service avec OpenAI."""
         logger.info("🤖 Initialisation du conversation_service...")
-        
+
         try:
-            # Vérifier DEEPSEEK_API_KEY
-            deepseek_key = settings.DEEPSEEK_API_KEY
-            if not deepseek_key:
-                raise ValueError("DEEPSEEK_API_KEY n'est pas configurée")
-            
-            logger.info(f"🔑 DEEPSEEK_API_KEY configurée: {deepseek_key[:20]}...")
-            
-            # Import et initialisation du conversation service
-            from config_service.config import settings
-            from conversation_service.core import deepseek_client
-            
+            # Vérifier OPENAI_API_KEY
+            openai_key = settings.OPENAI_API_KEY
+            if not openai_key:
+                raise ValueError("OPENAI_API_KEY n'est pas configurée")
+
+            logger.info(f"🔑 OPENAI_API_KEY configurée: {openai_key[:20]}...")
+
             # Validation de la configuration
+            from conversation_service.core import run_core_validation
+            from conversation_service.core.mvp_team_manager import MVPTeamManager
+
             logger.info("⚙️ Validation de la configuration...")
-            validation = settings.validate_configuration()
+            validation = run_core_validation()
             if not validation["valid"]:
                 raise ValueError(f"Configuration invalide: {validation['errors']}")
-            
             if validation["warnings"]:
                 logger.warning(f"⚠️ Avertissements: {validation['warnings']}")
-            
-            # Test de connexion DeepSeek
-            logger.info("🔍 Test de connexion DeepSeek...")
-            health_check = await deepseek_client.health_check()
-            
-            if health_check["status"] != "healthy":
-                raise ValueError(f"DeepSeek non disponible: {health_check.get('error', 'Unknown error')}")
-            
-            logger.info(f"✅ DeepSeek connecté - Temps de réponse: {health_check['response_time']:.2f}s")
-            
+
+            # Initialiser le gestionnaire d'équipe
+            team_manager = MVPTeamManager()
+            await team_manager.initialize_agents(initial_health_check=False)
+
             # Mettre les composants dans app.state
             app.state.conversation_service_initialized = True
-            app.state.deepseek_client = deepseek_client
+            app.state.team_manager = team_manager
             app.state.conversation_initialization_error = None
 
             self.conversation_service_initialized = True
@@ -151,10 +144,10 @@ class ServiceLoader:
         except Exception as e:
             error_msg = f"Erreur initialisation conversation_service: {str(e)}"
             logger.error(f"❌ {error_msg}")
-            
+
             # Marquer l'échec dans app.state
             app.state.conversation_service_initialized = False
-            app.state.deepseek_client = None
+            app.state.team_manager = None
             app.state.conversation_initialization_error = error_msg
 
             self.conversation_service_initialized = False
@@ -372,10 +365,10 @@ def create_app():
                 "architecture": "simplified_unified"
             }
 
-        # 5. ✅ CONVERSATION SERVICE - NOUVEAU avec DeepSeek
+        # 5. ✅ CONVERSATION SERVICE - NOUVEAU avec OpenAI
         logger.info("🤖 Chargement et initialisation du conversation_service...")
         try:
-            # D'abord initialiser les composants DeepSeek
+            # D'abord initialiser les composants OpenAI
             conversation_init_success = await loader.initialize_conversation_service(app)
             
             # Ensuite charger les routes
@@ -395,7 +388,7 @@ def create_app():
                         "prefix": "/api/v1/conversation",
                         "initialized": True,
                         "architecture": "llm_intent_agent",
-                        "model": "deepseek-chat",
+                        "model": settings.OPENAI_CHAT_MODEL,
                         "error": None,
                     })
                 else:
@@ -410,7 +403,7 @@ def create_app():
                         "initialized": False,
                         "error": loader.conversation_service_error,
                         "architecture": "llm_intent_agent",
-                        "model": "deepseek-chat",
+                        "model": settings.OPENAI_CHAT_MODEL,
                     })
 
             except ImportError as e:
@@ -500,7 +493,7 @@ def create_app():
                 "initialized": loader.conversation_service_initialized,
                 "error": loader.conversation_service_error,
                 "architecture": "llm_intent_agent",
-                "model": "deepseek-chat"
+                "model": settings.OPENAI_CHAT_MODEL
             }
         }
 
@@ -515,7 +508,7 @@ def create_app():
                 "sync_service - Synchronisation Bridge API", 
                 "enrichment_service - Enrichissement IA",
                 "search_service - Recherche lexicale (Architecture simplifiée)",
-                "conversation_service - Assistant IA avec DeepSeek (MVP)"
+                "conversation_service - Assistant IA avec OpenAI (MVP)"
             ],
             "services_coming_soon": [
                 "conversation_service v2 - Assistant IA avec AutoGen + équipes d'agents"
@@ -530,7 +523,7 @@ def create_app():
                 "/api/v1/categories/*": "Catégories",
                 "/api/v1/enrichment/*": "Enrichissement IA",
                 "/api/v1/search/*": "Recherche lexicale (Architecture unifiée)",
-                "/api/v1/conversation/*": "Assistant IA conversationnel (DeepSeek MVP)"
+                "/api/v1/conversation/*": "Assistant IA conversationnel (OpenAI MVP)"
             }
         }
 


### PR DESCRIPTION
## Summary
- Replace DeepSeek mentions with OpenAI across conversation service modules
- Adjust configuration defaults for OpenAI and add missing intent settings
- Update Heroku entrypoint to initialize conversation service with OpenAI

## Testing
- `OPENAI_API_KEY=dummy pytest` (4 failed, 48 passed, 1 skipped)

------
https://chatgpt.com/codex/tasks/task_e_68a630bcfa5483209b9a6bdb06c1f91e