### PR TITLE
Use db_service session for database access

### DIFF
--- a/enrichment_service/api/routes.py
+++ b/enrichment_service/api/routes.py
@@ -19,7 +19,7 @@ from fastapi import APIRouter, Depends, HTTPException, status, Query
 from sqlalchemy.orm import Session
 from datetime import datetime
 
-from conversation_service.api.dependencies import get_db
+from db_service.session import get_db
 from user_service.api.deps import get_current_active_user
 from db_service.models.user import User
 from db_service.models.sync import RawTransaction

--- a/user_service/api/deps.py
+++ b/user_service/api/deps.py
@@ -5,7 +5,7 @@ from jose import jwt, JWTError
 from sqlalchemy.orm import Session
 from typing import Optional, List
 
-from conversation_service.api.dependencies import get_db
+from db_service.session import get_db
 from db_service.models.user import User
 from user_service.services.users import get_user_by_id
 from config_service.config import settings


### PR DESCRIPTION
## Summary
- switch database dependency imports to `db_service.session.get_db`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'conversation_service.utils')*

------
https://chatgpt.com/codex/tasks/task_e_68a6e352d31c8320b04d123e8281eefa