### PR TITLE
feat: add core service clients

### DIFF
--- a/cache_client.py
+++ b/cache_client.py
@@ -1,0 +1,50 @@
+"""Simple Redis cache client used to store service responses.
+
+The real project relies on Redis for cross-service caching.  For the unit
+tests we merely need a small abstraction over ``redis.asyncio`` that
+provides ``get`` and ``set`` helpers with optional TTL handling.  Values
+are serialised to JSON so arbitrary Python structures can be stored.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+import redis.asyncio as redis
+
+
+class CacheClient:
+    """Asynchronous Redis cache helper."""
+
+    def __init__(self, url: str, *, prefix: str = "cache:") -> None:
+        self._prefix = prefix
+        self._client = redis.from_url(url, decode_responses=True)
+
+    def _format_key(self, key: str) -> str:
+        return f"{self._prefix}{key}"
+
+    async def get(self, key: str) -> Optional[Any]:
+        """Retrieve a value from the cache."""
+
+        raw = await self._client.get(self._format_key(key))
+        if raw is None:
+            return None
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            return raw
+
+    async def set(self, key: str, value: Any, ttl: Optional[int] = None) -> None:
+        """Store ``value`` under ``key`` with an optional TTL in seconds."""
+
+        if not isinstance(value, str):
+            value = json.dumps(value)
+        await self._client.set(self._format_key(key), value, ex=ttl)
+
+    async def delete(self, key: str) -> None:
+        await self._client.delete(self._format_key(key))
+
+    async def close(self) -> None:
+        await self._client.close()
+

--- a/openai_client.py
+++ b/openai_client.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+"""Simple OpenAI async client wrapper.
+
+This module provides :class:`OpenAIClient`, a thin wrapper around
+:class:`openai.AsyncOpenAI` that adds two features that are useful for the
+project:
+
+* **Retry logic** – failed requests are retried with an exponential
+  backoff.  Transient network errors are common when talking to the
+  OpenAI API and retrying greatly improves reliability.
+* **Cost tracking** – the client keeps track of the number of tokens used
+  and an estimated cost in USD.  The pricing table can easily be
+  customised per model.
+
+The implementation is intentionally lightweight; it only exposes the
+``chat_completion`` method which is the only one currently used by the
+project.  It can be extended later if more endpoints are required.
+"""
+
+import asyncio
+import logging
+from typing import Any, Dict, List, Optional
+
+from openai import AsyncOpenAI
+
+logger = logging.getLogger("openai_client")
+
+# Default pricing table (USD per 1K tokens).  The values do not need to be
+# perfectly accurate for the tests but give a reasonable estimation.  New
+# models can be added by consumers of the client by passing a custom
+# ``model_pricing`` mapping to ``OpenAIClient``.
+DEFAULT_MODEL_PRICING: Dict[str, float] = {
+    "gpt-4o-mini": 0.00015,
+}
+
+
+class OpenAIClient:
+    """Wrapper around :class:`AsyncOpenAI` with retries and cost tracking."""
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str = "https://api.openai.com/v1",
+        *,
+        model_pricing: Optional[Dict[str, float]] = None,
+        max_retries: int = 3,
+    ) -> None:
+        self._client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+        self._max_retries = max_retries
+        self._model_pricing = model_pricing or DEFAULT_MODEL_PRICING
+        self.total_tokens: int = 0
+        self.total_cost_usd: float = 0.0
+
+    async def chat_completion(
+        self, *, model: str, messages: List[Dict[str, str]], **kwargs: Any
+    ) -> Any:
+        """Call the OpenAI chat completion endpoint.
+
+        Retries the request on failure and updates cost metrics using the
+        pricing table.  The raw response from ``openai`` is returned so the
+        caller can access all available data.
+        """
+
+        last_error: Optional[Exception] = None
+        for attempt in range(1, self._max_retries + 1):
+            try:
+                response = await self._client.chat.completions.create(
+                    model=model, messages=messages, **kwargs
+                )
+
+                usage = getattr(response, "usage", None)
+                tokens = usage.total_tokens if usage else 0
+                self.total_tokens += tokens
+
+                price = self._model_pricing.get(model, 0.0)
+                cost = tokens / 1000 * price
+                self.total_cost_usd += cost
+
+                logger.debug(
+                    "OpenAI call succeeded", model=model, tokens=tokens, cost=cost
+                )
+                return response
+            except Exception as exc:  # pragma: no cover - network errors
+                last_error = exc
+                logger.warning(
+                    "OpenAI call failed (attempt %s/%s): %s",
+                    attempt,
+                    self._max_retries,
+                    exc,
+                )
+                if attempt >= self._max_retries:
+                    break
+                await asyncio.sleep(2 ** (attempt - 1))
+
+        # If we get here all retries failed, re-raise the last exception
+        assert last_error is not None
+        raise last_error
+
+    def get_total_cost(self) -> float:
+        """Return the accumulated estimated cost in USD."""
+
+        return self.total_cost_usd
+
+    async def close(self) -> None:
+        """Close the underlying HTTP session."""
+
+        await self._client.close()
+

--- a/search_client.py
+++ b/search_client.py
@@ -1,0 +1,55 @@
+"""Asynchronous client for the internal search service.
+
+The real application communicates with a separate micro-service that
+provides search capabilities.  The tests in this kata only need a very
+small portion of that behaviour: performing authenticated HTTP requests
+and returning the JSON payload.
+
+This module exposes :class:`SearchClient` which wraps :mod:`aiohttp` and
+handles authentication headers, session management and basic error
+handling.
+"""
+
+from __future__ import annotations
+
+import aiohttp
+from typing import Any, Dict, Optional
+
+
+class SearchClient:
+    """HTTP client used to talk to ``search_service``."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        token: Optional[str] = None,
+        timeout: float = 10.0,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self._token = token
+        self._timeout = aiohttp.ClientTimeout(total=timeout)
+        self._session: Optional[aiohttp.ClientSession] = None
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None:
+            headers = {"Accept": "application/json"}
+            if self._token:
+                headers["Authorization"] = f"Bearer {self._token}"
+            self._session = aiohttp.ClientSession(headers=headers, timeout=self._timeout)
+        return self._session
+
+    async def search(self, payload: Dict[str, Any], endpoint: str = "/search") -> Dict[str, Any]:
+        """Execute a search query and return the JSON response."""
+
+        session = await self._get_session()
+        url = f"{self.base_url}{endpoint}"
+        async with session.post(url, json=payload) as resp:
+            resp.raise_for_status()
+            return await resp.json()
+
+    async def close(self) -> None:
+        if self._session is not None:
+            await self._session.close()
+            self._session = None
+


### PR DESCRIPTION
## Summary
- add OpenAI async client with retry logic and cost tracking
- introduce HTTP client for the search service with auth support
- provide Redis cache helper for storing responses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a702021cdc8320ae6b72ea438e66b8