### PR TITLE
feat: add configurable search rate limit defaults

### DIFF
--- a/config_service/config.py
+++ b/config_service/config.py
@@ -179,6 +179,12 @@ class GlobalSettings(BaseSettings):
     RATE_LIMIT_REQUESTS: int = int(os.environ.get("RATE_LIMIT_REQUESTS", "60"))
     RATE_LIMIT_REQUESTS_PER_MINUTE: int = int(os.environ.get("RATE_LIMIT_REQUESTS_PER_MINUTE", "60"))
     RATE_LIMIT_BURST_SIZE: int = int(os.environ.get("RATE_LIMIT_BURST_SIZE", "10"))
+    SEARCH_RATE_LIMIT_REQUESTS_PER_MINUTE: int = int(
+        os.environ.get("SEARCH_RATE_LIMIT_REQUESTS_PER_MINUTE", "60")
+    )
+    SEARCH_RATE_LIMIT_WINDOW_SECONDS: int = int(
+        os.environ.get("SEARCH_RATE_LIMIT_WINDOW_SECONDS", "60")
+    )
     
     # ==========================================
     # PARAMÈTRES DE RECHERCHE PAR DÉFAUT

--- a/search_service/core/search_engine.py
+++ b/search_service/core/search_engine.py
@@ -52,8 +52,16 @@ class SearchEngine:
         self.cache_misses = 0
 
         # Rate limiting (par utilisateur)
-        self.requests_per_minute = settings.SEARCH_RATE_LIMIT_REQUESTS_PER_MINUTE
-        self.rate_limit_window = settings.SEARCH_RATE_LIMIT_WINDOW_SECONDS
+        self.requests_per_minute = getattr(
+            settings,
+            "SEARCH_RATE_LIMIT_REQUESTS_PER_MINUTE",
+            getattr(settings, "RATE_LIMIT_REQUESTS_PER_MINUTE", 60),
+        )
+        self.rate_limit_window = getattr(
+            settings,
+            "SEARCH_RATE_LIMIT_WINDOW_SECONDS",
+            getattr(settings, "RATE_LIMIT_PERIOD", 60),
+        )
         self._rate_limit_storage: Dict[int, deque] = defaultdict(deque)
     
     def set_elasticsearch_client(self, client):


### PR DESCRIPTION
## Summary
- allow SearchEngine to fall back to global rate limit settings
- expose search-specific rate limit settings via environment variables

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'conversation_service.agents.base_financial_agent')*

------
https://chatgpt.com/codex/tasks/task_e_68a6b34b2e588320ac93416aa7f2d5ff