### PR TITLE
feat: add websocket chat with session authentication

### DIFF
--- a/conversation_service/agents/response_generator.py
+++ b/conversation_service/agents/response_generator.py
@@ -1,0 +1,17 @@
+"""Lightweight response generation utilities.
+
+This module provides a minimal asynchronous generator used by the websocket
+endpoint to stream back responses. In the real application this would bridge
+with the more advanced ``ResponseGeneratorAgent``.
+"""
+
+from typing import AsyncGenerator
+
+
+async def stream_response(message: str) -> AsyncGenerator[str, None]:
+    """Yield a simple response for the provided message.
+
+    The implementation is intentionally lightweight to avoid heavy dependencies
+    during tests while illustrating how streaming would behave.
+    """
+    yield f"Response: {message}"

--- a/conversation_service/api/__init__.py
+++ b/conversation_service/api/__init__.py
@@ -1,0 +1,1 @@
+"""API components for the conversation service."""

--- a/conversation_service/api/dependencies.py
+++ b/conversation_service/api/dependencies.py
@@ -1,0 +1,17 @@
+from fastapi import WebSocket, HTTPException, status
+
+async def get_session_id(websocket: WebSocket) -> str:
+    """Authenticate websocket connections using a session token.
+
+    The token is expected in the query string as ``?session=<token>``. If the
+    token is missing the connection is closed with an appropriate code and a
+    403 error is raised so the dependency chain is halted.
+    """
+    session_id = websocket.query_params.get("session")
+    if not session_id:
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Session non authentifiée"
+        )
+    return session_id

--- a/conversation_service/api/router.py
+++ b/conversation_service/api/router.py
@@ -1,0 +1,42 @@
+"""Router exposing realtime conversation endpoints."""
+
+from typing import List
+
+from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
+
+from .dependencies import get_session_id
+from ..agents.response_generator import stream_response
+
+router = APIRouter()
+
+# Connected websocket clients
+connections: List[WebSocket] = []
+
+
+@router.websocket("/ws")
+async def websocket_endpoint(
+    websocket: WebSocket,
+    session_id: str = Depends(get_session_id),
+) -> None:
+    """Basic websocket endpoint broadcasting generated responses.
+
+    Each message received is passed to the :func:`stream_response` generator and
+    every chunk produced is broadcast to all connected clients.
+    """
+    await websocket.accept()
+    connections.append(websocket)
+    try:
+        while True:
+            message = await websocket.receive_text()
+            async for chunk in stream_response(message):
+                # broadcast
+                for ws in list(connections):
+                    try:
+                        await ws.send_text(chunk)
+                    except WebSocketDisconnect:
+                        connections.remove(ws)
+    except WebSocketDisconnect:
+        pass
+    finally:
+        if websocket in connections:
+            connections.remove(websocket)


### PR DESCRIPTION
## Summary
- add websocket router that broadcasts generated responses to clients
- authenticate websocket sessions via query parameters
- implement lightweight response generator for streaming replies

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a701d58dc0832097c7dedd3da9362d