### PR TITLE
feat(conversation): add prompt modules and utils

### DIFF
--- a/conversation_service/prompts/__init__.py
+++ b/conversation_service/prompts/__init__.py
@@ -1,0 +1,13 @@
+"""Prompts spécifiques au service de conversation.
+
+Ce package regroupe les utilitaires de gestion de prompts pour la
+classification d'intentions, l'extraction d'entités, la génération de
+requêtes et la formulation de réponses dans le service de conversation.
+"""
+
+__all__ = [
+    "intent_prompts",
+    "entity_prompts",
+    "query_prompts",
+    "response_prompts",
+]

--- a/conversation_service/prompts/entity_prompts.py
+++ b/conversation_service/prompts/entity_prompts.py
@@ -1,0 +1,39 @@
+"""Prompts pour l'extraction d'entités dans le service de conversation.
+
+Ce module propose un prompt par défaut et une gestion simplifiée des exemples
+few‑shot pour extraire des entités d'un texte utilisateur. Les prompts peuvent
+être chargés depuis un fichier externe ou récupérés depuis un cache.
+"""
+
+from pathlib import Path
+from typing import Dict, List, Optional
+
+DEFAULT_PROMPT = "Identifie les entités présentes dans le message utilisateur."
+
+_EXAMPLES: List[Dict[str, str]] = [
+    {"input": "J'ai dépensé 50€ chez Amazon", "output": "AMOUNT:50, MERCHANT:Amazon"},
+]
+
+_PROMPT_CACHE: Dict[str, str] = {}
+
+def load_prompt(path: Optional[str] = None, *, cache: Optional[Dict[str, str]] = None, cache_key: str = "default") -> str:
+    """Charger le prompt depuis un fichier ou un cache."""
+    cache = _PROMPT_CACHE if cache is None else cache
+    if cache_key in cache:
+        return cache[cache_key]
+    if path:
+        prompt = Path(path).read_text(encoding="utf-8")
+        cache[cache_key] = prompt
+        return prompt
+    return DEFAULT_PROMPT
+
+
+def get_examples() -> List[Dict[str, str]]:
+    """Récupérer les exemples actuels."""
+    return list(_EXAMPLES)
+
+
+def update_examples(examples: List[Dict[str, str]]) -> None:
+    """Mettre à jour les exemples few‑shot."""
+    _EXAMPLES.clear()
+    _EXAMPLES.extend(examples)

--- a/conversation_service/prompts/intent_prompts.py
+++ b/conversation_service/prompts/intent_prompts.py
@@ -1,0 +1,48 @@
+"""Prompts pour la détection d'intention dans le service de conversation.
+
+Ce module gère un prompt par défaut et des exemples few‑shot pour la
+classification d'intentions. Il offre des utilitaires pour charger un prompt
+depuis un fichier externe ou un cache en mémoire, ainsi que pour consulter ou
+mettre à jour les exemples utilisés.
+"""
+
+from pathlib import Path
+from typing import Dict, List, Optional
+
+DEFAULT_PROMPT = "Analyse l'intention du message utilisateur."
+
+_EXAMPLES: List[Dict[str, str]] = [
+    {"input": "Bonjour", "output": "GREETING"},
+]
+
+_PROMPT_CACHE: Dict[str, str] = {}
+
+def load_prompt(path: Optional[str] = None, *, cache: Optional[Dict[str, str]] = None, cache_key: str = "default") -> str:
+    """Charger le prompt depuis un fichier ou un cache.
+
+    Args:
+        path: chemin optionnel vers un fichier contenant le prompt.
+        cache: dictionnaire utilisé comme cache en mémoire.
+        cache_key: clé sous laquelle stocker/récupérer le prompt.
+    Returns:
+        Le texte du prompt.
+    """
+    cache = _PROMPT_CACHE if cache is None else cache
+    if cache_key in cache:
+        return cache[cache_key]
+    if path:
+        prompt = Path(path).read_text(encoding="utf-8")
+        cache[cache_key] = prompt
+        return prompt
+    return DEFAULT_PROMPT
+
+
+def get_examples() -> List[Dict[str, str]]:
+    """Récupérer la liste actuelle des exemples few‑shot."""
+    return list(_EXAMPLES)
+
+
+def update_examples(examples: List[Dict[str, str]]) -> None:
+    """Remplacer les exemples few‑shot par une nouvelle liste."""
+    _EXAMPLES.clear()
+    _EXAMPLES.extend(examples)

--- a/conversation_service/prompts/query_prompts.py
+++ b/conversation_service/prompts/query_prompts.py
@@ -16,7 +16,8 @@ Created: 2025-01-31
 Version: 1.0.0 - Elasticsearch Query Generation
 """
 
-from typing import Dict, List, Any
+from pathlib import Path
+from typing import Dict, List, Any, Optional
 
 # ================================
 # SYSTEM PROMPT
@@ -271,6 +272,33 @@ Génère une requête Elasticsearch optimisée au format SearchServiceQuery.""",
 }"""
     }
 ]
+
+_PROMPT_CACHE: Dict[str, str] = {}
+
+
+def load_prompt(path: Optional[str] = None, *, cache: Optional[Dict[str, str]] = None, cache_key: str = "system") -> str:
+    """Charger le prompt système depuis un fichier ou un cache."""
+    cache = _PROMPT_CACHE if cache is None else cache
+    if cache_key in cache:
+        return cache[cache_key]
+    if path:
+        prompt = Path(path).read_text(encoding="utf-8")
+        cache[cache_key] = prompt
+        return prompt
+    return QUERY_GENERATION_SYSTEM_PROMPT
+
+
+
+def get_examples() -> List[Dict[str, str]]:
+    """Récupérer les exemples few-shot pour la génération de requêtes."""
+    return list(QUERY_FEW_SHOT_EXAMPLES)
+
+
+
+def update_examples(examples: List[Dict[str, str]]) -> None:
+    """Mettre à jour les exemples few-shot utilisés pour la génération de requêtes."""
+    QUERY_FEW_SHOT_EXAMPLES.clear()
+    QUERY_FEW_SHOT_EXAMPLES.extend(examples)
 
 # ================================
 # INTENT-SPECIFIC TEMPLATES

--- a/conversation_service/prompts/response_prompts.py
+++ b/conversation_service/prompts/response_prompts.py
@@ -1,0 +1,54 @@
+"""Prompts pour la génération de réponses dans le service de conversation.
+
+Ce module fournit un prompt système, des exemples few‑shot et des
+modèles de réponse par intention. Il offre des utilitaires pour charger
+le prompt depuis un fichier ou un cache et pour gérer dynamiquement les
+exemples utilisés."""
+
+from pathlib import Path
+from typing import Dict, List, Optional
+
+RESPONSE_GENERATION_SYSTEM_PROMPT = (
+    "Tu synthétises les résultats de recherche en réponses claires et utiles."
+)
+
+RESPONSE_FEW_SHOT_EXAMPLES: List[Dict[str, str]] = [
+    {
+        "input": "transactions Amazon du mois dernier",
+        "output": "Vous avez 3 transactions chez Amazon en avril."
+    }
+]
+
+INTENT_RESPONSE_TEMPLATES: Dict[str, str] = {
+    "BALANCE_INQUIRY": "Votre solde est de {balance}€.",
+}
+
+FINANCIAL_FORMATTING_RULES: Dict[str, str] = {
+    "currency": "EUR",
+    "decimal_separator": ",",
+}
+
+_PROMPT_CACHE: Dict[str, str] = {}
+
+def load_prompt(path: Optional[str] = None, *, cache: Optional[Dict[str, str]] = None, cache_key: str = "system") -> str:
+    """Charger le prompt système depuis un fichier ou un cache."""
+    cache = _PROMPT_CACHE if cache is None else cache
+    if cache_key in cache:
+        return cache[cache_key]
+    if path:
+        prompt = Path(path).read_text(encoding="utf-8")
+        cache[cache_key] = prompt
+        return prompt
+    return RESPONSE_GENERATION_SYSTEM_PROMPT
+
+
+def get_examples() -> List[Dict[str, str]]:
+    """Retourner les exemples few-shot de génération de réponses."""
+    return list(RESPONSE_FEW_SHOT_EXAMPLES)
+
+
+def update_examples(examples: List[Dict[str, str]]) -> None:
+    """Mettre à jour les exemples few-shot."""
+    RESPONSE_FEW_SHOT_EXAMPLES.clear()
+    RESPONSE_FEW_SHOT_EXAMPLES.extend(examples)
+


### PR DESCRIPTION
## Summary
- add intent and entity prompt modules for conversation service
- unify query and response prompts with caching helpers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7020125fc83208dfb0a23e5ddfd1a