### PR TITLE
Add os import to conversation service entry point

### DIFF
--- a/conversation_service/main.py
+++ b/conversation_service/main.py
@@ -5,6 +5,7 @@ includes the API routers.  It exposes an ``app`` object that can be used by
 ASGI servers such as Uvicorn.
 """
 
+import os
 import logging
 import time
 import asyncio


### PR DESCRIPTION
## Summary
- import `os` in `conversation_service/main.py`

## Testing
- `uvicorn conversation_service.main:app` *(fails: MVPTeamManager not available - name 'os' is not defined)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6a5be06a0832093c874db5c213ccb