### PR TITLE
feat: user-isolated cache with expiry handling

### DIFF
--- a/search_service/core/search_engine.py
+++ b/search_service/core/search_engine.py
@@ -74,7 +74,6 @@ class SearchEngine:
         """Génère une clé de cache basée sur les paramètres de la requête."""
         return generate_cache_key(
             "search",
-            user_id=request.user_id,
             query=request.query,
             filters=json.dumps(request.filters, sort_keys=True),
             offset=request.offset,
@@ -139,7 +138,7 @@ class SearchEngine:
             cache_key = None
             if self.cache_enabled:
                 cache_key = self._generate_cache_key(request)
-                cached = await self.cache.get(cache_key)
+                cached = await self.cache.get(request.user_id, cache_key)
                 if cached:
                     self.cache_hits += 1
                     cached["response_metadata"]["cache_hit"] = True
@@ -200,7 +199,7 @@ class SearchEngine:
 
             # Mise en cache du résultat
             if self.cache_enabled:
-                await self.cache.set(cache_key, response, ttl=settings.SEARCH_CACHE_TTL)
+                await self.cache.set(request.user_id, cache_key, response, ttl=settings.SEARCH_CACHE_TTL)
 
             logger.info(
                 f"Search completed: {returned_results}/{total_results} results in {execution_time}ms"

--- a/search_service/utils/cache.py
+++ b/search_service/utils/cache.py
@@ -8,30 +8,36 @@ class MultiLevelCache:
 
     This minimal implementation provides the asynchronous interface expected by
     ``SearchEngine`` without relying on ``conversation_service``.  It stores
-    values in a dictionary along with an optional expiration timestamp.
+    values in a dictionary along with an optional expiration timestamp and is
+    namespaced by ``user_id`` to ensure isolation between users.
     """
 
     def __init__(self) -> None:
         self._store: Dict[str, Tuple[Optional[float], Any]] = {}
 
-    async def get(self, key: str) -> Any:
-        """Retrieve a value from the cache.
+    def _format_key(self, user_id: int, key: str) -> str:
+        return f"{user_id}:{key}"
+
+    async def get(self, user_id: int, key: str) -> Any:
+        """Retrieve a value from the cache for ``user_id``.
 
         Returns ``None`` if the key is not present or has expired."""
-        item = self._store.get(key)
+        namespaced_key = self._format_key(user_id, key)
+        item = self._store.get(namespaced_key)
         if not item:
             return None
         expires_at, value = item
         if expires_at is not None and expires_at < time.time():
             # Entry expired; remove it and behave as a miss
-            self._store.pop(key, None)
+            self._store.pop(namespaced_key, None)
             return None
         return value
 
-    async def set(self, key: str, value: Any, ttl: Optional[int] = None) -> None:
-        """Store a value in the cache with an optional time-to-live (seconds)."""
+    async def set(self, user_id: int, key: str, value: Any, ttl: Optional[int] = None) -> None:
+        """Store a value for ``user_id`` with an optional TTL in seconds."""
+        namespaced_key = self._format_key(user_id, key)
         expires_at = time.time() + ttl if ttl is not None else None
-        self._store[key] = (expires_at, value)
+        self._store[namespaced_key] = (expires_at, value)
 
     async def clear(self) -> None:
         """Clear all items from the cache."""

--- a/tests/test_multi_level_cache.py
+++ b/tests/test_multi_level_cache.py
@@ -1,0 +1,22 @@
+import asyncio
+import pytest
+
+from search_service.utils.cache import MultiLevelCache
+
+
+@pytest.mark.asyncio
+async def test_multi_level_cache_isolated_by_user_id():
+    cache = MultiLevelCache()
+    await cache.set(1, "greeting", "hello")
+    assert await cache.get(1, "greeting") == "hello"
+    assert await cache.get(2, "greeting") is None
+
+
+@pytest.mark.asyncio
+async def test_multi_level_cache_expires_entries():
+    cache = MultiLevelCache()
+    await cache.set(1, "temp", "data", ttl=0.1)
+    assert await cache.get(1, "temp") == "data"
+    await asyncio.sleep(0.2)
+    assert await cache.get(1, "temp") is None
+


### PR DESCRIPTION
## Summary
- namespace multi-level cache by user id and track expiration
- pass user id through search engine cache interactions
- add unit tests for cache isolation and TTL expiry

## Testing
- `pytest`
- `pytest tests/test_cache_client_isolation.py tests/test_multi_level_cache.py`


------
https://chatgpt.com/codex/tasks/task_e_68a72e34c5e48320b5603e8fa79a9e9e