### PR TITLE
Use dedicated prompt loaders with financial examples

### DIFF
--- a/conversation_service/agents/entity_extractor.py
+++ b/conversation_service/agents/entity_extractor.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional
 
 from .base_agent import BaseFinancialAgent
 from ..models.agent_models import AgentConfig
-from prompts.entity_prompts import load_prompt, get_examples
+from ..prompts import entity_prompts
 
 
 class EntityExtractorAgent(BaseFinancialAgent):
@@ -13,11 +13,11 @@ class EntityExtractorAgent(BaseFinancialAgent):
     def __init__(self, openai_client):
         config = AgentConfig(
             name="entity_extractor",
-            system_message=load_prompt(),
+            system_message=entity_prompts.get_prompt(),
             model_name="gpt-4o-mini",
         )
         super().__init__(config=config, openai_client=openai_client)
-        self.examples = get_examples()
+        self.examples = entity_prompts.get_examples()
 
     async def _process_implementation(
         self, input_data: Dict[str, Any]

--- a/conversation_service/agents/intent_classifier.py
+++ b/conversation_service/agents/intent_classifier.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional
 
 from .base_agent import BaseFinancialAgent
 from ..models.agent_models import AgentConfig
-from prompts.intent_prompts import load_prompt, get_examples
+from ..prompts import intent_prompts
 
 
 class IntentClassifierAgent(BaseFinancialAgent):
@@ -13,11 +13,11 @@ class IntentClassifierAgent(BaseFinancialAgent):
     def __init__(self, openai_client):
         config = AgentConfig(
             name="intent_classifier",
-            system_message=load_prompt(),
+            system_message=intent_prompts.get_prompt(),
             model_name="gpt-4o-mini",
         )
         super().__init__(config=config, openai_client=openai_client)
-        self.examples = get_examples()
+        self.examples = intent_prompts.get_examples()
 
     async def _process_implementation(
         self, input_data: Dict[str, Any]

--- a/conversation_service/agents/query_generator.py
+++ b/conversation_service/agents/query_generator.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional
 
 from .base_agent import BaseFinancialAgent
 from ..models.agent_models import AgentConfig
-from prompts.query_prompts import load_prompt, get_examples
+from ..prompts import query_prompts
 
 
 class QueryGeneratorAgent(BaseFinancialAgent):
@@ -13,11 +13,11 @@ class QueryGeneratorAgent(BaseFinancialAgent):
     def __init__(self, openai_client):
         config = AgentConfig(
             name="query_generator",
-            system_message=load_prompt(),
+            system_message=query_prompts.get_prompt(),
             model_name="gpt-4o-mini",
         )
         super().__init__(config=config, openai_client=openai_client)
-        self.examples = get_examples()
+        self.examples = query_prompts.get_examples()
 
     async def _process_implementation(
         self, input_data: Dict[str, Any]

--- a/conversation_service/agents/response_generator.py
+++ b/conversation_service/agents/response_generator.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional
 
 from .base_agent import BaseFinancialAgent
 from ..models.agent_models import AgentConfig
-from prompts.response_prompts import load_prompt, get_examples
+from ..prompts import response_prompts
 
 
 class ResponseGeneratorAgent(BaseFinancialAgent):
@@ -13,11 +13,11 @@ class ResponseGeneratorAgent(BaseFinancialAgent):
     def __init__(self, openai_client):
         config = AgentConfig(
             name="response_generator",
-            system_message=load_prompt(),
+            system_message=response_prompts.get_prompt(),
             model_name="gpt-4o-mini",
         )
         super().__init__(config=config, openai_client=openai_client)
-        self.examples = get_examples()
+        self.examples = response_prompts.get_examples()
 
     async def _process_implementation(
         self, input_data: Dict[str, Any]

--- a/conversation_service/prompts/__init__.py
+++ b/conversation_service/prompts/__init__.py
@@ -4,6 +4,7 @@ Ce package regroupe les utilitaires de gestion de prompts pour la
 classification d'intentions, l'extraction d'entités, la génération de
 requêtes et la formulation de réponses dans le service de conversation.
 """
+from . import intent_prompts, entity_prompts, query_prompts, response_prompts
 
 __all__ = [
     "intent_prompts",

--- a/conversation_service/prompts/entity_prompts.py
+++ b/conversation_service/prompts/entity_prompts.py
@@ -12,6 +12,10 @@ DEFAULT_PROMPT = "Identifie les entités présentes dans le message utilisateur.
 
 _EXAMPLES: List[Dict[str, str]] = [
     {"input": "J'ai dépensé 50€ chez Amazon", "output": "AMOUNT:50, MERCHANT:Amazon"},
+    {
+        "input": "Paiement de 200€ chez Carrefour hier",
+        "output": "AMOUNT:200, MERCHANT:Carrefour, DATE:hier",
+    },
 ]
 
 _PROMPT_CACHE: Dict[str, str] = {}
@@ -26,6 +30,16 @@ def load_prompt(path: Optional[str] = None, *, cache: Optional[Dict[str, str]] =
         cache[cache_key] = prompt
         return prompt
     return DEFAULT_PROMPT
+
+
+def get_prompt(
+    path: Optional[str] = None,
+    *,
+    cache: Optional[Dict[str, str]] = None,
+    cache_key: str = "default",
+) -> str:
+    """Retourner le prompt à utiliser par l'agent."""
+    return load_prompt(path=path, cache=cache, cache_key=cache_key)
 
 
 def get_examples() -> List[Dict[str, str]]:

--- a/conversation_service/prompts/intent_prompts.py
+++ b/conversation_service/prompts/intent_prompts.py
@@ -13,6 +13,10 @@ DEFAULT_PROMPT = "Analyse l'intention du message utilisateur."
 
 _EXAMPLES: List[Dict[str, str]] = [
     {"input": "Bonjour", "output": "GREETING"},
+    {
+        "input": "Quel est le solde de mon compte ?",
+        "output": "BALANCE_INQUIRY",
+    },
 ]
 
 _PROMPT_CACHE: Dict[str, str] = {}
@@ -35,6 +39,16 @@ def load_prompt(path: Optional[str] = None, *, cache: Optional[Dict[str, str]] =
         cache[cache_key] = prompt
         return prompt
     return DEFAULT_PROMPT
+
+
+def get_prompt(
+    path: Optional[str] = None,
+    *,
+    cache: Optional[Dict[str, str]] = None,
+    cache_key: str = "default",
+) -> str:
+    """Retourner le prompt à utiliser par l'agent."""
+    return load_prompt(path=path, cache=cache, cache_key=cache_key)
 
 
 def get_examples() -> List[Dict[str, str]]:

--- a/conversation_service/prompts/query_prompts.py
+++ b/conversation_service/prompts/query_prompts.py
@@ -270,6 +270,44 @@ Génère une requête Elasticsearch optimisée au format SearchServiceQuery.""",
     "operator": "match"
   }
 }"""
+    },
+    {
+        "input": """Message utilisateur : Bilan de mes revenus ce trimestre
+Intention détectée : BUDGET_ANALYSIS
+User ID : 55
+Entités extraites :
+- CATEGORY: income
+- DATE_RANGE: this_quarter
+
+Génère une requête Elasticsearch optimisée au format SearchServiceQuery.""",
+
+        "output": """{
+  "query_metadata": {
+    "intent_type": "BUDGET_ANALYSIS",
+    "agent_name": "query_generator",
+    "timestamp": "2024-01-31T10:30:00Z"
+  },
+  "search_parameters": {
+    "query_type": "aggregated_search",
+    "fields": ["user_id", "amount", "category_name", "date"],
+    "limit": 100,
+    "timeout_ms": 5000
+  },
+  "filters": {
+    "required": [
+      {"field": "user_id", "operator": "eq", "value": 55},
+      {"field": "category_name.keyword", "operator": "eq", "value": "income"}
+    ],
+    "ranges": [
+      {"field": "date", "operator": "between", "value": ["2024-04-01", "2024-06-30"]}
+    ]
+  },
+  "aggregations": {
+    "enabled": true,
+    "types": ["sum"],
+    "metrics": ["amount"]
+  }
+}"""
     }
 ]
 
@@ -286,6 +324,16 @@ def load_prompt(path: Optional[str] = None, *, cache: Optional[Dict[str, str]] =
         cache[cache_key] = prompt
         return prompt
     return QUERY_GENERATION_SYSTEM_PROMPT
+
+
+def get_prompt(
+    path: Optional[str] = None,
+    *,
+    cache: Optional[Dict[str, str]] = None,
+    cache_key: str = "system",
+) -> str:
+    """Retourner le prompt système à utiliser par l'agent."""
+    return load_prompt(path=path, cache=cache, cache_key=cache_key)
 
 
 

--- a/conversation_service/prompts/response_prompts.py
+++ b/conversation_service/prompts/response_prompts.py
@@ -16,7 +16,11 @@ RESPONSE_FEW_SHOT_EXAMPLES: List[Dict[str, str]] = [
     {
         "input": "transactions Amazon du mois dernier",
         "output": "Vous avez 3 transactions chez Amazon en avril."
-    }
+    },
+    {
+        "input": "solde du compte courant",
+        "output": "Le solde de votre compte courant est de 1 200€.",
+    },
 ]
 
 INTENT_RESPONSE_TEMPLATES: Dict[str, str] = {
@@ -40,6 +44,16 @@ def load_prompt(path: Optional[str] = None, *, cache: Optional[Dict[str, str]] =
         cache[cache_key] = prompt
         return prompt
     return RESPONSE_GENERATION_SYSTEM_PROMPT
+
+
+def get_prompt(
+    path: Optional[str] = None,
+    *,
+    cache: Optional[Dict[str, str]] = None,
+    cache_key: str = "system",
+) -> str:
+    """Retourner le prompt système à utiliser par l'agent."""
+    return load_prompt(path=path, cache=cache, cache_key=cache_key)
 
 
 def get_examples() -> List[Dict[str, str]]:

--- a/prompts/__init__.py
+++ b/prompts/__init__.py
@@ -5,6 +5,7 @@ Ce package fournit des modules simples pour gérer différents types de prompts
 fonctionnalités pour charger dynamiquement un prompt et manipuler des exemples
 few‑shot.
 """
+from . import intent_prompts, entity_prompts, query_prompts, response_prompts
 
 __all__ = [
     "intent_prompts",

--- a/prompts/entity_prompts.py
+++ b/prompts/entity_prompts.py
@@ -12,6 +12,10 @@ DEFAULT_PROMPT = "Identifie les entités présentes dans le message utilisateur.
 
 _EXAMPLES: List[Dict[str, str]] = [
     {"input": "J'ai dépensé 50€ chez Amazon", "output": "AMOUNT:50, MERCHANT:Amazon"},
+    {
+        "input": "Paiement de 200€ chez Carrefour hier",
+        "output": "AMOUNT:200, MERCHANT:Carrefour, DATE:hier",
+    },
 ]
 
 _PROMPT_CACHE: Dict[str, str] = {}
@@ -26,6 +30,16 @@ def load_prompt(path: Optional[str] = None, *, cache: Optional[Dict[str, str]] =
         cache[cache_key] = prompt
         return prompt
     return DEFAULT_PROMPT
+
+
+def get_prompt(
+    path: Optional[str] = None,
+    *,
+    cache: Optional[Dict[str, str]] = None,
+    cache_key: str = "default",
+) -> str:
+    """Retourner le prompt à utiliser par l'agent."""
+    return load_prompt(path=path, cache=cache, cache_key=cache_key)
 
 
 def get_examples() -> List[Dict[str, str]]:

--- a/prompts/intent_prompts.py
+++ b/prompts/intent_prompts.py
@@ -13,6 +13,10 @@ DEFAULT_PROMPT = "Analyse l'intention du message utilisateur."
 
 _EXAMPLES: List[Dict[str, str]] = [
     {"input": "Bonjour", "output": "GREETING"},
+    {
+        "input": "Quel est le solde de mon compte ?",
+        "output": "BALANCE_INQUIRY",
+    },
 ]
 
 _PROMPT_CACHE: Dict[str, str] = {}
@@ -35,6 +39,16 @@ def load_prompt(path: Optional[str] = None, *, cache: Optional[Dict[str, str]] =
         cache[cache_key] = prompt
         return prompt
     return DEFAULT_PROMPT
+
+
+def get_prompt(
+    path: Optional[str] = None,
+    *,
+    cache: Optional[Dict[str, str]] = None,
+    cache_key: str = "default",
+) -> str:
+    """Retourner le prompt à utiliser par l'agent."""
+    return load_prompt(path=path, cache=cache, cache_key=cache_key)
 
 
 def get_examples() -> List[Dict[str, str]]:

--- a/prompts/query_prompts.py
+++ b/prompts/query_prompts.py
@@ -12,6 +12,10 @@ DEFAULT_PROMPT = "Génère une requête basée sur l'intention détectée."
 
 _EXAMPLES: List[Dict[str, str]] = [
     {"input": "transactions supérieures à 100€", "output": "amount>100"},
+    {
+        "input": "dépenses chez Amazon en 2024",
+        "output": "merchant:Amazon AND date:2024*",
+    },
 ]
 
 _PROMPT_CACHE: Dict[str, str] = {}
@@ -26,6 +30,16 @@ def load_prompt(path: Optional[str] = None, *, cache: Optional[Dict[str, str]] =
         cache[cache_key] = prompt
         return prompt
     return DEFAULT_PROMPT
+
+
+def get_prompt(
+    path: Optional[str] = None,
+    *,
+    cache: Optional[Dict[str, str]] = None,
+    cache_key: str = "default",
+) -> str:
+    """Retourner le prompt à utiliser par l'agent."""
+    return load_prompt(path=path, cache=cache, cache_key=cache_key)
 
 
 def get_examples() -> List[Dict[str, str]]:

--- a/prompts/response_prompts.py
+++ b/prompts/response_prompts.py
@@ -14,6 +14,10 @@ _EXAMPLES: List[Dict[str, str]] = [
     {
         "input": "transactions Amazon du mois dernier",
         "output": "Vous avez 3 transactions chez Amazon en avril."},
+    {
+        "input": "solde du compte courant",
+        "output": "Le solde de votre compte courant est de 1 200€.",
+    },
 ]
 
 _PROMPT_CACHE: Dict[str, str] = {}
@@ -28,6 +32,16 @@ def load_prompt(path: Optional[str] = None, *, cache: Optional[Dict[str, str]] =
         cache[cache_key] = prompt
         return prompt
     return DEFAULT_PROMPT
+
+
+def get_prompt(
+    path: Optional[str] = None,
+    *,
+    cache: Optional[Dict[str, str]] = None,
+    cache_key: str = "default",
+) -> str:
+    """Retourner le prompt à utiliser par l'agent."""
+    return load_prompt(path=path, cache=cache, cache_key=cache_key)
 
 
 def get_examples() -> List[Dict[str, str]]:


### PR DESCRIPTION
## Summary
- load each agent's system prompt via dedicated `get_prompt` helper
- enrich prompt modules with financial few-shot examples and expose relative imports
- adjust package paths to ensure tests can import prompts

## Testing
- `pytest tests/test_prompts/test_query_prompts.py -q`
- `pytest -q` *(fails: ModuleNotFoundError for conversation_service.agents.intent_classifier_agent, entity_extractor_agent, query_generator_agent; AttributeError: module 'httpx' has no attribute 'Response')*

------
https://chatgpt.com/codex/tasks/task_e_68a70f517b4c83208c0f4e3772d2850e