### PR TITLE
feat: add user-aware ttl cache for agents

### DIFF
--- a/conversation_service/agents/entity_extractor_agent.py
+++ b/conversation_service/agents/entity_extractor_agent.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional
+import time
+from typing import Dict, List, Optional, Tuple
 
 try:  # pragma: no cover - optional runtime dependency
     from .entity_extractor import EntityExtractorAgent  # type: ignore
@@ -16,24 +17,37 @@ class EntityExtractionCache:
     """Simple in-memory cache for extracted entities."""
 
     def __init__(self) -> None:
-        self._store: Dict[str, List[FinancialEntity]] = {}
+        self._store: Dict[str, Tuple[float, List[FinancialEntity]]] = {}
         self.hits: int = 0
 
     @staticmethod
-    def _make_key(message: str, intent: str) -> str:
-        return f"{message}:{intent}"
+    def _make_key(user_id: str, message: str, intent: str) -> str:
+        return f"{user_id}:{message}:{intent}"
 
-    def get(self, message: str, intent: str) -> Optional[Dict[str, object]]:
-        key = self._make_key(message, intent)
-        entities = self._store.get(key)
-        if entities is None:
+    def get(
+        self, user_id: str, message: str, intent: str, ttl: int = 180
+    ) -> Optional[Dict[str, object]]:
+        key = self._make_key(user_id, message, intent)
+        entry = self._store.get(key)
+        if entry is None:
+            return None
+        inserted_at, entities = entry
+        if time.time() - inserted_at > ttl:
+            self._store.pop(key, None)
             return None
         self.hits += 1
         return {"entities": entities, "cached": True}
 
-    def set(self, message: str, intent: str, entities: List[FinancialEntity]) -> None:
-        key = self._make_key(message, intent)
-        self._store[key] = entities
+    def set(
+        self,
+        user_id: str,
+        message: str,
+        intent: str,
+        entities: List[FinancialEntity],
+        ttl: int = 180,
+    ) -> None:
+        key = self._make_key(user_id, message, intent)
+        self._store[key] = (time.time(), entities)
 
     def clear(self) -> None:
         self._store.clear()

--- a/conversation_service/tests/test_agents/test_entity_extraction_cache.py
+++ b/conversation_service/tests/test_agents/test_entity_extraction_cache.py
@@ -1,6 +1,8 @@
 import sys
+import sys
 import types
 import pytest
+import time
 
 sys.modules.setdefault("autogen", types.SimpleNamespace(AssistantAgent=object))
 
@@ -18,12 +20,27 @@ def test_entity_cache_store_and_retrieve():
         entity_type=EntityType.MERCHANT,
         raw_value="Amazon",
         normalized_value="Amazon",
-        confidence=0.95
+        confidence=0.95,
     )
-    cache.set("Spent at Amazon", "MERCHANT_ANALYSIS", [entity])
+    cache.set("user1", "Spent at Amazon", "MERCHANT_ANALYSIS", [entity])
 
-    cached = cache.get("Spent at Amazon", "MERCHANT_ANALYSIS")
+    cached = cache.get("user1", "Spent at Amazon", "MERCHANT_ANALYSIS")
     assert cached is not None
     assert cached["cached"] is True
     assert len(cached["entities"]) == 1
     assert cache.hits == 1
+
+
+def test_entity_cache_ttl_expiry():
+    cache = EntityExtractionCache()
+    entity = FinancialEntity(
+        entity_type=EntityType.MERCHANT,
+        raw_value="Amazon",
+        normalized_value="Amazon",
+        confidence=0.95,
+    )
+    cache.set("user1", "Will this expire?", "MERCHANT_ANALYSIS", [entity], ttl=1)
+
+    time.sleep(1.1)
+    cached = cache.get("user1", "Will this expire?", "MERCHANT_ANALYSIS", ttl=1)
+    assert cached is None

--- a/conversation_service/tests/test_agents/test_intent_classification_cache.py
+++ b/conversation_service/tests/test_agents/test_intent_classification_cache.py
@@ -1,6 +1,8 @@
 import sys
+import sys
 import types
 import pytest
+import time
 
 sys.modules.setdefault("autogen", types.SimpleNamespace(AssistantAgent=object))
 
@@ -17,11 +19,25 @@ def test_intent_cache_store_and_retrieve():
     result = IntentResult(
         intent=IntentType.BALANCE_INQUIRY,
         confidence=0.9,
-        reasoning="Clear request for balance information"
+        reasoning="Clear request for balance information",
     )
-    cache.set("What's my balance?", result)
+    cache.set("user1", "What's my balance?", result)
 
-    cached = cache.get("What's my balance?")
+    cached = cache.get("user1", "What's my balance?")
     assert cached is not None
     assert cached.intent == IntentType.BALANCE_INQUIRY
     assert cache.hits == 1
+
+
+def test_intent_cache_ttl_expiry():
+    cache = IntentClassificationCache()
+    result = IntentResult(
+        intent=IntentType.BALANCE_INQUIRY,
+        confidence=0.9,
+        reasoning="Clear request for balance information",
+    )
+    cache.set("user1", "Will this expire?", result, ttl=1)
+
+    time.sleep(1.1)
+    cached = cache.get("user1", "Will this expire?", ttl=1)
+    assert cached is None

--- a/conversation_service/tests/test_integration/test_conversation_scenario.py
+++ b/conversation_service/tests/test_integration/test_conversation_scenario.py
@@ -42,8 +42,8 @@ def test_conversation_pipeline():
         confidence=0.92,
         reasoning="User asks about spending at a merchant"
     )
-    cache.set("How much did I spend at Amazon?", intent_result)
-    cached_intent = cache.get("How much did I spend at Amazon?")
+    cache.set("user1", "How much did I spend at Amazon?", intent_result)
+    cached_intent = cache.get("user1", "How much did I spend at Amazon?")
 
     entity = FinancialEntity(
         entity_type=EntityType.MERCHANT,

--- a/tests/test_agents/test_entity_extraction_cache.py
+++ b/tests/test_agents/test_entity_extraction_cache.py
@@ -1,5 +1,7 @@
 import sys
+import sys
 import types
+import time
 
 sys.modules.setdefault("autogen", types.SimpleNamespace(AssistantAgent=object))
 
@@ -15,10 +17,25 @@ def test_entity_cache_store_and_retrieve():
         normalized_value="Amazon",
         confidence=0.95
     )
-    cache.set("Spent at Amazon", "MERCHANT_ANALYSIS", [entity])
+    cache.set("user1", "Spent at Amazon", "MERCHANT_ANALYSIS", [entity])
 
-    cached = cache.get("Spent at Amazon", "MERCHANT_ANALYSIS")
+    cached = cache.get("user1", "Spent at Amazon", "MERCHANT_ANALYSIS")
     assert cached is not None
     assert cached["cached"] is True
     assert len(cached["entities"]) == 1
     assert cache.hits == 1
+
+
+def test_entity_cache_ttl_expiry():
+    cache = EntityExtractionCache()
+    entity = FinancialEntity(
+        entity_type=EntityType.MERCHANT,
+        raw_value="Amazon",
+        normalized_value="Amazon",
+        confidence=0.95,
+    )
+    cache.set("user1", "Will this expire?", "MERCHANT_ANALYSIS", [entity], ttl=1)
+
+    time.sleep(1.1)
+    cached = cache.get("user1", "Will this expire?", "MERCHANT_ANALYSIS", ttl=1)
+    assert cached is None

--- a/tests/test_agents/test_intent_classification_cache.py
+++ b/tests/test_agents/test_intent_classification_cache.py
@@ -1,5 +1,7 @@
 import sys
+import sys
 import types
+import time
 
 sys.modules.setdefault("autogen", types.SimpleNamespace(AssistantAgent=object))
 
@@ -12,11 +14,25 @@ def test_intent_cache_store_and_retrieve():
     result = IntentResult(
         intent=IntentType.BALANCE_INQUIRY,
         confidence=0.9,
-        reasoning="Clear request for balance information"
+        reasoning="Clear request for balance information",
     )
-    cache.set("What's my balance?", result)
+    cache.set("user1", "What's my balance?", result)
 
-    cached = cache.get("What's my balance?")
+    cached = cache.get("user1", "What's my balance?")
     assert cached is not None
     assert cached.intent == IntentType.BALANCE_INQUIRY
     assert cache.hits == 1
+
+
+def test_intent_cache_ttl_expiry():
+    cache = IntentClassificationCache()
+    result = IntentResult(
+        intent=IntentType.BALANCE_INQUIRY,
+        confidence=0.9,
+        reasoning="Clear request for balance information",
+    )
+    cache.set("user1", "Will this expire?", result, ttl=1)
+
+    time.sleep(1.1)
+    cached = cache.get("user1", "Will this expire?", ttl=1)
+    assert cached is None

--- a/tests/test_integration/test_conversation_scenario.py
+++ b/tests/test_integration/test_conversation_scenario.py
@@ -31,10 +31,10 @@ def test_conversation_pipeline():
     intent_result = IntentResult(
         intent=IntentType.MERCHANT_ANALYSIS,
         confidence=0.92,
-        reasoning="User asks about spending at a merchant"
+        reasoning="User asks about spending at a merchant",
     )
-    cache.set("How much did I spend at Amazon?", intent_result)
-    cached_intent = cache.get("How much did I spend at Amazon?")
+    cache.set("user1", "How much did I spend at Amazon?", intent_result)
+    cached_intent = cache.get("user1", "How much did I spend at Amazon?")
 
     entity = FinancialEntity(
         entity_type=EntityType.MERCHANT,


### PR DESCRIPTION
## Summary
- include user_id in intent and entity cache keys
- track insertion time with TTL validation for cache entries
- extend cache interfaces to accept user_id and ttl

## Testing
- `pytest tests/test_agents/test_intent_classification_cache.py tests/test_agents/test_entity_extraction_cache.py tests/test_integration/test_conversation_scenario.py conversation_service/tests/test_agents/test_intent_classification_cache.py conversation_service/tests/test_agents/test_entity_extraction_cache.py conversation_service/tests/test_integration/test_conversation_scenario.py`
- `pytest` *(fails: collection errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a735ad6270832095561da19b6c1f88