### PR TITLE
fix: remove cache lookup without user id

### DIFF
--- a/conversation_service/agents/base_agent.py
+++ b/conversation_service/agents/base_agent.py
@@ -385,10 +385,8 @@ class BaseFinancialAgent(ABC):
             user_id = str(input_data.get("user_id", "anonymous"))
             if self.cache_manager:
                 cache_key = self._generate_cache_key(input_data)
-                cached_result_data = await self.cache_manager.get(cache_key)
-
                 cached_result_data = await self.cache_manager.get(cache_key, user_id)
-                
+
                 if cached_result_data:
                     processing_time_ms = int((time.time() - start_time) * 1000)
                     cached_result = True


### PR DESCRIPTION
## Summary
- avoid redundant cache lookup in `BaseFinancialAgent.process`

## Testing
- `pytest` *(fails: No module named 'autogen_agentchat', No module named 'pydantic_settings', No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68a72e2bbe7c83209180e7ccc0a2f59c