### PR TITLE
refactor: drop legacy config_service stubs in tests

### DIFF
--- a/tests/test_prompts/test_prompt_examples.py
+++ b/tests/test_prompts/test_prompt_examples.py
@@ -1,19 +1,3 @@
-import types
-import sys
-
-# Preserve original modules so other tests are unaffected
-_orig_config_service = sys.modules.get("config_service")
-_orig_config_config = sys.modules.get("config_service.config")
-_orig_pydantic_settings = sys.modules.get("pydantic_settings")
-
-sys.modules["pydantic_settings"] = types.ModuleType("pydantic_settings")
-config_module = types.ModuleType("config_service.config")
-setattr(config_module, "settings", types.SimpleNamespace())
-config_package = types.ModuleType("config_service")
-setattr(config_package, "config", config_module)
-sys.modules["config_service"] = config_package
-sys.modules["config_service.config"] = config_module
-
 from conversation_service.prompts.search_prompts import format_search_prompt
 from conversation_service.prompts.response_prompts import format_response_prompt
 from conversation_service.prompts.intent_prompts import format_intent_prompt
@@ -21,20 +5,6 @@ from conversation_service.prompts.orchestrator_prompts import (
     format_orchestrator_prompt,
     WorkflowStep,
 )
-
-# Restore original modules after imports
-if _orig_config_service is not None:
-    sys.modules["config_service"] = _orig_config_service
-else:
-    del sys.modules["config_service"]
-if _orig_config_config is not None:
-    sys.modules["config_service.config"] = _orig_config_config
-else:
-    del sys.modules["config_service.config"]
-if _orig_pydantic_settings is not None:
-    sys.modules["pydantic_settings"] = _orig_pydantic_settings
-else:
-    del sys.modules["pydantic_settings"]
 
 
 def test_search_prompt_examples_loaded():


### PR DESCRIPTION
## Summary
- remove test scaffolding that referenced `config_service.config`
- rely on new `config.settings` configuration system for prompts tests

## Testing
- `pytest tests/test_prompts/test_prompt_examples.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a69ff39e6083208985a2cb9f362518