### PR TITLE
feat: add middleware and orchestrated chat endpoint

### DIFF
--- a/api/middleware.py
+++ b/api/middleware.py
@@ -1,0 +1,19 @@
+"""Application middleware setup for logging and metrics."""
+
+from typing import Dict
+
+from fastapi import FastAPI
+
+from utils.logging import StructuredLoggingMiddleware
+from core.metrics_collector import metrics_collector
+
+
+def setup_middleware(app: FastAPI) -> None:
+    """Configure structured logging and expose metrics endpoint."""
+    app.add_middleware(StructuredLoggingMiddleware)
+
+    @app.get("/metrics", tags=["monitoring"])
+    async def metrics() -> Dict[str, Dict[str, float]]:
+        """Return collected application metrics."""
+        return metrics_collector.get_metrics()
+

--- a/api/routes.py
+++ b/api/routes.py
@@ -1,7 +1,15 @@
 from fastapi import APIRouter
 
-router = APIRouter()
+from models.conversation_models import AgentQueryRequest, AgentQueryResponse
+from teams.team_orchestrator import TeamOrchestrator
 
-@router.get("/chat")
-async def chat_endpoint():
-    return {"ok": True}
+router = APIRouter(tags=["conversation"])
+orchestrator = TeamOrchestrator()
+
+
+@router.post("/chat", response_model=AgentQueryResponse)
+async def chat_endpoint(payload: AgentQueryRequest) -> AgentQueryResponse:
+    """Proxy a chat message through the team orchestrator."""
+    conv_id = orchestrator.start_conversation()
+    reply = await orchestrator.query_agents(conv_id, payload.message)
+    return AgentQueryResponse(conversation_id=conv_id, reply=reply)

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from api.routes import router as api_router
 from api.websocket import router as ws_router
+from api.middleware import setup_middleware
 from config.settings import settings
 
 
@@ -11,6 +12,8 @@ def create_app() -> FastAPI:
 
     app.include_router(api_router)
     app.include_router(ws_router)
+
+    setup_middleware(app)
 
     app.add_middleware(
         CORSMiddleware,

--- a/conversation_service/api/dependencies.py
+++ b/conversation_service/api/dependencies.py
@@ -1,5 +1,9 @@
 from fastapi import WebSocket, HTTPException, status
 
+from clients.cache_client import CacheClient
+from clients.openai_client import OpenAIClient
+from config.autogen_config import AutogenConfig, autogen_settings
+
 async def get_session_id(websocket: WebSocket) -> str:
     """Authenticate websocket connections using a session token.
 
@@ -15,3 +19,22 @@ async def get_session_id(websocket: WebSocket) -> str:
             detail="Session non authentifiée"
         )
     return session_id
+
+
+_cache_client = CacheClient()
+_openai_client = OpenAIClient(cache=_cache_client)
+
+
+def get_cache_client() -> CacheClient:
+    """Return the shared cache client instance."""
+    return _cache_client
+
+
+def get_openai_client() -> OpenAIClient:
+    """Return the shared OpenAI client configured with caching."""
+    return _openai_client
+
+
+def get_autogen_config() -> AutogenConfig:
+    """Provide AutoGen configuration settings."""
+    return autogen_settings

--- a/conversation_service/api/websocket.py
+++ b/conversation_service/api/websocket.py
@@ -1,4 +1,4 @@
-"""Router exposing realtime conversation endpoints."""
+"""Websocket endpoints exposing realtime conversation features."""
 
 from typing import List
 


### PR DESCRIPTION
## Summary
- rename realtime router to websocket module
- add structured logging and metrics middleware
- expose OpenAI/cache dependencies and AutoGen config
- route chat requests through the team orchestrator

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68a70f3fdf4c8320ba397bfc2703dd7e