### PR TITLE
Consolidate conversation dependency docstring

### DIFF
--- a/conversation_service/api/dependencies.py
+++ b/conversation_service/api/dependencies.py
@@ -1,10 +1,10 @@
 """FastAPI dependencies for the Conversation Service MVP.
 
-"""Minimal dependency definitions for the conversation service.
+Minimal dependency definitions for the conversation service.
 
 This module provides dependency injection helpers for FastAPI endpoints,
-managing AutoGen team managers, conversation context, authentication and
-request validation.
+    managing AutoGen team managers, conversation context, authentication and
+    request validation.
 
 Dependencies:
     - get_team_manager: Provides singleton ``MVPTeamManager`` instance


### PR DESCRIPTION
## Summary
- fix top-level docstring in conversation dependencies to remove stray quotes

## Testing
- `pytest tests/test_dependency_singletons.py` *(fails: AttributeError: 'Settings' object has no attribute 'SQLALCHEMY_DATABASE_URI')*

------
https://chatgpt.com/codex/tasks/task_e_68a69ff591448320be8bcdb4ab8d615c