### PR TITLE
Adjust cache TTLs for intent and entity agents

### DIFF
--- a/conversation_service/agents/base_agent.py
+++ b/conversation_service/agents/base_agent.py
@@ -48,8 +48,8 @@ logger = get_structured_logger(__name__)
 
 # Default cache TTL (seconds) per agent
 AGENT_CACHE_TTLS = {
-    "intent_classifier": 600,
-    "entity_extractor": 900,
+    "intent_classifier": 300,
+    "entity_extractor": 180,
     "query_generator": 120,
     "response_generator": 60,
 }


### PR DESCRIPTION
## Summary
- shorten intent classifier cache TTL to 300 seconds
- reduce entity extractor cache TTL to 180 seconds

## Testing
- `pytest tests/test_agents/test_intent_classification_cache.py::test_intent_cache_store_and_retrieve -q` *(fails: SyntaxError in conversation_service/agents/__init__.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a72e2601b483208cafa885b1bda1c1