### PR TITLE
Add utility package for conversation service

### DIFF
--- a/conversation_service/utils/__init__.py
+++ b/conversation_service/utils/__init__.py
@@ -1,0 +1,13 @@
+"""Utility helpers for the conversation service."""
+
+from .logging import get_structured_logger
+from .decorators import metrics, cache
+from .helpers import chunks, flatten_dict
+
+__all__ = [
+    "get_structured_logger",
+    "metrics",
+    "cache",
+    "chunks",
+    "flatten_dict",
+]

--- a/conversation_service/utils/decorators.py
+++ b/conversation_service/utils/decorators.py
@@ -1,0 +1,86 @@
+"""Decorators for metrics collection and caching."""
+from __future__ import annotations
+
+import asyncio
+import time
+from functools import wraps
+from typing import Any, Callable, Dict, Hashable, Tuple, TypeVar
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def metrics(metrics_collector: Any, name: str) -> Callable[[F], F]:
+    """Decorator that records invocation count and execution time."""
+
+    def decorator(func: F) -> F:
+        if asyncio.iscoroutinefunction(func):
+
+            @wraps(func)
+            async def async_wrapper(*args, **kwargs):
+                start = time.time()
+                try:
+                    return await func(*args, **kwargs)
+                finally:
+                    if metrics_collector:
+                        metrics_collector.record_request(name, 1)
+                        elapsed = int((time.time() - start) * 1000)
+                        metrics_collector.record_response_time(name, elapsed)
+
+            return async_wrapper  # type: ignore[return-value]
+
+        @wraps(func)
+        def sync_wrapper(*args, **kwargs):
+            start = time.time()
+            try:
+                return func(*args, **kwargs)
+            finally:
+                if metrics_collector:
+                    metrics_collector.record_request(name, 1)
+                    elapsed = int((time.time() - start) * 1000)
+                    metrics_collector.record_response_time(name, elapsed)
+
+        return sync_wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+def cache(ttl: int = 60) -> Callable[[F], F]:
+    """Simple in-memory TTL cache decorator."""
+
+    def decorator(func: F) -> F:
+        store: Dict[Hashable, Tuple[float, Any]] = {}
+
+        if asyncio.iscoroutinefunction(func):
+
+            @wraps(func)
+            async def async_wrapper(*args, **kwargs):
+                key = (args, frozenset(kwargs.items()))
+                now = time.time()
+                if key in store:
+                    exp, value = store[key]
+                    if now - exp < ttl:
+                        return value
+                value = await func(*args, **kwargs)
+                store[key] = (now, value)
+                return value
+
+            return async_wrapper  # type: ignore[return-value]
+
+        @wraps(func)
+        def sync_wrapper(*args, **kwargs):
+            key = (args, frozenset(kwargs.items()))
+            now = time.time()
+            if key in store:
+                exp, value = store[key]
+                if now - exp < ttl:
+                    return value
+            value = func(*args, **kwargs)
+            store[key] = (now, value)
+            return value
+
+        return sync_wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+__all__ = ["metrics", "cache"]

--- a/conversation_service/utils/helpers.py
+++ b/conversation_service/utils/helpers.py
@@ -1,0 +1,33 @@
+"""Common helper functions used by agents."""
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Iterator, List
+
+
+def chunks(iterable: Iterable[Any], size: int) -> Iterator[List[Any]]:
+    """Yield successive chunks from ``iterable`` of length ``size``."""
+
+    chunk: List[Any] = []
+    for item in iterable:
+        chunk.append(item)
+        if len(chunk) == size:
+            yield chunk
+            chunk = []
+    if chunk:
+        yield chunk
+
+
+def flatten_dict(data: Dict[str, Any], parent_key: str = "", sep: str = ".") -> Dict[str, Any]:
+    """Flatten a nested dictionary using ``sep`` as separator."""
+
+    items: Dict[str, Any] = {}
+    for key, value in data.items():
+        new_key = f"{parent_key}{sep}{key}" if parent_key else key
+        if isinstance(value, dict):
+            items.update(flatten_dict(value, new_key, sep=sep))
+        else:
+            items[new_key] = value
+    return items
+
+
+__all__ = ["chunks", "flatten_dict"]

--- a/conversation_service/utils/logging.py
+++ b/conversation_service/utils/logging.py
@@ -1,0 +1,53 @@
+"""Structured logging utilities for agents."""
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from typing import Any, Dict
+
+
+class JsonFormatter(logging.Formatter):
+    """Formatter that outputs logs as JSON."""
+
+    def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - trivial
+        log_record: Dict[str, Any] = {
+            "timestamp": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        extra = getattr(record, "extra", None)
+        if isinstance(extra, dict):
+            log_record.update(extra)
+        return json.dumps(log_record, ensure_ascii=False)
+
+
+def get_structured_logger(name: str, **context: Any) -> logging.Logger:
+    """Return a logger that outputs JSON formatted messages.
+
+    Parameters
+    ----------
+    name:
+        Name of the logger to create or retrieve.
+    context:
+        Optional contextual information to include with every log entry.
+    """
+
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setFormatter(JsonFormatter())
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+    if context:
+        class ContextAdapter(logging.LoggerAdapter):
+            def process(self, msg, kwargs):  # pragma: no cover - passthrough
+                extra = kwargs.setdefault("extra", {})
+                extra.update(context)
+                return msg, kwargs
+        return ContextAdapter(logger, {})
+    return logger
+
+
+__all__ = ["get_structured_logger", "JsonFormatter"]


### PR DESCRIPTION
## Summary
- add utility package under conversation_service for structured logging
- implement metrics and cache decorators
- provide common helper functions for agents

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'conversation_service.agents.entity_extractor_agent')*


------
https://chatgpt.com/codex/tasks/task_e_68a70f56469483208e0abc8990c531e2