### PR TITLE
Document FastAPI app factory

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,5 @@
+"""Application entrypoint for the Harena FastAPI service."""
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -7,6 +9,8 @@ from config.settings import settings
 
 
 def create_app() -> FastAPI:
+    """Instantiate and configure the FastAPI application."""
+
     app = FastAPI(title=settings.APP_TITLE, version=settings.APP_VERSION)
 
     app.include_router(api_router)


### PR DESCRIPTION
## Summary
- describe FastAPI application via create_app factory including routers and configuration

## Testing
- `pytest tests/test_create_app.py::test_create_app_registers_routes_and_middleware -q`
- `pytest tests/test_websocket.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'conversation_service.agents.entity_extractor_agent')*

------
https://chatgpt.com/codex/tasks/task_e_68a70f3d32288320aa86ddf833c146d6