### PR TITLE
chore: tidy intent classifier agent module

### DIFF
--- a/conversation_service/agents/intent_classifier_agent.py
+++ b/conversation_service/agents/intent_classifier_agent.py
@@ -1,6 +1,4 @@
-"""Minimal utilities for intent classification agents used in tests."""
 """Utilities for intent classification agents used in tests."""
-
 from __future__ import annotations
 
 from typing import Dict, Optional


### PR DESCRIPTION
## Summary
- dedupe module docstring in intent classifier agent
- ensure from __future__ import annotations directly follows module docstring

## Testing
- `pytest tests/test_agents/test_intent_classification_cache.py tests/test_agents/test_agent_imports.py tests/test_integration/test_conversation_scenario.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a732c339dc83209d4cfe5d679b6c63