### PR TITLE
Simplify agents package initialization

### DIFF
--- a/conversation_service/agents/__init__.py
+++ b/conversation_service/agents/__init__.py
@@ -1,35 +1,18 @@
-"""Lightweight namespace package for conversation agents.
+"""Conversation agents package."""
 
-Only utility modules with minimal dependencies are imported eagerly so that
-unit tests can run in constrained environments.  Full agent implementations
-should be imported from their respective modules when needed.
-"""Lightweight package initializer for conversation agents.
-
-Only small utility modules are imported eagerly so that tests can run in a
-minimal environment without optional third-party dependencies. Full agent
-implementations can be imported from their respective modules when required.
-"""
-
-from __future__ import annotations
-
-try:  # pragma: no cover - optional utility
-# Query optimizer is used across tests; import lazily to keep dependencies light.
-try:  # pragma: no cover - optional import
-    from .query_generator_agent import QueryOptimizer
-except Exception:  # pragma: no cover - dependency missing
-    QueryOptimizer = object  # type: ignore
-
-__all__ = ["QueryOptimizer"]
-try:  # pragma: no cover - optional utility
-    from .query_generator_agent import QueryOptimizer
-except Exception:  # pragma: no cover - fallback when dependency missing
-    QueryOptimizer = object  # type: ignore[misc, assignment]
+from .query_generator_agent import QueryOptimizer
 
 __all__ = [
     "QueryOptimizer",
-    "intent_classifier_agent",
+    "base_agent",
+    "context_manager",
+    "entity_extractor",
     "entity_extractor_agent",
+    "intent_classifier",
+    "intent_classifier_agent",
+    "query_generator",
     "query_generator_agent",
+    "response_generator",
     "response_generator_agent",
 ]
 


### PR DESCRIPTION
## Summary
- Replace `conversation_service.agents` initializer with a single docstring and straightforward import
- Expose agent submodules in `__all__` without duplicates

## Testing
- `python -m py_compile conversation_service/agents/__init__.py`
- `pytest conversation_service/tests/test_agents/test_package_import.py -q`
- `pytest conversation_service/tests/test_agents -q` *(fails: ModuleNotFoundError: No module named 'conversation_service.agents.agent_team')*

------
https://chatgpt.com/codex/tasks/task_e_68a72e1f73b88320b0c672d4cf24a89b