### PR TITLE
Validate Redis URL and propagate cache prefix

### DIFF
--- a/config_service/config.py
+++ b/config_service/config.py
@@ -154,13 +154,21 @@ class GlobalSettings(BaseSettings):
     # ==========================================
     # CONFIGURATION REDIS
     # ==========================================
-    REDIS_URL: str = os.environ.get("REDIS_URL", "redis://localhost:6379")
+    REDIS_URL: str = os.environ.get("REDIS_URL", "")  # Required
     REDISCLOUD_URL: str = os.environ.get("REDISCLOUD_URL", "")  # Heroku Redis
     REDIS_PASSWORD: Optional[str] = os.environ.get("REDIS_PASSWORD", None)
     REDIS_DB: int = int(os.environ.get("REDIS_DB", "0"))
+    REDIS_CACHE_PREFIX: str = "harena_conv"
     REDIS_MAX_CONNECTIONS: int = int(os.environ.get("REDIS_MAX_CONNECTIONS", "20"))
     REDIS_RETRY_ON_TIMEOUT: bool = os.environ.get("REDIS_RETRY_ON_TIMEOUT", "true").lower() == "true"
     REDIS_HEALTH_CHECK_INTERVAL: int = int(os.environ.get("REDIS_HEALTH_CHECK_INTERVAL", "30"))
+
+    @field_validator("REDIS_URL")
+    @classmethod
+    def validate_redis_url(cls, v: str) -> str:
+        if not v:
+            raise ValueError("REDIS_URL environment variable is required")
+        return v
     
     # ==========================================
     # CONFIGURATION DE PERFORMANCE ET CACHE

--- a/conversation_service/clients/cache_client.py
+++ b/conversation_service/clients/cache_client.py
@@ -17,7 +17,17 @@ from redis.exceptions import RedisError
 
 
 class CacheClient:
-    """Asynchronous Redis cache helper with retry logic."""
+    """Asynchronous Redis cache helper with retry logic.
+
+    Parameters
+    ----------
+    url:
+        Redis connection URL.
+    prefix:
+        Prefix applied to all cache keys.
+    max_retries:
+        Number of retry attempts on failures.
+    """
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary
- enforce harena_conv Redis cache prefix and require REDIS_URL at startup
- inject cache prefix from settings when creating CacheClient
- document required Redis config and clean up CacheClient usage

## Testing
- `pytest` *(fails: SyntaxError in conversation_service/agents/__init__.py; AttributeError: module 'httpx' has no attribute 'Response')*

------
https://chatgpt.com/codex/tasks/task_e_68a71edda894832082c039aba7941f52