### PR TITLE
Fix agents package init and add import test

### DIFF
--- a/conversation_service/agents/__init__.py
+++ b/conversation_service/agents/__init__.py
@@ -1,31 +1,16 @@
 """Lightweight package initializer for conversation agents.
 
 Only small utility modules are imported eagerly so that tests can run in a
-minimal environment without optional third‑party dependencies.  Full agent
+minimal environment without optional third-party dependencies. Full agent
 implementations can be imported from their respective modules when required.
 """
 
 from __future__ import annotations
 
-try:  # pragma: no cover - optional import for test friendliness
-"""Lightweight namespace package for conversation agents.
-
-Only utility modules that have minimal dependencies are imported at package
-initialisation time to keep the test environment small.  Heavier agent
-implementations can be imported directly from their modules when required.
-"""
-
-try:  # pragma: no cover - optional import
-"""Lightweight namespace for conversation agents."""
-
 try:  # pragma: no cover - optional utility
     from .query_generator_agent import QueryOptimizer
 except Exception:  # pragma: no cover - fallback when dependency missing
-    QueryOptimizer = object  # type: ignore
-
-
-__all__ = ["QueryOptimizer"]
-"""Lightweight namespace package for conversation agents."""
+    QueryOptimizer = object  # type: ignore[misc, assignment]
 
 __all__ = [
     "QueryOptimizer",
@@ -34,3 +19,4 @@ __all__ = [
     "query_generator_agent",
     "response_generator_agent",
 ]
+

--- a/conversation_service/tests/test_agents/test_package_import.py
+++ b/conversation_service/tests/test_agents/test_package_import.py
@@ -1,0 +1,9 @@
+"""Ensure the :mod:`conversation_service.agents` package imports cleanly."""
+
+
+def test_agents_package_import() -> None:
+    """Import the package and access the exported utility."""
+    from conversation_service import agents
+
+    assert hasattr(agents, "QueryOptimizer")
+


### PR DESCRIPTION
## Summary
- clean up `conversation_service.agents` package initialization and handle optional imports
- add unit test validating package import

## Testing
- `pytest conversation_service/tests/test_agents/test_package_import.py -q`
- `pytest -q` *(fails: No module named 'autogen_agentchat', 'aiohttp', 'fastapi', 'pydantic_settings', 'sqlalchemy', and syntax errors in some agent modules)*


------
https://chatgpt.com/codex/tasks/task_e_68a7291d7cf08320b09b862aaa443d8a