### PR TITLE
Refactor agent coordination into FinancialTeam

### DIFF
--- a/conversation_service/agents/context_manager.py
+++ b/conversation_service/agents/context_manager.py
@@ -44,25 +44,3 @@ class ContextManager:
         """Remove all stored context entries."""
 
         self._context.clear()
-"""Simple context manager to maintain conversational state."""
-
-from typing import Any, Dict, List
-
-
-class ContextManager:
-    """Maintain conversation history between user and agents."""
-
-    def __init__(self) -> None:
-        self._history: List[Dict[str, Any]] = []
-
-    def add_message(self, role: str, content: str) -> None:
-        """Add a message to the conversation history."""
-        self._history.append({"role": role, "content": content})
-
-    def get_history(self) -> List[Dict[str, Any]]:
-        """Return the full conversation history."""
-        return list(self._history)
-
-    def clear(self) -> None:
-        """Clear the conversation history."""
-        self._history.clear()

--- a/conversation_service/agents/entity_extractor.py
+++ b/conversation_service/agents/entity_extractor.py
@@ -23,4 +23,5 @@ class EntityExtractorAgent(BaseFinancialAgent):
         self, input_data: Dict[str, Any]
     ) -> Optional[Dict[str, Any]]:
         """Return a placeholder list of entities."""
-        return {"input": input_data, "entities": []}
+        context = input_data.get("context", {})
+        return {"input": input_data, "context": context, "entities": []}

--- a/conversation_service/agents/intent_classifier.py
+++ b/conversation_service/agents/intent_classifier.py
@@ -23,4 +23,5 @@ class IntentClassifierAgent(BaseFinancialAgent):
         self, input_data: Dict[str, Any]
     ) -> Optional[Dict[str, Any]]:
         """Return a placeholder intent classification result."""
-        return {"input": input_data, "intent": "UNKNOWN"}
+        context = input_data.get("context", {})
+        return {"input": input_data, "context": context, "intent": "UNKNOWN"}

--- a/conversation_service/agents/query_generator.py
+++ b/conversation_service/agents/query_generator.py
@@ -23,4 +23,5 @@ class QueryGeneratorAgent(BaseFinancialAgent):
         self, input_data: Dict[str, Any]
     ) -> Optional[Dict[str, Any]]:
         """Return a placeholder search query."""
-        return {"input": input_data, "query": ""}
+        context = input_data.get("context", {})
+        return {"input": input_data, "context": context, "query": ""}

--- a/conversation_service/agents/response_generator.py
+++ b/conversation_service/agents/response_generator.py
@@ -23,7 +23,8 @@ class ResponseGeneratorAgent(BaseFinancialAgent):
         self, input_data: Dict[str, Any]
     ) -> Optional[Dict[str, Any]]:
         """Return a placeholder response."""
-        return {"input": input_data, "response": ""}
+        context = input_data.get("context", {})
+        return {"input": input_data, "context": context, "response": ""}
 """Lightweight response generation utilities.
 
 This module provides a minimal asynchronous generator used by the websocket

--- a/teams/__init__.py
+++ b/teams/__init__.py
@@ -1,0 +1,3 @@
+from .financial_team import FinancialTeam
+
+__all__ = ["FinancialTeam"]

--- a/teams/financial_team.py
+++ b/teams/financial_team.py
@@ -1,18 +1,18 @@
-"""Orchestration utilities for coordinating multiple agents.
+"""Financial conversation agent team coordinator.
 
-The :class:`AgentTeam` sequentially invokes a set of conversational agents
-(intent classification, entity extraction, query generation and response
-production).  Results from each step are stored in a shared
-:class:`~conversation_service.agents.context_manager.ContextManager` so that
-subsequent agents can leverage previous outputs.
+This module implements the orchestration logic previously found in
+``conversation_service.agents.agent_team``.  The :class:`FinancialTeam`
+sequentially invokes the individual agents (intent classification, entity
+extraction, query generation, and response generation) while sharing state via
+the :class:`~conversation_service.agents.context_manager.ContextManager`.
 """
 
 from __future__ import annotations
 
 from typing import Any, Dict, Optional, Protocol
 
-from .context_manager import ContextManager
-from ..models.core_models import AgentResponse
+from conversation_service.agents.context_manager import ContextManager
+from conversation_service.models.core_models import AgentResponse
 
 
 class ConversationAgent(Protocol):
@@ -22,8 +22,8 @@ class ConversationAgent(Protocol):
         ...
 
 
-class AgentTeam:
-    """Pipeline executor for the Harena conversation agents."""
+class FinancialTeam:
+    """Pipeline executor for Harena financial conversation agents."""
 
     def __init__(
         self,
@@ -82,3 +82,4 @@ class AgentTeam:
             self.context.update(response=response_resp.result)
 
         return response_resp
+

--- a/tests/test_teams/test_financial_team.py
+++ b/tests/test_teams/test_financial_team.py
@@ -1,6 +1,6 @@
 import pytest
 
-from conversation_service.agents.agent_team import AgentTeam
+from teams.financial_team import FinancialTeam
 from conversation_service.agents.context_manager import ContextManager
 from conversation_service.models.core_models import AgentResponse
 
@@ -22,9 +22,9 @@ class DummyAgent:
 
 
 @pytest.mark.asyncio
-async def test_agent_team_context_flow() -> None:
+async def test_financial_team_context_flow() -> None:
     ctx = ContextManager()
-    team = AgentTeam(
+    team = FinancialTeam(
         DummyAgent("intent", {"intent": "BALANCE_INQUIRY"}),
         DummyAgent("entity", {"entities": []}),
         DummyAgent("query", {"q": 1}),
@@ -40,3 +40,4 @@ async def test_agent_team_context_flow() -> None:
     assert context["entities"] == {"entities": []}
     assert context["query"] == {"q": 1}
     assert context["response"] == {"text": "ok"}
+


### PR DESCRIPTION
## Summary
- move agent orchestration logic into `teams/financial_team.py`
- ensure agents inherit from `BaseFinancialAgent`, load prompts, and access shared context
- streamline `ContextManager` for shared state
- add tests for `FinancialTeam` pipeline

## Testing
- `pytest` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68a70f446c9883209ab2dd0025c152f8