### PR TITLE
feat: add async service clients

### DIFF
--- a/conversation_service/agents/base_agent.py
+++ b/conversation_service/agents/base_agent.py
@@ -30,7 +30,8 @@ from dataclasses import dataclass
 
 # AutoGen imports
 from autogen import AssistantAgent
-from openai import AsyncOpenAI
+
+from ..clients.openai_client import OpenAIClient
 
 # Local imports
 from ..models.agent_models import AgentConfig, AgentResponse
@@ -309,7 +310,7 @@ class BaseFinancialAgent(ABC):
     def __init__(
         self,
         config: AgentConfig,
-        openai_client: AsyncOpenAI,
+        openai_client: OpenAIClient,
         cache_manager: Optional[CacheManager] = None,
         metrics_collector: Optional[MetricsCollector] = None
     ):
@@ -546,13 +547,13 @@ class BaseFinancialAgent(ABC):
         
         # Call OpenAI
         try:
-            response = await self.openai_client.chat.completions.create(
+            response = await self.openai_client.chat_completion(
                 model=self.config.model_name,
                 messages=messages,
                 temperature=self.config.temperature,
                 max_tokens=self.config.max_tokens,
                 timeout=self.config.timeout_seconds,
-                **kwargs
+                **kwargs,
             )
             
             return {

--- a/conversation_service/api/dependencies.py
+++ b/conversation_service/api/dependencies.py
@@ -1,4 +1,15 @@
+from typing import Optional
+
 from fastapi import WebSocket, HTTPException, status
+
+from ..clients import OpenAIClient, SearchClient, CacheClient
+from openai_config import openai_config
+from config_service.config import settings
+
+
+_openai_client: Optional[OpenAIClient] = None
+_search_client: Optional[SearchClient] = None
+_cache_client: Optional[CacheClient] = None
 
 async def get_session_id(websocket: WebSocket) -> str:
     """Authenticate websocket connections using a session token.
@@ -15,3 +26,36 @@ async def get_session_id(websocket: WebSocket) -> str:
             detail="Session non authentifiée"
         )
     return session_id
+
+
+async def get_openai_client() -> OpenAIClient:
+    """Return a shared :class:`OpenAIClient` instance."""
+
+    global _openai_client
+    if _openai_client is None:
+        _openai_client = OpenAIClient(
+            api_key=openai_config.api_key, base_url=openai_config.base_url
+        )
+    return _openai_client
+
+
+async def get_search_client() -> SearchClient:
+    """Return a shared :class:`SearchClient` instance."""
+
+    global _search_client
+    if _search_client is None:
+        base_url = getattr(settings, "SEARCHBOX_URL", None) or getattr(
+            settings, "ELASTICSEARCH_URL", "http://localhost"
+        )
+        _search_client = SearchClient(base_url)
+    return _search_client
+
+
+async def get_cache_client() -> CacheClient:
+    """Return a shared :class:`CacheClient` instance."""
+
+    global _cache_client
+    if _cache_client is None:
+        redis_url = getattr(settings, "REDIS_URL", "redis://localhost:6379")
+        _cache_client = CacheClient(redis_url)
+    return _cache_client

--- a/conversation_service/clients/__init__.py
+++ b/conversation_service/clients/__init__.py
@@ -1,0 +1,7 @@
+"""Asynchronous service clients used by the conversation service."""
+
+from .openai_client import OpenAIClient
+from .search_client import SearchClient
+from .cache_client import CacheClient
+
+__all__ = ["OpenAIClient", "SearchClient", "CacheClient"]

--- a/conversation_service/clients/cache_client.py
+++ b/conversation_service/clients/cache_client.py
@@ -1,0 +1,91 @@
+"""Simple Redis cache client used to store service responses.
+
+The real project relies on Redis for cross-service caching.  For the unit
+tests we merely need a small abstraction over ``redis.asyncio`` that
+provides ``get`` and ``set`` helpers with optional TTL handling.  Values
+are serialised to JSON so arbitrary Python structures can be stored.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Optional
+
+import redis.asyncio as redis
+from redis.exceptions import RedisError
+
+
+class CacheClient:
+    """Asynchronous Redis cache helper with retry logic."""
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        prefix: str = "cache:",
+        max_retries: int = 3,
+    ) -> None:
+        self._prefix = prefix
+        self._client = redis.from_url(url, decode_responses=True)
+        self._max_retries = max_retries
+
+    def _format_key(self, key: str) -> str:
+        return f"{self._prefix}{key}"
+
+    async def get(self, key: str) -> Optional[Any]:
+        """Retrieve a value from the cache."""
+
+        last_error: Optional[Exception] = None
+        for attempt in range(1, self._max_retries + 1):
+            try:
+                raw = await self._client.get(self._format_key(key))
+                if raw is None:
+                    return None
+                try:
+                    return json.loads(raw)
+                except json.JSONDecodeError:
+                    return raw
+            except RedisError as exc:
+                last_error = exc
+                if attempt >= self._max_retries:
+                    break
+                await asyncio.sleep(2 ** (attempt - 1))
+        assert last_error is not None
+        raise last_error
+
+    async def set(self, key: str, value: Any, ttl: Optional[int] = None) -> None:
+        """Store ``value`` under ``key`` with an optional TTL in seconds."""
+
+        last_error: Optional[Exception] = None
+        for attempt in range(1, self._max_retries + 1):
+            try:
+                if not isinstance(value, str):
+                    value = json.dumps(value)
+                await self._client.set(self._format_key(key), value, ex=ttl)
+                return None
+            except RedisError as exc:
+                last_error = exc
+                if attempt >= self._max_retries:
+                    break
+                await asyncio.sleep(2 ** (attempt - 1))
+        assert last_error is not None
+        raise last_error
+
+    async def delete(self, key: str) -> None:
+        last_error: Optional[Exception] = None
+        for attempt in range(1, self._max_retries + 1):
+            try:
+                await self._client.delete(self._format_key(key))
+                return None
+            except RedisError as exc:
+                last_error = exc
+                if attempt >= self._max_retries:
+                    break
+                await asyncio.sleep(2 ** (attempt - 1))
+        assert last_error is not None
+        raise last_error
+
+    async def close(self) -> None:
+        await self._client.close()
+

--- a/conversation_service/clients/openai_client.py
+++ b/conversation_service/clients/openai_client.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+"""Simple OpenAI async client wrapper.
+
+This module provides :class:`OpenAIClient`, a thin wrapper around
+:class:`openai.AsyncOpenAI` that adds two features that are useful for the
+project:
+
+* **Retry logic** – failed requests are retried with an exponential
+  backoff.  Transient network errors are common when talking to the
+  OpenAI API and retrying greatly improves reliability.
+* **Cost tracking** – the client keeps track of the number of tokens used
+  and an estimated cost in USD.  The pricing table can easily be
+  customised per model.
+
+The implementation is intentionally lightweight; it only exposes the
+``chat_completion`` method which is the only one currently used by the
+project.  It can be extended later if more endpoints are required.
+"""
+
+import asyncio
+import logging
+from typing import Any, Dict, List, Optional
+
+from openai import AsyncOpenAI
+
+logger = logging.getLogger("openai_client")
+
+# Default pricing table (USD per 1K tokens).  The values do not need to be
+# perfectly accurate for the tests but give a reasonable estimation.  New
+# models can be added by consumers of the client by passing a custom
+# ``model_pricing`` mapping to ``OpenAIClient``.
+DEFAULT_MODEL_PRICING: Dict[str, float] = {
+    "gpt-4o-mini": 0.00015,
+}
+
+
+class OpenAIClient:
+    """Wrapper around :class:`AsyncOpenAI` with retries and cost tracking."""
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str = "https://api.openai.com/v1",
+        *,
+        model_pricing: Optional[Dict[str, float]] = None,
+        max_retries: int = 3,
+    ) -> None:
+        self._client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+        self._max_retries = max_retries
+        self._model_pricing = model_pricing or DEFAULT_MODEL_PRICING
+        self.total_tokens: int = 0
+        self.total_cost_usd: float = 0.0
+
+    async def chat_completion(
+        self, *, model: str, messages: List[Dict[str, str]], **kwargs: Any
+    ) -> Any:
+        """Call the OpenAI chat completion endpoint.
+
+        Retries the request on failure and updates cost metrics using the
+        pricing table.  The raw response from ``openai`` is returned so the
+        caller can access all available data.
+        """
+
+        last_error: Optional[Exception] = None
+        for attempt in range(1, self._max_retries + 1):
+            try:
+                response = await self._client.chat.completions.create(
+                    model=model, messages=messages, **kwargs
+                )
+
+                usage = getattr(response, "usage", None)
+                tokens = usage.total_tokens if usage else 0
+                self.total_tokens += tokens
+
+                price = self._model_pricing.get(model, 0.0)
+                cost = tokens / 1000 * price
+                self.total_cost_usd += cost
+
+                logger.debug(
+                    "OpenAI call succeeded", model=model, tokens=tokens, cost=cost
+                )
+                return response
+            except Exception as exc:  # pragma: no cover - network errors
+                last_error = exc
+                logger.warning(
+                    "OpenAI call failed (attempt %s/%s): %s",
+                    attempt,
+                    self._max_retries,
+                    exc,
+                )
+                if attempt >= self._max_retries:
+                    break
+                await asyncio.sleep(2 ** (attempt - 1))
+
+        # If we get here all retries failed, re-raise the last exception
+        assert last_error is not None
+        raise last_error
+
+    def get_total_cost(self) -> float:
+        """Return the accumulated estimated cost in USD."""
+
+        return self.total_cost_usd
+
+    async def close(self) -> None:
+        """Close the underlying HTTP session."""
+
+        await self._client.close()
+

--- a/conversation_service/clients/search_client.py
+++ b/conversation_service/clients/search_client.py
@@ -1,0 +1,68 @@
+"""Asynchronous client for the internal search service.
+
+The real application communicates with a separate micro-service that
+provides search capabilities.  The tests in this kata only need a very
+small portion of that behaviour: performing authenticated HTTP requests
+and returning the JSON payload.
+
+This module exposes :class:`SearchClient` which wraps :mod:`aiohttp` and
+handles authentication headers, session management and basic error
+handling.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import aiohttp
+from typing import Any, Dict, Optional
+
+
+class SearchClient:
+    """HTTP client used to talk to ``search_service``."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        token: Optional[str] = None,
+        timeout: float = 10.0,
+        max_retries: int = 3,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self._token = token
+        self._timeout = aiohttp.ClientTimeout(total=timeout)
+        self._session: Optional[aiohttp.ClientSession] = None
+        self._max_retries = max_retries
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None:
+            headers = {"Accept": "application/json"}
+            if self._token:
+                headers["Authorization"] = f"Bearer {self._token}"
+            self._session = aiohttp.ClientSession(headers=headers, timeout=self._timeout)
+        return self._session
+
+    async def search(self, payload: Dict[str, Any], endpoint: str = "/search") -> Dict[str, Any]:
+        """Execute a search query and return the JSON response."""
+
+        session = await self._get_session()
+        url = f"{self.base_url}{endpoint}"
+        last_error: Optional[Exception] = None
+        for attempt in range(1, self._max_retries + 1):
+            try:
+                async with session.post(url, json=payload) as resp:
+                    resp.raise_for_status()
+                    return await resp.json()
+            except aiohttp.ClientError as exc:
+                last_error = exc
+                if attempt >= self._max_retries:
+                    break
+                await asyncio.sleep(2 ** (attempt - 1))
+        assert last_error is not None
+        raise last_error
+
+    async def close(self) -> None:
+        if self._session is not None:
+            await self._session.close()
+            self._session = None
+


### PR DESCRIPTION
## Summary
- add async OpenAI, search, and cache clients with retry logic
- wire dependencies to provide shared clients
- update base agent to use new OpenAI client wrapper

## Testing
- `pytest -q` *(fails: No module named 'conversation_service.agents.entity_extractor_agent')*
- `pytest tests/test_websocket.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a70f4ab0208320a694b269ce76e9d1