### PR TITLE
feat: add financial agent team orchestrator

### DIFF
--- a/conversation_service/api/routes.py
+++ b/conversation_service/api/routes.py
@@ -13,7 +13,7 @@ from models.conversation_models import (
     ConversationStartRequest,
     ConversationStartResponse,
 )
-from teams.team_orchestrator import TeamOrchestrator
+from conversation_service.teams.team_orchestrator import TeamOrchestrator
 
 router = APIRouter(tags=["conversation"])
 

--- a/conversation_service/teams/__init__.py
+++ b/conversation_service/teams/__init__.py
@@ -1,0 +1,12 @@
+"""Team modules for coordinating conversation agents.
+
+This package exposes utilities to build specialised agent teams and
+orchestrate conversations.  The :class:`FinancialTeam` bundles the
+financial agents while :class:`TeamOrchestrator` manages conversation
+sessions for the API layer.
+"""
+
+from .financial_team import FinancialTeam
+from .team_orchestrator import TeamOrchestrator
+
+__all__ = ["FinancialTeam", "TeamOrchestrator"]

--- a/conversation_service/teams/financial_team.py
+++ b/conversation_service/teams/financial_team.py
@@ -1,0 +1,41 @@
+"""Utilities to assemble the financial conversation agents into a team.
+
+The :class:`FinancialTeam` wires together the intent classifier, entity
+extractor, query generator and response generator agents.  A shared
+:class:`~conversation_service.agents.context_manager.ContextManager` is
+used so intermediate results can be exchanged between agents during the
+processing pipeline.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from conversation_service.agents.agent_team import AgentTeam
+from conversation_service.agents.context_manager import ContextManager
+from conversation_service.agents.intent_classifier import IntentClassifierAgent
+from conversation_service.agents.entity_extractor import EntityExtractorAgent
+from conversation_service.agents.query_generator import QueryGeneratorAgent
+from conversation_service.agents.response_generator import ResponseGeneratorAgent
+from conversation_service.models.core_models import AgentResponse
+from openai_client import OpenAIClient
+
+
+class FinancialTeam:
+    """Bundle the four core financial agents with a shared context."""
+
+    def __init__(self, openai_client: Optional[OpenAIClient] = None) -> None:
+        self.openai_client = openai_client or OpenAIClient(api_key="dummy")
+        self.context = ContextManager()
+        self.agent_team = AgentTeam(
+            IntentClassifierAgent(self.openai_client),
+            EntityExtractorAgent(self.openai_client),
+            QueryGeneratorAgent(self.openai_client),
+            ResponseGeneratorAgent(self.openai_client),
+            context_manager=self.context,
+        )
+
+    async def process(self, message: str) -> AgentResponse:
+        """Run the full agent pipeline for ``message``."""
+
+        return await self.agent_team.run(message)

--- a/conversation_service/teams/team_orchestrator.py
+++ b/conversation_service/teams/team_orchestrator.py
@@ -1,39 +1,51 @@
-from __future__ import annotations
+"""In-memory orchestrator coordinating financial agent teams.
 
-"""Simple in-memory team orchestrator for conversation agents."""
+The orchestrator manages conversation sessions, keeping track of message
+history per conversation and delegating message processing to a
+:class:`FinancialTeam` instance.
+"""
+
+from __future__ import annotations
 
 from typing import Dict, List, Optional
 from uuid import uuid4
 
 from models.conversation_models import ConversationMessage
 
+from .financial_team import FinancialTeam
+
 
 class TeamOrchestrator:
-    """Coordinate agents and manage conversation history."""
+    """Coordinate agent teams and manage conversation history."""
 
     def __init__(self) -> None:
         self._conversations: Dict[str, List[ConversationMessage]] = {}
+        self._teams: Dict[str, FinancialTeam] = {}
 
     def start_conversation(self, user_id: Optional[int] = None) -> str:
         """Create a new conversation and return its identifier."""
+
         conv_id = str(uuid4())
         self._conversations[conv_id] = []
+        self._teams[conv_id] = FinancialTeam()
         return conv_id
 
     def get_history(self, conversation_id: str) -> Optional[List[ConversationMessage]]:
         """Return history for a conversation or ``None`` if not found."""
+
         return self._conversations.get(conversation_id)
 
     async def query_agents(self, conversation_id: str, message: str) -> str:
-        """Process a message through the agent team.
+        """Process a message through the financial agent team."""
 
-        The current implementation is a placeholder that simply echoes the
-        user's message. It also stores the user and assistant turns in memory.
-        """
         history = self._conversations.setdefault(conversation_id, [])
         history.append(ConversationMessage(role="user", content=message))
 
-        # Placeholder agent behaviour: echo the message
-        reply = f"Echo: {message}"
+        team = self._teams.setdefault(conversation_id, FinancialTeam())
+        response = await team.process(message)
+        reply = ""
+        if response.success and isinstance(response.result, dict):
+            reply = response.result.get("response", "")
+
         history.append(ConversationMessage(role="assistant", content=reply))
         return reply


### PR DESCRIPTION
## Summary
- implement `FinancialTeam` assembling intent, entity, query and response agents with shared context
- add `TeamOrchestrator` to manage conversations using `FinancialTeam`
- update conversation API routes to use new orchestrator

## Testing
- `pytest -q` *(fails: No module named 'conversation_service.agents.entity_extractor_agent')*


------
https://chatgpt.com/codex/tasks/task_e_68a70f46848c8320951bf516d16d3e1f