### PR TITLE
Add agent pipeline and fallback coordination utilities

### DIFF
--- a/conversation_service/core/fallback_manager.py
+++ b/conversation_service/core/fallback_manager.py
@@ -1,0 +1,5 @@
+"""Re-export :class:`FallbackManager` from the shared core package."""
+
+from core.fallback_manager import FallbackManager
+
+__all__ = ["FallbackManager"]

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,3 +1,6 @@
-"""Core utilities for shared validation logic."""
+"""Core utilities for shared validation logic and pipeline execution."""
 
-__all__: list[str] = []
+from .agent_pipeline import AgentPipeline, PipelineStep
+from .fallback_manager import FallbackManager
+
+__all__ = ["AgentPipeline", "PipelineStep", "FallbackManager"]

--- a/core/agent_pipeline.py
+++ b/core/agent_pipeline.py
@@ -1,0 +1,58 @@
+"""Simple agent pipeline execution utilities.
+
+This module exposes the :class:`AgentPipeline` which executes a sequence
+of callable agents.  Each step receives the output of the previous step
+and can be synchronous or asynchronous.  An optional
+:class:`~core.fallback_manager.FallbackManager` can be used to provide
+fallback behaviours for individual steps.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable, Sequence
+
+from .fallback_manager import FallbackManager
+
+CallableType = Callable[..., Any]
+
+
+@dataclass
+class PipelineStep:
+    """Represent a single step in a pipeline.
+
+    Attributes
+    ----------
+    main:
+        The primary callable for this step.
+    fallbacks:
+        Optional sequence of fallback callables executed if ``main``
+        raises an exception.
+    """
+
+    main: CallableType
+    fallbacks: Sequence[CallableType] | None = None
+
+
+class AgentPipeline:
+    """Run a series of agents sequentially."""
+
+    def __init__(self, steps: Iterable[PipelineStep]) -> None:
+        self.steps = list(steps)
+        self.fallback_manager = FallbackManager()
+
+    async def run(self, data: Any) -> Any:
+        """Execute the pipeline starting with ``data``.
+
+        The output of each step becomes the input for the next one.  If a
+        step defines fallbacks, the :class:`FallbackManager` will try them
+        in order.
+        """
+        result = data
+        for step in self.steps:
+            handlers = [step.main]
+            if step.fallbacks:
+                handlers.extend(step.fallbacks)
+            self.fallback_manager.handlers = handlers
+            result = await self.fallback_manager.execute([result])
+        return result

--- a/core/fallback_manager.py
+++ b/core/fallback_manager.py
@@ -1,0 +1,78 @@
+"""Fallback execution utilities.
+
+This module provides a :class:`FallbackManager` that coordinates a
+primary callable and a series of fallback callables.  The manager tries
+each callable in order until one succeeds.  It supports both synchronous
+and asynchronous callables which allows it to be used with the agents in
+this project.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable, Sequence
+import inspect
+import logging
+
+logger = logging.getLogger(__name__)
+
+CallableType = Callable[..., Any]
+
+
+async def _maybe_await(result: Any) -> Any:
+    """Return the awaited result if *result* is awaitable.
+
+    Parameters
+    ----------
+    result:
+        The value returned by a callable which may be awaitable.
+    """
+    if inspect.isawaitable(result):
+        return await result
+    return result
+
+
+class FallbackManager:
+    """Execute callables with fallback strategies.
+
+    The manager receives a sequence of callables.  When executed it tries
+    each callable in order and returns the first successful result.  If
+    all callables raise an exception the last exception is propagated.
+
+    Examples
+    --------
+    >>> fm = FallbackManager([primary, fallback])
+    >>> result = await fm.execute(args)
+    """
+
+    def __init__(self, handlers: Sequence[CallableType] | None = None) -> None:
+        self.handlers: list[CallableType] = list(handlers or [])
+
+    def add_handler(self, handler: CallableType) -> None:
+        """Register an additional fallback handler."""
+        self.handlers.append(handler)
+
+    async def execute(self, args: Iterable[Any] | None = None, **kwargs: Any) -> Any:
+        """Execute the registered handlers until one succeeds.
+
+        Parameters
+        ----------
+        args:
+            Positional arguments passed to the handlers.  If ``None`` an
+            empty argument list is used.
+        kwargs:
+            Keyword arguments passed to the handlers.
+        """
+        positional = list(args or [])
+        last_exc: Exception | None = None
+
+        for handler in self.handlers:
+            try:
+                logger.debug("Executing handler %s", handler)
+                result = handler(*positional, **kwargs)
+                return await _maybe_await(result)
+            except Exception as exc:  # pragma: no cover - logging path
+                logger.warning("Handler %s failed: %s", handler, exc)
+                last_exc = exc
+        if last_exc is not None:
+            raise last_exc
+        raise RuntimeError("No handlers configured")


### PR DESCRIPTION
## Summary
- add `FallbackManager` to coordinate primary and fallback handlers
- introduce `AgentPipeline` interface for sequential agent execution
- re-export `FallbackManager` in conversation service core and update package exports

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a701e5912083208c08a885d4c7eed5