### PR TITLE
feat: add structured logging and metrics

### DIFF
--- a/core/errors.py
+++ b/core/errors.py
@@ -1,0 +1,32 @@
+import functools
+import inspect
+from typing import Any, Callable, TypeVar, Awaitable
+
+T = TypeVar("T")
+
+class BusinessError(Exception):
+    """Erreur métier générique."""
+
+
+def wrap_business_errors(func: Callable[..., T]) -> Callable[..., T]:
+    """Décorateur pour envelopper les exceptions non gérées en BusinessError."""
+    if inspect.iscoroutinefunction(func):
+        @functools.wraps(func)
+        async def async_wrapper(*args: Any, **kwargs: Any) -> T:
+            try:
+                return await func(*args, **kwargs)
+            except BusinessError:
+                raise
+            except Exception as exc:  # pragma: no cover - sécurité
+                raise BusinessError(str(exc)) from exc
+        return async_wrapper
+    else:
+        @functools.wraps(func)
+        def sync_wrapper(*args: Any, **kwargs: Any) -> T:
+            try:
+                return func(*args, **kwargs)
+            except BusinessError:
+                raise
+            except Exception as exc:  # pragma: no cover - sécurité
+                raise BusinessError(str(exc)) from exc
+        return sync_wrapper

--- a/core/metrics_collector.py
+++ b/core/metrics_collector.py
@@ -1,0 +1,31 @@
+from collections import defaultdict
+from threading import Lock
+from typing import Dict, Tuple
+
+class MetricsCollector:
+    """Collecte simple de métriques en mémoire."""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._counts: Dict[Tuple[str, str, int], int] = defaultdict(int)
+        self._times: Dict[Tuple[str, str, int], float] = defaultdict(float)
+
+    def record_request(self, *, path: str, method: str, status_code: int, process_time: float) -> None:
+        key = (path, method, status_code)
+        with self._lock:
+            self._counts[key] += 1
+            self._times[key] += process_time
+
+    def get_metrics(self) -> Dict[str, Dict[str, float]]:
+        with self._lock:
+            result: Dict[str, Dict[str, float]] = {}
+            for key, count in self._counts.items():
+                path, method, status = key
+                total_time = self._times[key]
+                result[f"{method} {path} {status}"] = {
+                    "count": count,
+                    "avg_time": total_time / count if count else 0.0,
+                }
+            return result
+
+metrics_collector = MetricsCollector()

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -1,0 +1,35 @@
+import json
+import time
+import logging
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+from core.metrics_collector import metrics_collector
+
+logger = logging.getLogger("harena.middleware")
+
+class StructuredLoggingMiddleware(BaseHTTPMiddleware):
+    """Middleware de journalisation structurée des requêtes HTTP."""
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        start_time = time.time()
+        response: Response = await call_next(request)
+        process_time = time.time() - start_time
+
+        log_payload = {
+            "method": request.method,
+            "path": request.url.path,
+            "status_code": response.status_code,
+            "process_time_ms": round(process_time * 1000, 2),
+        }
+        logger.info(json.dumps(log_payload))
+
+        metrics_collector.record_request(
+            path=request.url.path,
+            method=request.method,
+            status_code=response.status_code,
+            process_time=process_time,
+        )
+
+        return response


### PR DESCRIPTION
## Summary
- add structured logging middleware with per-request metrics
- track request metrics in dedicated collector
- wrap business logic errors for clearer responses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a701d918688320b4a23efd7840d7e0