### PR TITLE
Ignore extra environment variables in config settings

### DIFF
--- a/config/autogen_config.py
+++ b/config/autogen_config.py
@@ -31,7 +31,7 @@ class AutoGenConfig(BaseSettings):
     max_consecutive_auto_reply: int = 1
     description: str = "Harena financial assistant"
 
-    model_config = SettingsConfigDict(env_prefix="AUTOGEN_", env_file=".env")
+    model_config = SettingsConfigDict(env_prefix="AUTOGEN_", env_file=".env", extra="ignore")
 
     def build_agent_params(
         self,

--- a/config/openai_config.py
+++ b/config/openai_config.py
@@ -16,7 +16,7 @@ class OpenAIConfig(BaseSettings):
     timeout: int = 30
 
     # Environment variables are prefixed with ``OPENAI_``
-    model_config = SettingsConfigDict(env_prefix="OPENAI_", env_file=".env")
+    model_config = SettingsConfigDict(env_prefix="OPENAI_", env_file=".env", extra="ignore")
 
 
 # ``get_openai_config`` in :mod:`config` should be used instead of creating

--- a/config/settings.py
+++ b/config/settings.py
@@ -16,7 +16,7 @@ class Settings(BaseSettings):
     BRIDGE_CLIENT_ID: str = ""
     BRIDGE_CLIENT_SECRET: str = ""
 
-    model_config = SettingsConfigDict(env_file=".env")
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
 
 # The ``get_settings`` accessor in :mod:`config` should be preferred over


### PR DESCRIPTION
## Summary
- ignore unexpected environment variables in app Settings
- ignore unexpected environment variables in OpenAI and AutoGen settings

## Testing
- `pytest tests/test_config_files.py`


------
https://chatgpt.com/codex/tasks/task_e_68a735af981c83208c0fbf8ee30a143e