### PR TITLE
Add database settings configuration

### DIFF
--- a/config/database_config.py
+++ b/config/database_config.py
@@ -1,0 +1,29 @@
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import field_validator
+from urllib.parse import quote_plus
+
+
+class DatabaseSettings(BaseSettings):
+    """Paramètres de configuration pour la base de données."""
+
+    POSTGRES_SERVER: str = "localhost"
+    POSTGRES_USER: str = "postgres"
+    POSTGRES_PASSWORD: str = ""
+    POSTGRES_DB: str = ""
+    POSTGRES_PORT: int = 5432
+    SQLALCHEMY_DATABASE_URI: str | None = None
+
+    @field_validator("SQLALCHEMY_DATABASE_URI", mode="before")
+    @classmethod
+    def assemble_db_connection(cls, v: str | None, info):
+        if v:
+            return v
+        data = info.data
+        user = quote_plus(data.get("POSTGRES_USER", "postgres"))
+        password = quote_plus(data.get("POSTGRES_PASSWORD", ""))
+        server = data.get("POSTGRES_SERVER", "localhost")
+        port = data.get("POSTGRES_PORT", 5432)
+        db = data.get("POSTGRES_DB", "")
+        return f"postgresql://{user}:{password}@{server}:{port}/{db}"
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")

--- a/config/settings.py
+++ b/config/settings.py
@@ -1,8 +1,9 @@
 from .openai_config import OpenAISettings
 from .autogen_config import AutoGenSettings
+from .database_config import DatabaseSettings
 
 
-class Settings(AutoGenSettings, OpenAISettings):
+class Settings(DatabaseSettings, AutoGenSettings, OpenAISettings):
     """Paramètres globaux de l'application."""
 
 


### PR DESCRIPTION
## Summary
- add DatabaseSettings with PostgreSQL connection fields and URL validator
- include DatabaseSettings in global Settings

## Testing
- `python - <<'PY'
from config.settings import settings
print(settings.SQLALCHEMY_DATABASE_URI)
PY`
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml'; No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68a6a2939e188320b8aa1b1fb678346d