### PR TITLE
feat: add redis cache with per-agent ttl and fallback

### DIFF
--- a/conversation_service/agents/__init__.py
+++ b/conversation_service/agents/__init__.py
@@ -1,37 +1,8 @@
-"""Agent utilities for the conversation service.
+"""Lightweight namespace for conversation agents."""
 
-Only lightweight utilities are imported eagerly to keep the package usable in
-restricted test environments where optional dependencies (like ``aiohttp`` or
-``autogen``) may not be installed.  The production agents can still be
-imported directly from their respective modules when needed.
-"""
-
-try:  # pragma: no cover - optional imports for test friendliness
+try:  # pragma: no cover - optional utility
     from .query_generator_agent import QueryOptimizer
 except Exception:  # pragma: no cover
     QueryOptimizer = object  # type: ignore
 
 __all__ = ["QueryOptimizer"]
-
-"""Lightweight namespace package for conversation agents.
-
-The original project exposes many agent implementations with heavy
-third‑party dependencies.  For the purposes of the kata the package keeps its
-initialisation minimal so that individual utility modules (like small caches or
-optimisers) can be imported in isolation during testing.
-"""Lightweight package initializer for conversation agents.
-
-The original project exposes many agent implementations which pull in optional
-runtime dependencies.  For the purposes of the tests in this kata we avoid
-importing those heavy modules at import time to keep the environment minimal.
-
-Only the lightweight wrapper modules are guaranteed to be available.  They can
-be imported directly, e.g. ``conversation_service.agents.intent_classifier_agent``.
-"""
-
-__all__ = [
-    "intent_classifier_agent",
-    "entity_extractor_agent",
-    "query_generator_agent",
-    "response_generator_agent",
-]

--- a/conversation_service/agents/entity_extractor_agent.py
+++ b/conversation_service/agents/entity_extractor_agent.py
@@ -1,91 +1,50 @@
-"""Caches for entity extraction agents.
-
-The :class:`EntityExtractionCache` mirrors the API of
-:class:`~conversation_service.agents.intent_classifier_agent.IntentClassificationCache`.
-It stores lists of `FinancialEntity` instances keyed by both the user query
-and the type of analysis performed.  Each cache hit increments a counter so
-that callers can monitor effectiveness.
-"""
+"""Entity extraction utilities with Redis-backed cache."""
 
 from __future__ import annotations
 
+import asyncio
+import os
 from typing import Dict, List, Optional, Tuple
 
-"""Wrapper module for entity extraction utilities.
-
-This file re-exports :class:`EntityExtractorAgent` from the existing
-``entity_extractor`` module and defines :class:`EntityExtractionCache` used in
-unit tests.  The cache stores lists of :class:`FinancialEntity` objects keyed by
-both the user's prompt and the intent type.
-"""
-
-from typing import Dict, List, Optional, Tuple
-
-# Importing the full ``EntityExtractorAgent`` would require optional runtime
-# dependencies.  We attempt to import it lazily and fall back to ``None`` when
-# those dependencies are unavailable.
-try:  # pragma: no cover - defensive import
+try:  # pragma: no cover - optional runtime dependency
     from .entity_extractor import EntityExtractorAgent  # type: ignore
 except Exception:  # pragma: no cover - dependency not available
     EntityExtractorAgent = None  # type: ignore
 
+from ..clients.cache_client import CacheClient
+from ..core.cache_manager import CacheManager
 from ..models.core_models import FinancialEntity
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379")
 
 
 class EntityExtractionCache:
-    """Simple in-memory cache for entity extraction results."""
+    """Cache extracted entities keyed by message and intent."""
 
-    def __init__(self) -> None:
-        # Keyed by (query, analysis_type)
-        self._store: Dict[Tuple[str, str], List[FinancialEntity]] = {}
-        self.hits: int = 0
-
-    def set(self, query: str, analysis_type: str, entities: List[FinancialEntity]) -> None:
-        """Store extracted entities for a query/analysis pair."""
-        self._store[(query, analysis_type)] = entities
-
-    def get(self, query: str, analysis_type: str) -> Optional[Dict[str, object]]:
-        """Retrieve cached entities if present.
-
-        Returns a dictionary containing the cached entities with a flag
-        indicating the result was served from cache.  The hit counter is only
-        incremented when a cached value is found.
-        """
-        entities = self._store.get((query, analysis_type))
-        if entities is None:
-            return None
-        self.hits += 1
-        return {"cached": True, "entities": entities}
-    """In-memory cache of extracted entities."""
-
-    def __init__(self) -> None:
-        # Keyed by (message, intent)
-        self._store: Dict[Tuple[str, str], List[FinancialEntity]] = {}
-        self.hits: int = 0
+    def __init__(self, ttl: int = 900) -> None:
+        client = CacheClient(REDIS_URL)
+        self._cache = CacheManager(cache_client=client, default_ttl=ttl)
+        self.hits = 0
+        self._user_id = "test"
 
     @staticmethod
-    def _make_key(message: str, intent: str) -> Tuple[str, str]:
-        return message, str(intent)
+    def _make_key(message: str, intent: str) -> str:
+        return f"{message}:{intent}"
 
     def get(self, message: str, intent: str) -> Optional[Dict[str, object]]:
-        """Return cached entities for ``message`` and ``intent`` if available."""
         key = self._make_key(message, intent)
-        entities = self._store.get(key)
+        entities = asyncio.run(self._cache.get(key, self._user_id))
         if entities is None:
             return None
         self.hits += 1
         return {"entities": entities, "cached": True}
 
-    def set(
-        self, message: str, intent: str, entities: List[FinancialEntity]
-    ) -> None:
-        """Store ``entities`` for the given ``message`` and ``intent``."""
+    def set(self, message: str, intent: str, entities: List[FinancialEntity]) -> None:
         key = self._make_key(message, intent)
-        self._store[key] = entities
+        asyncio.run(self._cache.set(key, entities, user_id=self._user_id))
 
     def clear(self) -> None:
-        """Clear the cache and reset hit counter."""
-        self._store.clear()
+        self._cache.clear()
         self.hits = 0
 
 

--- a/conversation_service/agents/intent_classifier_agent.py
+++ b/conversation_service/agents/intent_classifier_agent.py
@@ -1,93 +1,44 @@
-"""Utility classes for intent classification agents.
-
-This module provides a tiny in-memory cache used in tests.  The cache
-stores `IntentResult` objects keyed by the original user query and keeps
-track of cache hit statistics.
-"""
+"""Intent classification utilities with Redis-backed cache."""
 
 from __future__ import annotations
 
-from typing import Dict, Optional
+import asyncio
+import os
+from typing import Optional
 
-"""Wrapper module exposing intent classification utilities.
-
-This wrapper re-exports :class:`IntentClassifierAgent` from the existing
-``intent_classifier`` module and provides a lightweight in-memory cache used in
-unit tests.  The cache stores :class:`IntentResult` instances keyed by the
-user's prompt.
-"""
-
-from typing import Dict, Optional
-
-# The real ``IntentClassifierAgent`` pulls in optional runtime dependencies
-# (OpenAI clients, HTTP libraries, etc.).  Importing it eagerly would cause the
-# test environment to require those extras.  We therefore attempt to import the
-# class lazily and fall back to ``None`` when those dependencies are missing.
-try:  # pragma: no cover - defensive import
+try:  # pragma: no cover - optional runtime dependency
     from .intent_classifier import IntentClassifierAgent  # type: ignore
 except Exception:  # pragma: no cover - dependency not available
     IntentClassifierAgent = None  # type: ignore
 
+from ..clients.cache_client import CacheClient
+from ..core.cache_manager import CacheManager
 from ..models.core_models import IntentResult
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379")
 
 
 class IntentClassificationCache:
-    """Cache for intent classification results.
+    """Cache for intent classification results using Redis when available."""
 
-    The cache exposes two simple operations:
+    def __init__(self, ttl: int = 600) -> None:
+        client = CacheClient(REDIS_URL)
+        self._cache = CacheManager(cache_client=client, default_ttl=ttl)
+        self.hits = 0
+        # Tests do not provide user identifiers; a fixed value isolates keys.
+        self._user_id = "test"
 
-    - :meth:`set` to store a result for a given query
-    - :meth:`get` to retrieve a cached result
-
-    Each successful retrieval increments the :attr:`hits` counter so tests
-    can assert cache effectiveness.
-    """Simple in-memory cache for intent classification results.
-
-    The cache is intentionally minimal – it supports storing and retrieving
-    :class:`IntentResult` objects by the original user message and tracks the
-    number of cache hits for testing purposes.
-    """
-
-    def __init__(self) -> None:
-        self._store: Dict[str, IntentResult] = {}
-        self.hits: int = 0
-
-    def set(self, query: str, result: IntentResult) -> None:
-        """Store an intent classification result.
-
-        Parameters
-        ----------
-        query:
-            Original user query used as cache key.
-        result:
-            The :class:`IntentResult` produced by the classifier.
-        """
-        self._store[query] = result
-
-    def get(self, query: str) -> Optional[IntentResult]:
-        """Retrieve a cached result if present.
-
-        Each successful lookup increments the :attr:`hits` counter.  When the
-        query is not found ``None`` is returned and the counter is unchanged.
-        """
-        result = self._store.get(query)
-        if result is not None:
-            self.hits += 1
-        return result
     def get(self, message: str) -> Optional[IntentResult]:
-        """Retrieve a cached result for ``message`` if available."""
-        result = self._store.get(message)
+        result = asyncio.run(self._cache.get(message, self._user_id))
         if result is not None:
             self.hits += 1
         return result
 
     def set(self, message: str, result: IntentResult) -> None:
-        """Store ``result`` for ``message`` in the cache."""
-        self._store[message] = result
+        asyncio.run(self._cache.set(message, result, user_id=self._user_id))
 
     def clear(self) -> None:
-        """Clear all cached entries and reset hit counter."""
-        self._store.clear()
+        self._cache.clear()
         self.hits = 0
 
 

--- a/conversation_service/agents/query_generator_agent.py
+++ b/conversation_service/agents/query_generator_agent.py
@@ -1,42 +1,11 @@
-"""Query optimization utilities for conversation service.
-
-This module exposes :class:`QueryOptimizer`, a lightweight helper that applies
-post-processing rules to search queries before they are sent to the search
-service.  The optimizer understands domain specific intents and adjusts the
-query accordingly so that downstream services receive well scoped requests.
-
-Supported optimization rules
-----------------------------
-* :class:`~conversation_service.models.enums.IntentType.MERCHANT_ANALYSIS` –
-  limits the number of returned merchants to 15 and applies a deterministic
-  sort on the aggregated spend so that the highest spending merchants appear
-  first.
-
-Additional rules can be added in the future as new intents require special
-handling.
-"""
 """Utility helpers for query generation agents."""
 
 from __future__ import annotations
 
-from typing import Any, Dict
-
-
-"""Wrapper module for query generation utilities.
-
-The wrapper re-exports :class:`QueryGeneratorAgent` from the existing
-``query_generator`` module and provides a minimal :class:`QueryOptimizer`
-implementation used in tests.  The optimizer applies simple rules to augment
-search queries based on the detected intent.
-"""
-
 from copy import deepcopy
 from typing import Any, Dict
 
-# Importing the concrete ``QueryGeneratorAgent`` may pull in optional
-# dependencies.  We therefore import it lazily and degrade gracefully when those
-# dependencies are missing.
-try:  # pragma: no cover - defensive import
+try:  # pragma: no cover - optional dependency
     from .query_generator import QueryGeneratorAgent  # type: ignore
 except Exception:  # pragma: no cover - dependency not available
     QueryGeneratorAgent = None  # type: ignore
@@ -45,94 +14,20 @@ from ..models.core_models import IntentType
 
 
 class QueryOptimizer:
-    """Apply intent specific tweaks to a search query."""
+    """Apply intent-specific tweaks to a search query."""
 
     _MERCHANT_LIMIT = 15
 
     @staticmethod
-    def optimize_query(query: Dict[str, Any], intent: IntentType) -> Dict[str, Any]:
-        """Return an optimized version of ``query`` based on ``intent``.
-
-        Parameters
-        ----------
-        query:
-            Base query structure targeting the search service. It must contain a
-            ``"search_parameters"`` mapping that will be updated in place.
-        intent:
-            The detected user intent guiding which optimization rules are
-            applied.
-
-        For :class:`IntentType.MERCHANT_ANALYSIS` the method enforces a limit of
-        15 merchants and adds a default sort clause ordering results by
-        descending spend.
-        """
-
-        # Ensure the query has the expected container for search parameters.
-        search_params = query.setdefault("search_parameters", {})
-
-        if intent == IntentType.MERCHANT_ANALYSIS:
-            # Restrict the number of results returned to the top merchants and
-            # apply a deterministic sort so that results are ordered by the
-            # total amount spent in descending order.
-            search_params["limit"] = QueryOptimizer._MERCHANT_LIMIT
-            search_params.setdefault("sort", [{"total_spent": {"order": "desc"}}])
-
-        return query
-    """Apply small optimizations to search queries based on intent.
-
-    The real project contains a much more elaborate optimizer, but for the
-    purposes of the exercises we only implement the behaviour required by the
-    tests.  The function operates on a dictionary describing the query and
-    returns a new optimized dictionary leaving the original untouched.
-    """
-
-    @staticmethod
     def optimize_query(base_query: Dict[str, Any], intent: IntentType) -> Dict[str, Any]:
-        """Return an optimized copy of ``base_query``.
-
-        Parameters
-        ----------
-        base_query:
-            Dictionary with keys ``search_parameters`` and ``aggregations``.
-        intent:
-            The :class:`IntentType` guiding the optimisation rules.
-        """
-        # Create a shallow copy to avoid mutating caller's structure
-        optimized = {
-            "search_parameters": dict(base_query.get("search_parameters", {})),
-            "aggregations": dict(base_query.get("aggregations", {})),
-        }
-
-        params = optimized["search_parameters"]
+        query = deepcopy(base_query)
+        params = query.setdefault("search_parameters", {})
 
         if intent == IntentType.MERCHANT_ANALYSIS:
-            # Apply simple defaults tailored for merchant analysis queries
-            params.setdefault("limit", 15)
-            params.setdefault("sort", ["amount:desc"])
+            params.setdefault("limit", QueryOptimizer._MERCHANT_LIMIT)
+            params.setdefault("sort", [{"total_spent": {"order": "desc"}}])
         else:
             params.setdefault("limit", 50)
-
-        return optimized
-    """Utility to apply intent-specific optimisations to search queries."""
-
-    @staticmethod
-    def optimize_query(base_query: Dict[str, Any], intent: IntentType) -> Dict[str, Any]:
-        """Return a new query augmented according to ``intent``.
-
-        The optimisation rules are intentionally lightweight and only implement
-        what is required by the unit tests:
-
-        * ``MERCHANT_ANALYSIS`` – limit results and ensure a sort order.
-        """
-
-        query = deepcopy(base_query)
-        search_params = query.setdefault("search_parameters", {})
-
-        if intent == IntentType.MERCHANT_ANALYSIS:
-            search_params.setdefault("limit", 15)
-            # The value of ``sort`` is not important for the tests; only its
-            # presence matters.  A simple field ordering is provided.
-            search_params.setdefault("sort", {"field": "amount", "order": "desc"})
 
         return query
 


### PR DESCRIPTION
## Summary
- replace in-memory cache manager with Redis-backed implementation and memory fallback
- compose cache keys using `REDIS_CACHE_PREFIX` and `user_id`
- add per-agent TTL mapping and update agent caches to use Redis client

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a71ed94edc8320b4bbdcb231f8526b