### PR TITLE
Add foundational tests for agents, teams, prompts and integration

### DIFF
--- a/tests/test_agents/test_entity_extraction_cache.py
+++ b/tests/test_agents/test_entity_extraction_cache.py
@@ -1,0 +1,24 @@
+import sys
+import types
+
+sys.modules.setdefault("autogen", types.SimpleNamespace(AssistantAgent=object))
+
+from conversation_service.agents.entity_extractor_agent import EntityExtractionCache
+from conversation_service.models.core_models import FinancialEntity, EntityType
+
+
+def test_entity_cache_store_and_retrieve():
+    cache = EntityExtractionCache()
+    entity = FinancialEntity(
+        entity_type=EntityType.MERCHANT,
+        raw_value="Amazon",
+        normalized_value="Amazon",
+        confidence=0.95
+    )
+    cache.set("Spent at Amazon", "MERCHANT_ANALYSIS", [entity])
+
+    cached = cache.get("Spent at Amazon", "MERCHANT_ANALYSIS")
+    assert cached is not None
+    assert cached["cached"] is True
+    assert len(cached["entities"]) == 1
+    assert cache.hits == 1

--- a/tests/test_agents/test_intent_classification_cache.py
+++ b/tests/test_agents/test_intent_classification_cache.py
@@ -1,0 +1,22 @@
+import sys
+import types
+
+sys.modules.setdefault("autogen", types.SimpleNamespace(AssistantAgent=object))
+
+from conversation_service.agents.intent_classifier_agent import IntentClassificationCache
+from conversation_service.models.core_models import IntentResult, IntentType
+
+
+def test_intent_cache_store_and_retrieve():
+    cache = IntentClassificationCache()
+    result = IntentResult(
+        intent=IntentType.BALANCE_INQUIRY,
+        confidence=0.9,
+        reasoning="Clear request for balance information"
+    )
+    cache.set("What's my balance?", result)
+
+    cached = cache.get("What's my balance?")
+    assert cached is not None
+    assert cached.intent == IntentType.BALANCE_INQUIRY
+    assert cache.hits == 1

--- a/tests/test_agents/test_query_optimizer.py
+++ b/tests/test_agents/test_query_optimizer.py
@@ -1,0 +1,28 @@
+import sys
+import types
+from enum import Enum
+
+sys.modules.setdefault("autogen", types.SimpleNamespace(AssistantAgent=object))
+sys.modules.setdefault("conversation_service.models.agent_models", types.SimpleNamespace(AgentConfig=object))
+sys.modules.setdefault("conversation_service.base_agent", types.SimpleNamespace(BaseFinancialAgent=object))
+sys.modules.setdefault("conversation_service.core.cache_manager", types.SimpleNamespace(CacheManager=object))
+sys.modules.setdefault("conversation_service.core.metrics_collector", types.SimpleNamespace(MetricsCollector=object))
+sys.modules.setdefault("conversation_service.utils.logging", types.SimpleNamespace(get_structured_logger=lambda name: None))
+
+import conversation_service.models.core_models as core_models
+
+class QueryType(str, Enum):
+    SIMPLE_SEARCH = "simple_search"
+
+core_models.QueryType = QueryType
+
+from conversation_service.agents.query_generator_agent import QueryOptimizer
+from conversation_service.models.core_models import IntentType
+
+
+def test_query_optimizer_applies_merchant_rule():
+    base_query = {"search_parameters": {}, "aggregations": {}}
+    optimized = QueryOptimizer.optimize_query(base_query, IntentType.MERCHANT_ANALYSIS)
+
+    assert optimized["search_parameters"]["limit"] == 15
+    assert "sort" in optimized["search_parameters"]

--- a/tests/test_agents/test_response_generator_agent.py
+++ b/tests/test_agents/test_response_generator_agent.py
@@ -1,0 +1,8 @@
+import pytest
+
+agent_module = pytest.importorskip("conversation_service.agents.response_generator_agent")
+
+
+@pytest.mark.skip(reason="Response generator agent dependencies incomplete")
+def test_placeholder():
+    assert agent_module is not None

--- a/tests/test_integration/test_conversation_scenario.py
+++ b/tests/test_integration/test_conversation_scenario.py
@@ -1,0 +1,51 @@
+import sys
+import types
+from enum import Enum
+
+sys.modules.setdefault("autogen", types.SimpleNamespace(AssistantAgent=object))
+sys.modules.setdefault("conversation_service.models.agent_models", types.SimpleNamespace(AgentConfig=object))
+sys.modules.setdefault("conversation_service.base_agent", types.SimpleNamespace(BaseFinancialAgent=object))
+sys.modules.setdefault("conversation_service.core.cache_manager", types.SimpleNamespace(CacheManager=object))
+sys.modules.setdefault("conversation_service.core.metrics_collector", types.SimpleNamespace(MetricsCollector=object))
+sys.modules.setdefault("conversation_service.utils.logging", types.SimpleNamespace(get_structured_logger=lambda name: None))
+
+import conversation_service.models.core_models as core_models
+
+class QueryType(str, Enum):
+    SIMPLE_SEARCH = "simple_search"
+
+core_models.QueryType = QueryType
+
+from conversation_service.agents.intent_classifier_agent import IntentClassificationCache
+from conversation_service.agents.query_generator_agent import QueryOptimizer
+from conversation_service.models.core_models import (
+    FinancialEntity,
+    EntityType,
+    IntentResult,
+    IntentType,
+)
+
+
+def test_conversation_pipeline():
+    cache = IntentClassificationCache()
+    intent_result = IntentResult(
+        intent=IntentType.MERCHANT_ANALYSIS,
+        confidence=0.92,
+        reasoning="User asks about spending at a merchant"
+    )
+    cache.set("How much did I spend at Amazon?", intent_result)
+    cached_intent = cache.get("How much did I spend at Amazon?")
+
+    entity = FinancialEntity(
+        entity_type=EntityType.MERCHANT,
+        raw_value="Amazon",
+        normalized_value="Amazon",
+        confidence=0.95,
+    )
+    filter_dict = entity.to_search_filter()
+
+    base_query = {"search_parameters": {}, "aggregations": {}}
+    optimized_query = QueryOptimizer.optimize_query(base_query, cached_intent.intent)
+
+    assert "merchant_name" in filter_dict["bool"]["should"][0]["match"]
+    assert optimized_query["search_parameters"]["limit"] == 15

--- a/tests/test_prompts/test_query_prompts.py
+++ b/tests/test_prompts/test_query_prompts.py
@@ -1,0 +1,11 @@
+from conversation_service.prompts import query_prompts
+
+
+def test_system_prompt_mentions_elasticsearch():
+    assert "Elasticsearch" in query_prompts.QUERY_GENERATION_SYSTEM_PROMPT
+    assert "user_id" in query_prompts.QUERY_GENERATION_SYSTEM_PROMPT
+
+
+def test_few_shot_examples_have_input_and_output():
+    example = query_prompts.QUERY_FEW_SHOT_EXAMPLES[0]
+    assert "input" in example and "output" in example

--- a/tests/test_teams/test_financial_entity.py
+++ b/tests/test_teams/test_financial_entity.py
@@ -1,0 +1,22 @@
+from conversation_service.models.core_models import FinancialEntity, EntityType
+
+
+def test_is_action_related_true():
+    entity = FinancialEntity(
+        entity_type=EntityType.BENEFICIARY,
+        raw_value="John",
+        normalized_value="John",
+        confidence=0.9,
+    )
+    assert entity.is_action_related() is True
+
+
+def test_to_search_filter_amount():
+    entity = FinancialEntity(
+        entity_type=EntityType.AMOUNT,
+        raw_value="100",
+        normalized_value="100",
+        confidence=0.9,
+    )
+    filt = entity.to_search_filter()
+    assert filt["range"]["amount_abs"]["gte"] == 90.0

--- a/tests/test_teams/test_sync_orchestrator.py
+++ b/tests/test_teams/test_sync_orchestrator.py
@@ -1,0 +1,65 @@
+import sys
+import types
+from dataclasses import dataclass
+
+import pytest
+
+sys.modules.setdefault("pydantic_settings", types.SimpleNamespace(BaseSettings=object, SettingsConfigDict=dict))
+sys.modules.setdefault("config_service.config", types.SimpleNamespace(settings=types.SimpleNamespace()))
+
+from sync_service.sync_manager import orchestrator
+
+
+@dataclass
+class MockSyncItem:
+    user_id: int
+    bridge_item_id: int
+    status: int
+    status_code_info: str | None = None
+    status_description: str | None = None
+    provider_id: int | None = None
+    account_types: str | None = None
+    needs_user_action: bool = False
+    last_successful_refresh: any = None
+    last_try_refresh: any = None
+    id: int = 1
+
+# provide class attribute for query comparisons
+MockSyncItem.bridge_item_id = 0
+
+
+class FakeQuery:
+    def filter(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return None
+
+
+class FakeSession:
+    def query(self, model):
+        return FakeQuery()
+
+    def add(self, obj):
+        self.obj = obj
+
+    def commit(self):
+        pass
+
+    def refresh(self, obj):
+        pass
+
+    def rollback(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_create_or_update_sync_item_sets_needs_user_action(monkeypatch):
+    monkeypatch.setattr(orchestrator, "SyncItem", MockSyncItem)
+    monkeypatch.setattr(orchestrator, "get_contextual_logger", lambda *a, **k: orchestrator.logging.getLogger("test"))
+
+    db = FakeSession()
+    item = await orchestrator.create_or_update_sync_item(
+        db, user_id=1, bridge_item_id=123, item_data={"status": 402}
+    )
+    assert item.needs_user_action is True


### PR DESCRIPTION
## Summary
- add unit tests for intent and entity caching
- cover query optimizer and orchestrator logic
- validate prompt examples and an end-to-end conversation pipeline

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7020c9f288320992c07fa184cead7