### PR TITLE
Integrate conversation service API

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -1,15 +1,7 @@
 from fastapi import APIRouter
 
-from models.conversation_models import AgentQueryRequest, AgentQueryResponse
-from teams.team_orchestrator import TeamOrchestrator
-
-router = APIRouter(tags=["conversation"])
-orchestrator = TeamOrchestrator()
+from conversation_service.api.routes import router as conversation_router
 
 
-@router.post("/chat", response_model=AgentQueryResponse)
-async def chat_endpoint(payload: AgentQueryRequest) -> AgentQueryResponse:
-    """Proxy a chat message through the team orchestrator."""
-    conv_id = orchestrator.start_conversation()
-    reply = await orchestrator.query_agents(conv_id, payload.message)
-    return AgentQueryResponse(conversation_id=conv_id, reply=reply)
+router = APIRouter()
+router.include_router(conversation_router, prefix="/conversation")

--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from api.routes import router as api_router
+from api.routes import router as api_router  # provides REST endpoints including conversation
 from api.websocket import router as ws_router
 from api.middleware import setup_middleware
 from config.settings import settings


### PR DESCRIPTION
## Summary
- Mount conversation service REST API under `/conversation`
- Export conversation endpoints through main app router
- Clarify app factory imports so conversation routes are included

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'conversation_service.agents.agent_team')*

------
https://chatgpt.com/codex/tasks/task_e_68a71656f0c0832083c966dfd45c2896