### PR TITLE
refactor: centralize settings imports

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -39,7 +39,7 @@ except ImportError as e:
     raise
 
 # Import de la configuration
-from config_service.config import settings
+from config.settings import settings
 
 # -----------------------------------------------------------------------------
 # Configuration Alembic

--- a/config/settings.py
+++ b/config/settings.py
@@ -7,9 +7,5 @@ class Settings(AutoGenSettings, OpenAISettings):
 
 
 settings = Settings()
-from config_service.config import GlobalSettings, settings as _settings
 
-# Re-export settings for the new configuration module
-settings = _settings
-
-__all__ = ["GlobalSettings", "settings"]
+__all__ = ["settings"]

--- a/config_service/__init__.py
+++ b/config_service/__init__.py
@@ -5,6 +5,6 @@ Ce module fournit un point d'accès unique aux paramètres de configuration
 pour tous les services de la plateforme Harena.
 """
 
-from config_service.config import settings
+from config.settings import settings
 
-__all__ = ['settings']
+__all__ = ["settings"]

--- a/db_service/session.py
+++ b/db_service/session.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import sessionmaker, scoped_session
 from sqlalchemy.ext.declarative import declarative_base
 from contextlib import contextmanager
 
-from config_service.config import settings
+from config.settings import settings
 
 # Création de l'engine central
 engine = create_engine(settings.SQLALCHEMY_DATABASE_URI, pool_pre_ping=True)

--- a/enrichment_service/main.py
+++ b/enrichment_service/main.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from enrichment_service.api.routes import router
 from enrichment_service.storage.elasticsearch_client import ElasticsearchClient
 from enrichment_service.core.processor import ElasticsearchTransactionProcessor
-from config_service.config import settings
+from config.settings import settings
 
 # Configuration du logging
 logging.basicConfig(

--- a/enrichment_service/storage/elasticsearch_client.py
+++ b/enrichment_service/storage/elasticsearch_client.py
@@ -11,7 +11,7 @@ import time
 from typing import Dict, Any, List, Optional
 from datetime import datetime
 
-from config_service.config import settings
+from config.settings import settings
 
 logger = logging.getLogger("enrichment_service.elasticsearch")
 

--- a/heroku_app.py
+++ b/heroku_app.py
@@ -111,7 +111,6 @@ class ServiceLoader:
             logger.info(f"🔑 Clé API configurée: {api_key[:20]}...")
 
             # Import et initialisation du conversation service
-            from config_service.config import settings
             # Vérifier OPENAI_API_KEY
             openai_key = settings.OPENAI_API_KEY
             if not openai_key:

--- a/main.py
+++ b/main.py
@@ -82,7 +82,7 @@ available_services = {}
 try:
     from user_service.main import create_app as create_user_app
     user_app = create_user_app()
-    from config_service.config import settings as user_settings
+    from config.settings import settings as user_settings
     logger.info("User Service importé avec succès")
     available_services["user_service"] = {
         "app": user_app,

--- a/search_service/api/routes.py
+++ b/search_service/api/routes.py
@@ -4,7 +4,7 @@ from typing import Dict, Any
 
 from search_service.models.request import SearchRequest
 from search_service.core.search_engine import SearchEngine, RateLimitExceeded
-from config_service.config import settings
+from config.settings import settings
 
 logger = logging.getLogger(__name__)
 

--- a/search_service/core/elasticsearch_client.py
+++ b/search_service/core/elasticsearch_client.py
@@ -3,7 +3,7 @@ import aiohttp
 import ssl
 import threading
 from typing import Dict, Any, Optional
-from config_service.config import settings
+from config.settings import settings
 
 logger = logging.getLogger(__name__)
 

--- a/search_service/main.py
+++ b/search_service/main.py
@@ -5,7 +5,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from config_service.config import settings
+from config.settings import settings
 from .api import router, initialize_search_engine
 
 # Configuration du logging

--- a/sync_service/api/endpoints/webhooks.py
+++ b/sync_service/api/endpoints/webhooks.py
@@ -12,7 +12,7 @@ from typing import Dict, Any, Optional
 logger = logging.getLogger(__name__)
 
 from conversation_service.api.dependencies import get_db
-from config_service.config import settings
+from config.settings import settings
 from sync_service.webhook_handler.processor import process_webhook, validate_webhook
 
 router = APIRouter()

--- a/sync_service/api/router.py
+++ b/sync_service/api/router.py
@@ -256,7 +256,7 @@ def setup_middleware(app: FastAPI) -> None:
     logger.info("Logging middleware configured")
     
     # Ajouter le middleware de limitation de taux conditionnellement
-    from config_service.config import settings
+    from config.settings import settings
     
     if getattr(settings, "RATE_LIMIT_ENABLED", False):
         rate_limit = getattr(settings, "RATE_LIMIT_REQUESTS", 60)
@@ -307,7 +307,7 @@ def create_error_handlers(app: FastAPI) -> None:
         )
         
         # Déterminer le niveau de détail selon l'environnement
-        from config_service.config import settings
+        from config.settings import settings
         is_dev = getattr(settings, "ENVIRONMENT", "production").lower() in ["development", "dev", "local"]
         
         error_content = {
@@ -336,7 +336,7 @@ def create_error_handlers(app: FastAPI) -> None:
         )
         
         # Déterminer le niveau de détail selon l'environnement
-        from config_service.config import settings
+        from config.settings import settings
         is_dev = getattr(settings, "ENVIRONMENT", "production").lower() in ["development", "dev", "local"]
         
         error_content = {

--- a/sync_service/main.py
+++ b/sync_service/main.py
@@ -11,7 +11,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
 
 from sync_service.api.router import register_routers, setup_middleware
-from config_service.config import settings
+from config.settings import settings
 from sync_service.utils.logging import setup_logging
 
 # Configuration du logging

--- a/sync_service/services/bridge_service.py
+++ b/sync_service/services/bridge_service.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone, timedelta
 from typing import Dict, List, Any, Optional
 from urllib.parse import urlencode
 
-from config_service.config import settings
+from config.settings import settings
 
 logger = logging.getLogger(__name__)
 

--- a/sync_service/sync_manager/orchestrator.py
+++ b/sync_service/sync_manager/orchestrator.py
@@ -17,7 +17,7 @@ from db_service.models.sync import SyncItem, SyncAccount
 from db_service.models.user import User, BridgeConnection
 
 # Import des services
-from config_service.config import settings
+from config.settings import settings
 from sync_service.utils.logging import get_contextual_logger
 
 # Import des gestionnaires spécifiques

--- a/user_service/api/deps.py
+++ b/user_service/api/deps.py
@@ -8,7 +8,7 @@ from typing import Optional, List
 from conversation_service.api.dependencies import get_db
 from db_service.models.user import User
 from user_service.services.users import get_user_by_id
-from config_service.config import settings
+from config.settings import settings
 from user_service.core.security import ALGORITHM
 from user_service.schemas.user import TokenData
 

--- a/user_service/api/endpoints/users.py
+++ b/user_service/api/endpoints/users.py
@@ -10,7 +10,7 @@ from user_service.schemas.user import (
 )
 from user_service.api.deps import get_db, get_current_active_user
 from user_service.services import users, bridge
-from config_service.config import settings
+from config.settings import settings
 from user_service.core.security import create_access_token
 
 router = APIRouter()

--- a/user_service/core/security.py
+++ b/user_service/core/security.py
@@ -5,7 +5,7 @@ import logging
 from jose import jwt
 from passlib.context import CryptContext
 
-from config_service.config import settings
+from config.settings import settings
 
 # Configuration des logs
 logging.basicConfig(level=logging.INFO)

--- a/user_service/db/session.py
+++ b/user_service/db/session.py
@@ -3,7 +3,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
-from config_service.config import settings
+from config.settings import settings
 
 engine = create_engine(settings.SQLALCHEMY_DATABASE_URI, pool_pre_ping=True)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/user_service/main.py
+++ b/user_service/main.py
@@ -12,7 +12,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
 
 from user_service.api.endpoints import users
-from config_service.config import settings
+from config.settings import settings
 
 # Configuration du logging
 logging.basicConfig(

--- a/user_service/services/bridge.py
+++ b/user_service/services/bridge.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import Session
 from fastapi import HTTPException, status
 
 from db_service.models.user import User, BridgeConnection
-from config_service.config import settings
+from config.settings import settings
 
 
 # Configuration des logs


### PR DESCRIPTION
## Summary
- remove config_service re-exports so `config.settings` only exposes a single `settings` instance
- update services to import `settings` from `config.settings`

## Testing
- `pytest` *(fails: conversation_service/api/dependencies.py syntax error; httpx missing Response attribute)*

------
https://chatgpt.com/codex/tasks/task_e_68a637c5727083209230534a130491a2