### PR TITLE
Integrate AutoGen team runtime with context sharing

### DIFF
--- a/agent_runtime.py
+++ b/agent_runtime.py
@@ -1,0 +1,44 @@
+"""Runtime helpers for executing an AutoGen team."""
+
+from __future__ import annotations
+
+from autogen_agentchat.agents import AssistantAgent
+
+from teams.team_orchestrator import TeamOrchestrator
+
+
+class AgentRuntime:
+    """Lightweight wrapper around a :class:`TeamOrchestrator`."""
+
+    def __init__(self, team: TeamOrchestrator) -> None:
+        self.team = team
+
+    async def run(self, message: str) -> str:
+        """Execute the agent pipeline for a user message."""
+
+        result = await self.team.run(task=message)
+        final_message = result.messages[-1]
+        return getattr(final_message, "content", "")
+
+    def get_context(self) -> dict[str, str]:
+        """Return the shared context accumulated by the team."""
+
+        return dict(self.team.context)
+
+
+def create_runtime(
+    classifier: AssistantAgent | None = None,
+    extractor: AssistantAgent | None = None,
+    query_agent: AssistantAgent | None = None,
+    responder: AssistantAgent | None = None,
+) -> AgentRuntime:
+    """Factory that builds an :class:`AgentRuntime` with the provided agents."""
+
+    team = TeamOrchestrator(
+        classifier=classifier,
+        extractor=extractor,
+        query_agent=query_agent,
+        responder=responder,
+    )
+    return AgentRuntime(team)
+

--- a/teams/__init__.py
+++ b/teams/__init__.py
@@ -1,3 +1,17 @@
-from .financial_team import FinancialTeam
+"""Team package with lazy imports to avoid heavy dependencies."""
 
-__all__ = ["FinancialTeam"]
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+__all__ = ["FinancialTeam", "TeamOrchestrator"]
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - simple loader
+    if name == "FinancialTeam":
+        return import_module(".financial_team", __name__).FinancialTeam
+    if name == "TeamOrchestrator":
+        return import_module(".team_orchestrator", __name__).TeamOrchestrator
+    raise AttributeError(name)
+

--- a/teams/team_orchestrator.py
+++ b/teams/team_orchestrator.py
@@ -1,39 +1,117 @@
+"""Agent team orchestration using AutoGen 0.4 agents."""
+
 from __future__ import annotations
 
-"""Simple in-memory team orchestrator for conversation agents."""
+from typing import Any, Mapping, Sequence
 
-from typing import Dict, List, Optional
-from uuid import uuid4
+from autogen_agentchat.agents import AssistantAgent, BaseChatAgent
+from autogen_agentchat.base import Response, TaskResult, Team
+from autogen_agentchat.base._task import AgentEvent, ChatMessage
+from autogen_agentchat.messages import TextMessage
+from autogen_core import CancellationToken
 
-from models.conversation_models import ConversationMessage
+
+class _EchoAgent(AssistantAgent):
+    """Fallback assistant that simply echoes incoming text."""
+
+    produced_message_types = [TextMessage]
+
+    def __init__(self, name: str) -> None:
+        BaseChatAgent.__init__(self, name=name, description="echo agent")
+
+    async def on_messages(
+        self, messages: Sequence[ChatMessage], cancellation_token: CancellationToken
+    ) -> Response:
+        content = messages[0].content if messages else ""
+        return Response(chat_message=TextMessage(content=content, source=self.name))
+
+    async def on_reset(self, cancellation_token: CancellationToken) -> None:  # pragma: no cover - stateless
+        return None
 
 
-class TeamOrchestrator:
-    """Coordinate agents and manage conversation history."""
+class TeamOrchestrator(Team):
+    """Coordinate a team of assistant agents with shared context."""
 
-    def __init__(self) -> None:
-        self._conversations: Dict[str, List[ConversationMessage]] = {}
+    def __init__(
+        self,
+        classifier: AssistantAgent | None = None,
+        extractor: AssistantAgent | None = None,
+        query_agent: AssistantAgent | None = None,
+        responder: AssistantAgent | None = None,
+    ) -> None:
+        self.classifier = classifier or _EchoAgent("classification")
+        self.extractor = extractor or _EchoAgent("extraction")
+        self.query_agent = query_agent or _EchoAgent("query")
+        self.responder = responder or _EchoAgent("response")
+        self.context: dict[str, Any] = {}
 
-    def start_conversation(self, user_id: Optional[int] = None) -> str:
-        """Create a new conversation and return its identifier."""
-        conv_id = str(uuid4())
-        self._conversations[conv_id] = []
-        return conv_id
+    async def run(
+        self,
+        *,
+        task: str | ChatMessage | Sequence[ChatMessage] | None = None,
+        cancellation_token: CancellationToken | None = None,
+    ) -> TaskResult:
+        if cancellation_token is None:
+            cancellation_token = CancellationToken()
+        if isinstance(task, str):
+            message = TextMessage(content=task, source="user")
+        elif isinstance(task, TextMessage):
+            message = task
+        else:
+            raise ValueError("Task must be a string or TextMessage")
 
-    def get_history(self, conversation_id: str) -> Optional[List[ConversationMessage]]:
-        """Return history for a conversation or ``None`` if not found."""
-        return self._conversations.get(conversation_id)
+        outputs: list[AgentEvent | ChatMessage] = [message]
 
-    async def query_agents(self, conversation_id: str, message: str) -> str:
-        """Process a message through the agent team.
+        # Intent classification
+        resp = await self.classifier.on_messages([message], cancellation_token)
+        self.context["classification"] = resp.chat_message.content
+        outputs.append(resp.chat_message)
 
-        The current implementation is a placeholder that simply echoes the
-        user's message. It also stores the user and assistant turns in memory.
-        """
-        history = self._conversations.setdefault(conversation_id, [])
-        history.append(ConversationMessage(role="user", content=message))
+        # Entity extraction
+        msg = TextMessage(content=resp.chat_message.content, source=self.classifier.name)
+        resp = await self.extractor.on_messages([msg], cancellation_token)
+        self.context["extraction"] = resp.chat_message.content
+        outputs.append(resp.chat_message)
 
-        # Placeholder agent behaviour: echo the message
-        reply = f"Echo: {message}"
-        history.append(ConversationMessage(role="assistant", content=reply))
-        return reply
+        # Query generation
+        msg = TextMessage(content=resp.chat_message.content, source=self.extractor.name)
+        resp = await self.query_agent.on_messages([msg], cancellation_token)
+        self.context["query"] = resp.chat_message.content
+        outputs.append(resp.chat_message)
+
+        # Response generation
+        msg = TextMessage(content=resp.chat_message.content, source=self.query_agent.name)
+        resp = await self.responder.on_messages([msg], cancellation_token)
+        self.context["response"] = resp.chat_message.content
+        outputs.append(resp.chat_message)
+
+        return TaskResult(messages=outputs)
+
+    def run_stream(
+        self,
+        *,
+        task: str | ChatMessage | Sequence[ChatMessage] | None = None,
+        cancellation_token: CancellationToken | None = None,
+    ) -> Any:
+        async def _gen() -> Any:
+            result = await self.run(task=task, cancellation_token=cancellation_token)
+            for msg in result.messages:
+                yield msg
+            yield result
+
+        return _gen()
+
+    async def reset(self) -> None:
+        self.context.clear()
+        token = CancellationToken()
+        await self.classifier.on_reset(token)
+        await self.extractor.on_reset(token)
+        await self.query_agent.on_reset(token)
+        await self.responder.on_reset(token)
+
+    async def save_state(self) -> Mapping[str, Any]:
+        return {"context": dict(self.context)}
+
+    async def load_state(self, state: Mapping[str, Any]) -> None:
+        self.context = dict(state.get("context", {}))
+

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -1,0 +1,43 @@
+import asyncio
+
+from autogen_agentchat.agents import AssistantAgent, BaseChatAgent
+from autogen_agentchat.base import Response
+from autogen_agentchat.messages import TextMessage
+
+from agent_runtime import create_runtime
+
+
+class DummyAgent(AssistantAgent):
+    """Assistant that returns a preconfigured reply."""
+
+    produced_message_types = [TextMessage]
+
+    def __init__(self, name: str, reply: str) -> None:
+        BaseChatAgent.__init__(self, name=name, description="dummy")
+        self._reply = reply
+
+    async def on_messages(self, messages, cancellation_token):  # type: ignore[override]
+        return Response(chat_message=TextMessage(content=self._reply, source=self.name))
+
+    async def on_reset(self, cancellation_token) -> None:  # pragma: no cover - stateless
+        return None
+
+
+def test_full_workflow_context_sharing() -> None:
+    runtime = create_runtime(
+        classifier=DummyAgent("classification", "intent"),
+        extractor=DummyAgent("extraction", "entities"),
+        query_agent=DummyAgent("query", "sql"),
+        responder=DummyAgent("response", "done"),
+    )
+
+    result = asyncio.run(runtime.run("hello"))
+
+    assert result == "done"
+    assert runtime.get_context() == {
+        "classification": "intent",
+        "extraction": "entities",
+        "query": "sql",
+        "response": "done",
+    }
+


### PR DESCRIPTION
## Summary
- Implement AutoGen-based `TeamOrchestrator` coordinating classification, extraction, query and response agents with shared context
- Provide `AgentRuntime` wrapper and factory for assembling teams
- Add workflow test covering context propagation

## Testing
- `pytest tests/test_agent_runtime.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a71f0f16bc8320b46343299053b7d4