### PR TITLE
refactor(sync_service): use db service session for get_db

### DIFF
--- a/sync_service/api/endpoints/accounts.py
+++ b/sync_service/api/endpoints/accounts.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, status, Query
 from sqlalchemy.orm import Session
 from typing import Dict, Any, List, Optional
 
-from conversation_service.api.dependencies import get_db
+from db_service.session import get_db
 from user_service.api.deps import get_current_active_user
 from db_service.models.user import User
 from db_service.models.sync import SyncAccount, LoanDetail, RawStock, AccountInformation

--- a/sync_service/api/endpoints/categories.py
+++ b/sync_service/api/endpoints/categories.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 from typing import Dict, Any, List, Optional
 
-from conversation_service.api.dependencies import get_db
+from db_service.session import get_db
 from user_service.api.deps import get_current_active_user, get_current_active_superuser
 from db_service.models.user import User
 from db_service.models.sync import BridgeCategory

--- a/sync_service/api/endpoints/insights.py
+++ b/sync_service/api/endpoints/insights.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 from typing import Dict, Any, Optional
 
-from conversation_service.api.dependencies import get_db
+from db_service.session import get_db
 from user_service.api.deps import get_current_active_user
 from db_service.models.user import User
 from db_service.models.sync import BridgeInsight

--- a/sync_service/api/endpoints/items.py
+++ b/sync_service/api/endpoints/items.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, status, BackgroundTasks
 from sqlalchemy.orm import Session
 from typing import Dict, Any, List, Optional
 
-from conversation_service.api.dependencies import get_db
+from db_service.session import get_db
 from user_service.api.deps import get_current_active_user
 from db_service.models.user import User
 from db_service.models.sync import SyncItem

--- a/sync_service/api/endpoints/stocks.py
+++ b/sync_service/api/endpoints/stocks.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 from typing import Dict, Any, List, Optional
 from datetime import datetime
 
-from conversation_service.api.dependencies import get_db
+from db_service.session import get_db
 from user_service.api.deps import get_current_active_user
 from db_service.models.user import User
 from db_service.models.sync import RawStock, SyncAccount

--- a/sync_service/api/endpoints/sync.py
+++ b/sync_service/api/endpoints/sync.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 from typing import Dict, Any, List
 from datetime import datetime
 
-from conversation_service.api.dependencies import get_db
+from db_service.session import get_db
 from user_service.api.deps import get_current_active_user
 from db_service.models.user import User
 from db_service.models.sync import SyncItem

--- a/sync_service/api/endpoints/transactions.py
+++ b/sync_service/api/endpoints/transactions.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 from typing import Dict, Any, List, Optional
 from datetime import datetime, date
 
-from conversation_service.api.dependencies import get_db
+from db_service.session import get_db
 from user_service.api.deps import get_current_active_user
 from db_service.models.user import User
 from db_service.models.sync import RawTransaction, SyncAccount, BridgeCategory

--- a/sync_service/api/endpoints/webhooks.py
+++ b/sync_service/api/endpoints/webhooks.py
@@ -11,7 +11,7 @@ from typing import Dict, Any, Optional
 # Configuration du logger
 logger = logging.getLogger(__name__)
 
-from conversation_service.api.dependencies import get_db
+from db_service.session import get_db
 from config_service.config import settings
 from sync_service.webhook_handler.processor import process_webhook, validate_webhook
 


### PR DESCRIPTION
## Summary
- replace `get_db` dependency across sync service endpoints to use `db_service.session`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'conversation_service.utils')*


------
https://chatgpt.com/codex/tasks/task_e_68a6e349413883209f2242e9d2539adf