### PR TITLE
refactor: clean team orchestrator

### DIFF
--- a/teams/team_orchestrator.py
+++ b/teams/team_orchestrator.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Simple orchestrator that persists conversation messages to the database."""
+
+from __future__ import annotations
 
 import asyncio
 import logging
@@ -17,89 +17,12 @@ from conversation_service.core.metrics_collector import (
 )
 from conversation_service.message_repository import ConversationMessageRepository
 from conversation_service.repository import ConversationRepository
-from models.conversation_models import ConversationMessage as ConversationMessageModel
-
+from models.conversation_models import (
+    ConversationMessage as ConversationMessageModel,
+)
 
 logger = logging.getLogger(__name__)
 
-"""Agent team orchestration using lightweight agent protocol."""
-
-from __future__ import annotations
-
-from typing import Any, Mapping, Sequence, AsyncGenerator
-
-from agent_types import AssistantAgent, ChatMessage, Response, TaskResult
-
-
-class _EchoAgent:
-    """Fallback assistant that simply echoes incoming text."""
-
-    def __init__(self, name: str) -> None:
-        self.name = name
-
-    async def on_messages(
-        self, messages: Sequence[ChatMessage], cancellation_token: Any
-    ) -> Response:
-        content = messages[0].content if messages else ""
-        return Response(chat_message=ChatMessage(content=content, source=self.name))
-
-    async def on_reset(self, cancellation_token: Any) -> None:  # pragma: no cover - stateless
-        return None
-
-
-class TeamOrchestrator:
-    """Coordinate a team of assistant agents with shared context."""
-
-    def __init__(
-        self,
-        classifier: AssistantAgent | None = None,
-        extractor: AssistantAgent | None = None,
-        query_agent: AssistantAgent | None = None,
-        responder: AssistantAgent | None = None,
-    ) -> None:
-        self.classifier = classifier or _EchoAgent("classification")
-        self.extractor = extractor or _EchoAgent("extraction")
-        self.query_agent = query_agent or _EchoAgent("query")
-        self.responder = responder or _EchoAgent("response")
-        self.context: dict[str, Any] = {}
-
-    async def run(
-        self,
-        *,
-        task: str | ChatMessage | Sequence[ChatMessage] | None = None,
-        cancellation_token: Any | None = None,
-    ) -> TaskResult:
-        if isinstance(task, str):
-            message = ChatMessage(content=task, source="user")
-        elif isinstance(task, ChatMessage):
-            message = task
-        else:
-            raise ValueError("Task must be a string or ChatMessage")
-
-        outputs: list[ChatMessage] = [message]
-
-        # Intent classification
-        resp = await self.classifier.on_messages([message], cancellation_token)
-        self.context["classification"] = resp.chat_message.content
-        outputs.append(resp.chat_message)
-
-        # Entity extraction
-        msg = ChatMessage(content=resp.chat_message.content, source=self.classifier.name)
-        resp = await self.extractor.on_messages([msg], cancellation_token)
-        self.context["extraction"] = resp.chat_message.content
-        outputs.append(resp.chat_message)
-
-        # Query generation
-        msg = ChatMessage(content=resp.chat_message.content, source=self.extractor.name)
-        resp = await self.query_agent.on_messages([msg], cancellation_token)
-        self.context["query"] = resp.chat_message.content
-        outputs.append(resp.chat_message)
-
-        # Response generation
-        msg = ChatMessage(content=resp.chat_message.content, source=self.query_agent.name)
-        resp = await self.responder.on_messages([msg], cancellation_token)
-        self.context["response"] = resp.chat_message.content
-        outputs.append(resp.chat_message)
 
 class TeamOrchestrator:
     """Coordinate agent interactions and store message history."""
@@ -174,30 +97,3 @@ class TeamOrchestrator:
             else 0.0,
         }
 
-    def run_stream(
-        self,
-        *,
-        task: str | ChatMessage | Sequence[ChatMessage] | None = None,
-        cancellation_token: Any | None = None,
-    ) -> AsyncGenerator[ChatMessage | TaskResult, None]:
-        async def _gen() -> AsyncGenerator[ChatMessage | TaskResult, None]:
-            result = await self.run(task=task, cancellation_token=cancellation_token)
-            for msg in result.messages:
-                yield msg
-            yield result
-
-        return _gen()
-
-    async def reset(self) -> None:
-        self.context.clear()
-        token = None
-        await self.classifier.on_reset(token)
-        await self.extractor.on_reset(token)
-        await self.query_agent.on_reset(token)
-        await self.responder.on_reset(token)
-
-    async def save_state(self) -> Mapping[str, Any]:
-        return {"context": dict(self.context)}
-
-    async def load_state(self, state: Mapping[str, Any]) -> None:
-        self.context = dict(state.get("context", {}))


### PR DESCRIPTION
## Summary
- streamline TeamOrchestrator into a single implementation
- drop redundant module docstring and consolidate imports

## Testing
- `pytest` *(fails: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68a732cb05308320ae4d2ba2efb259d7