### PR TITLE
feat: generate responses with OpenAI

### DIFF
--- a/conversation_service/agents/response_generator.py
+++ b/conversation_service/agents/response_generator.py
@@ -1,10 +1,11 @@
 """Response generation agent."""
 
 from typing import Any, Dict, Optional
+import asyncio
+import json
 
 from .base_agent import BaseFinancialAgent
 from ..models.agent_models import AgentConfig
-from ..prompts.response_prompts import load_prompt, get_examples
 from ..prompts import response_prompts
 
 
@@ -23,9 +24,59 @@ class ResponseGeneratorAgent(BaseFinancialAgent):
     async def _process_implementation(
         self, input_data: Dict[str, Any]
     ) -> Optional[Dict[str, Any]]:
-        """Return a placeholder response."""
+        """Generate a personalised response from search results.
+
+        The method leverages the OpenAI client to craft a natural language
+        summary of ``search_response`` while incorporating user profile
+        information for formatting and tailored insights.
+        """
+
         context = input_data.get("context", {})
-        return {"input": input_data, "context": context, "response": ""}
+        search_response = input_data.get("search_response", {})
+        user_profile = context.get("user_profile", {})
+
+        # Prepare a short JSON serialisation of the search results for the
+        # language model.  Only include the top few entries to keep the prompt
+        # compact.
+        results = search_response.get("results", [])
+        top_results = results[:3]
+        results_json = json.dumps(top_results, ensure_ascii=False)
+
+        prompt = (
+            "Tu es un assistant financier. Résume les résultats suivants en "
+            "fournissant des conseils adaptés au profil utilisateur.\n\n"
+            f"Profil utilisateur: {json.dumps(user_profile, ensure_ascii=False)}\n"
+            f"Résultats de recherche: {results_json}"
+        )
+
+        last_error: Optional[Exception] = None
+        for attempt in range(3):
+            try:
+                response = await asyncio.wait_for(
+                    self._call_openai(prompt, few_shot_examples=self.examples),
+                    timeout=self.config.timeout_seconds,
+                )
+                message = response["content"].strip()
+                break
+            except Exception as exc:  # pragma: no cover - network/timeout
+                last_error = exc
+                if attempt >= 2:
+                    raise
+                await asyncio.sleep(2 ** attempt)
+
+        if last_error:
+            raise last_error
+
+        user_name = user_profile.get("name", "client")
+        formatted = f"### Résumé personnalisé pour {user_name}\n\n{message}"
+        insights = {"result_count": len(results)}
+
+        return {
+            "input": input_data,
+            "context": context,
+            "response": formatted,
+            "insights": insights,
+        }
 """Lightweight response generation utilities.
 
 This module provides a minimal asynchronous generator used by the websocket


### PR DESCRIPTION
## Summary
- use OpenAI to craft responses from search results
- personalize formatting with user profile insights

## Testing
- `pytest` *(fails: ModuleNotFoundError for sqlalchemy, pydantic_settings, fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68a73b098a948320aec0eae36c83cb34