### PR TITLE
Use websocket router from routes module

### DIFF
--- a/local_app.py
+++ b/local_app.py
@@ -418,8 +418,10 @@ def create_app():
         try:
             conv_init = await loader.initialize_conversation_service()
             if conv_init:
-                from conversation_service.api.routes import router as conversation_router
-                from conversation_service.api.websocket import router as conversation_ws_router
+                from conversation_service.api.routes import (
+                    router as conversation_router,
+                    websocket_router as conversation_ws_router,
+                )
 
                 app.include_router(
                     conversation_router,


### PR DESCRIPTION
## Summary
- import conversation websocket router from `conversation_service.api.routes`
- keep HTTP and WebSocket routes under `/api/v1/conversation`

## Testing
- `pytest -q` *(fails: SyntaxError in `conversation_service/api/dependencies.py`, AttributeError: module 'httpx' has no attribute 'Response')*

------
https://chatgpt.com/codex/tasks/task_e_68a637c3f0c08320a7cb8b841c751283