### PR TITLE
feat: validate search requests and add search client

### DIFF
--- a/conversation_service/agents/query_generator.py
+++ b/conversation_service/agents/query_generator.py
@@ -2,18 +2,22 @@
 
 from typing import Any, Dict, Optional
 
+from pydantic import ValidationError
+
 from .query_generator_agent import QueryOptimizer
 
 from .base_agent import BaseFinancialAgent
 from ..models.agent_models import AgentConfig
 from ..prompts.query_prompts import load_prompt, get_examples
 from ..prompts import query_prompts
+from ..clients import SearchClient
+from search_service.models import SearchRequest
 
 
 class QueryGeneratorAgent(BaseFinancialAgent):
     """Generate search queries based on extracted data."""
 
-    def __init__(self, openai_client):
+    def __init__(self, openai_client, search_client: SearchClient):
         config = AgentConfig(
             name="query_generator",
             system_message=query_prompts.get_prompt(),
@@ -21,10 +25,32 @@ class QueryGeneratorAgent(BaseFinancialAgent):
         )
         super().__init__(config=config, openai_client=openai_client)
         self.examples = query_prompts.get_examples()
+        self.search_client = search_client
 
     async def _process_implementation(
         self, input_data: Dict[str, Any]
     ) -> Optional[Dict[str, Any]]:
-        """Return a placeholder search query."""
+        """Build and execute a search request based on ``input_data``."""
+
         context = input_data.get("context", {})
-        return {"input": input_data, "context": context, "query": ""}
+        payload = {
+            "user_id": context.get("user_id"),
+            "query": context.get("query", ""),
+            "filters": context.get("filters", {}),
+            "aggregations": context.get("aggregations"),
+        }
+
+        try:
+            request_model = SearchRequest(**payload)
+        except ValidationError:
+            # If validation fails we do not query the search service
+            return None
+
+        response = await self.search_client.search(request_model.model_dump())
+
+        return {
+            "input": input_data,
+            "context": context,
+            "search_request": request_model.model_dump(),
+            "search_response": response,
+        }

--- a/search_service_client.py
+++ b/search_service_client.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+"""Asynchronous client for the search micro-service.
+
+The real project communicates with an external search service over HTTP.
+This module provides a small :class:`SearchServiceClient` wrapper around
+:mod:`aiohttp` that exposes a single :py:meth:`search` method.  The client
+handles authentication headers, timeouts and basic error handling so that
+callers can focus on crafting the request payload.
+"""
+
+from typing import Any, Dict, Optional
+
+import aiohttp
+
+
+class SearchServiceError(RuntimeError):
+    """Raised when the search service request fails."""
+
+
+class SearchServiceClient:
+    """HTTP client used to communicate with the search service."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        token: Optional[str] = None,
+        timeout: float = 10.0,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self._token = token
+        self._timeout = aiohttp.ClientTimeout(total=timeout)
+        self._session: Optional[aiohttp.ClientSession] = None
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None:
+            headers = {"Accept": "application/json"}
+            if self._token:
+                headers["Authorization"] = f"Bearer {self._token}"
+            self._session = aiohttp.ClientSession(headers=headers, timeout=self._timeout)
+        return self._session
+
+    async def search(self, payload: Dict[str, Any], endpoint: str = "/search") -> Dict[str, Any]:
+        """Send ``payload`` to the search service and return the JSON body."""
+
+        session = await self._get_session()
+        url = f"{self.base_url}{endpoint}"
+        try:
+            async with session.post(url, json=payload) as resp:
+                resp.raise_for_status()
+                return await resp.json()
+        except aiohttp.ClientError as exc:  # pragma: no cover - network error
+            raise SearchServiceError(f"Search service request failed: {exc}") from exc
+
+    async def close(self) -> None:
+        """Close the underlying HTTP session."""
+
+        if self._session is not None:
+            await self._session.close()
+            self._session = None
+
+
+# Backwards compatibility alias
+SearchClient = SearchServiceClient


### PR DESCRIPTION
## Summary
- validate and execute search requests in query generator
- add async search service client with basic error handling

## Testing
- `pytest` *(fails: conversation_service/agents/__init__.py: SyntaxError: unterminated triple-quoted string literal)*

------
https://chatgpt.com/codex/tasks/task_e_68a71ef10fd0832091289a7a4a6f45e9