### PR TITLE
Add modular configuration modules for settings, OpenAI and AutoGen agents

### DIFF
--- a/autogen_config.py
+++ b/autogen_config.py
@@ -1,0 +1,73 @@
+"""Configuration helpers for AutoGen based agents."""
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from openai_config import OpenAIConfig
+
+
+@dataclass
+class AgentParameters:
+    """Minimal set of parameters required to build an AutoGen agent."""
+
+    name: str
+    system_message: str
+    model_client_config: Dict[str, Any]
+    max_consecutive_auto_reply: int = 1
+    description: str | None = None
+
+
+class AutoGenConfig(BaseSettings):
+    """Configuration for AutoGen agents.
+
+    Values are loaded from environment variables prefixed with ``AUTOGEN_``.
+    Only a small subset of parameters is exposed for now – this module is
+    intentionally lightweight but can be extended as the project evolves.
+    """
+
+    agent_name: str = "harena-agent"
+    max_consecutive_auto_reply: int = 1
+    description: str = "Harena financial assistant"
+
+    model_config = SettingsConfigDict(env_prefix="AUTOGEN_", env_file=".env")
+
+    def build_agent_params(
+        self,
+        system_message: str,
+        *,
+        openai: OpenAIConfig | None = None,
+    ) -> AgentParameters:
+        """Return :class:`AgentParameters` for an agent using OpenAI settings.
+
+        Parameters
+        ----------
+        system_message:
+            Message passed to the AutoGen ``AssistantAgent`` as its system
+            prompt.
+        openai:
+            Optional :class:`OpenAIConfig` instance.  When ``None`` a fresh
+            instance is created so the latest environment variables are read.
+        """
+
+        openai = openai or OpenAIConfig()
+        model_config_dict = {
+            "model": openai.chat_model,
+            "api_key": openai.api_key,
+            "base_url": openai.base_url,
+            "temperature": openai.temperature,
+            "max_tokens": openai.max_tokens,
+            "top_p": openai.top_p,
+            "timeout": openai.timeout,
+        }
+        return AgentParameters(
+            name=self.agent_name,
+            system_message=system_message,
+            model_client_config=model_config_dict,
+            max_consecutive_auto_reply=self.max_consecutive_auto_reply,
+            description=self.description,
+        )
+
+
+# Singleton instance for convenience
+autogen_config = AutoGenConfig()

--- a/openai_config.py
+++ b/openai_config.py
@@ -1,0 +1,28 @@
+"""OpenAI configuration utilities.
+
+This module exposes a small ``OpenAIConfig`` class that gathers all
+parameters required to interact with the OpenAI API.  Values are read
+from environment variables prefixed with ``OPENAI_`` allowing different
+settings per deployment environment.
+"""
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class OpenAIConfig(BaseSettings):
+    """Configuration container for OpenAI clients."""
+
+    api_key: str = ""
+    base_url: str = "https://api.openai.com/v1"
+    chat_model: str = "gpt-4o-mini"
+    reasoner_model: str = "gpt-4o-mini"
+    temperature: float = 1.0
+    max_tokens: int = 2048
+    top_p: float = 0.95
+    timeout: int = 30
+
+    # Read variables from the environment using the OPENAI_ prefix
+    model_config = SettingsConfigDict(env_prefix="OPENAI_", env_file=".env")
+
+
+# Export a ready-to-use instance
+openai_config = OpenAIConfig()

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,31 @@
+"""Application-wide configuration settings.
+
+This module centralizes access to environment variables and common
+filesystem paths used across the codebase.  Values are loaded using
+``pydantic_settings.BaseSettings`` so they can be overridden through the
+environment or a ``.env`` file during local development.
+"""
+from pathlib import Path
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """General application settings.
+
+    Attributes
+    ----------
+    environment:
+        Deployment environment name (e.g. ``production``, ``development``).
+    base_dir:
+        Absolute path to the project's root directory.  This is helpful for
+        constructing other path based settings.
+    """
+
+    environment: str = "production"
+    base_dir: str = str(Path(__file__).resolve().parent)
+
+    model_config = SettingsConfigDict(env_file=".env")
+
+
+# Singleton instance used throughout the project
+settings = Settings()

--- a/tests/test_config_files.py
+++ b/tests/test_config_files.py
@@ -1,0 +1,31 @@
+import os
+from pathlib import Path
+
+from settings import Settings, settings
+from openai_config import OpenAIConfig
+from autogen_config import AutoGenConfig
+
+
+def test_settings_reads_env(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "testing")
+    cfg = Settings()
+    assert cfg.environment == "testing"
+    assert Path(cfg.base_dir).exists()
+
+
+def test_openai_config_reads_env(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_CHAT_MODEL", "gpt-test")
+    cfg = OpenAIConfig()
+    assert cfg.api_key == "sk-test"
+    assert cfg.chat_model == "gpt-test"
+
+
+def test_autogen_config_builds_params(monkeypatch):
+    monkeypatch.setenv("AUTOGEN_AGENT_NAME", "unit-agent")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test2")
+    auto_cfg = AutoGenConfig()
+    params = auto_cfg.build_agent_params("hello")
+    assert params.name == "unit-agent"
+    assert params.model_client_config["api_key"] == "sk-test2"
+    assert params.system_message == "hello"


### PR DESCRIPTION
## Summary
- Add `settings.py` for general environment and path configuration
- Introduce `openai_config.py` to centralize OpenAI API parameters
- Provide `autogen_config.py` with helper to build AutoGen agent parameters
- Add tests ensuring each config class reads environment variables properly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7020a683c8320b6ad7432f11accf8