### PR TITLE
Add financial taxonomy, validators, cache and metrics utilities

### DIFF
--- a/conversation_service/core/cache_manager.py
+++ b/conversation_service/core/cache_manager.py
@@ -1,0 +1,55 @@
+"""Utility caching module for Harena conversation service.
+
+Provides a simple in-memory cache with time-to-live (TTL) support and
+least-recently-used eviction.  The implementation is intentionally
+lightweight and dependency free so it can be reused by agents or other
+components without additional infrastructure.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any, Optional
+
+__all__ = ["CacheManager"]
+
+
+@dataclass
+class _CacheEntry:
+    value: Any
+    expires_at: float
+
+
+class CacheManager:
+    """Simple in-memory cache with TTL and LRU eviction."""
+
+    def __init__(self, ttl_seconds: int = 300, max_size: int = 128) -> None:
+        self.ttl = ttl_seconds
+        self.max_size = max_size
+        self._store: "OrderedDict[str, _CacheEntry]" = OrderedDict()
+
+    def get(self, key: str) -> Optional[Any]:
+        entry = self._store.get(key)
+        if not entry:
+            return None
+        if entry.expires_at < time.time():
+            del self._store[key]
+            return None
+        # mark as recently used
+        self._store.move_to_end(key)
+        return entry.value
+
+    def set(self, key: str, value: Any, ttl: Optional[int] = None) -> None:
+        if key in self._store:
+            self._store.move_to_end(key)
+        elif len(self._store) >= self.max_size:
+            # remove least recently used item
+            self._store.popitem(last=False)
+        expires = time.time() + (ttl if ttl is not None else self.ttl)
+        self._store[key] = _CacheEntry(value=value, expires_at=expires)
+
+    def clear(self) -> None:
+        """Remove all cached items."""
+        self._store.clear()

--- a/conversation_service/core/metrics_collector.py
+++ b/conversation_service/core/metrics_collector.py
@@ -1,0 +1,38 @@
+"""Basic metrics collection utilities for Harena conversation service."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from statistics import mean
+from typing import Any, Dict, List
+
+__all__ = ["MetricsCollector"]
+
+
+class MetricsCollector:
+    """Collects counters and timing information for agents."""
+
+    def __init__(self) -> None:
+        self.counters = defaultdict(int)
+        self.timings: Dict[str, List[float]] = defaultdict(list)
+
+    def increment(self, name: str, value: int = 1) -> None:
+        """Increment a named counter."""
+        self.counters[name] += value
+
+    def record_timing(self, name: str, duration_ms: float) -> None:
+        """Record execution time for an operation in milliseconds."""
+        self.timings[name].append(duration_ms)
+
+    def summary(self) -> Dict[str, Any]:
+        """Return aggregated metrics suitable for logging or reporting."""
+        return {
+            "counters": dict(self.counters),
+            "timings": {
+                key: {
+                    "count": len(values),
+                    "avg_ms": mean(values) if values else 0.0,
+                }
+                for key, values in self.timings.items()
+            },
+        }

--- a/conversation_service/core/taxonomies.py
+++ b/conversation_service/core/taxonomies.py
@@ -1,0 +1,37 @@
+"""Financial taxonomy definitions for Harena conversation service."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Dict, List
+
+__all__ = ["FinancialCategory", "FINANCIAL_TAXONOMY", "get_subcategories"]
+
+
+class FinancialCategory(str, Enum):
+    """High level financial categories used in Harena."""
+
+    INCOME = "INCOME"
+    EXPENSE = "EXPENSE"
+    ASSET = "ASSET"
+    LIABILITY = "LIABILITY"
+
+
+FINANCIAL_TAXONOMY: Dict[FinancialCategory, List[str]] = {
+    FinancialCategory.INCOME: ["salary", "bonus", "interest", "dividend"],
+    FinancialCategory.EXPENSE: [
+        "groceries",
+        "transport",
+        "housing",
+        "utilities",
+        "entertainment",
+        "health",
+    ],
+    FinancialCategory.ASSET: ["cash", "checking_account", "savings_account", "investment"],
+    FinancialCategory.LIABILITY: ["mortgage", "loan", "credit_card", "overdraft"],
+}
+
+
+def get_subcategories(category: FinancialCategory) -> List[str]:
+    """Return subcategories for a financial category."""
+    return FINANCIAL_TAXONOMY.get(category, [])

--- a/conversation_service/models/validators.py
+++ b/conversation_service/models/validators.py
@@ -1,0 +1,28 @@
+"""Custom Pydantic validators for the Harena conversation service."""
+
+from __future__ import annotations
+
+import re
+from pydantic import field_validator
+
+__all__ = ["CurrencyAmountValidators"]
+
+
+class CurrencyAmountValidators:
+    """Reusable mixin providing currency and amount validators."""
+
+    @field_validator("currency")
+    @classmethod
+    def validate_currency_code(cls, value: str) -> str:
+        """Ensure currency codes follow ISO 4217."""
+        if not re.fullmatch(r"[A-Z]{3}", value):
+            raise ValueError("currency must be a 3-letter ISO code")
+        return value
+
+    @field_validator("amount")
+    @classmethod
+    def validate_positive_amount(cls, value: float) -> float:
+        """Verify that monetary amounts are positive."""
+        if value < 0:
+            raise ValueError("amount must be positive")
+        return value


### PR DESCRIPTION
## Summary
- introduce in-memory cache manager with TTL and LRU eviction
- add lightweight metrics collector for agent instrumentation
- define reusable financial taxonomy and Pydantic validators

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a702068574832080d3c799300eee2c