### PR TITLE
Make OpenAI optional for agents

### DIFF
--- a/conversation_service/agents/query_generator.py
+++ b/conversation_service/agents/query_generator.py
@@ -14,7 +14,11 @@ from search_service.models import SearchRequest
 class QueryGeneratorAgent(BaseFinancialAgent):
     """Generate search queries based on extracted data."""
 
-    def __init__(self, openai_client, search_client: SearchClient):
+    def __init__(
+        self,
+        search_client: SearchClient,
+        openai_client: Optional[Any] = None,
+    ):
         config = AgentConfig(
             name="query_generator",
             system_message=query_prompts.get_prompt(),

--- a/tests/test_agents/test_query_optimizer.py
+++ b/tests/test_agents/test_query_optimizer.py
@@ -1,6 +1,7 @@
 import sys
 import types
 from enum import Enum
+import asyncio
 import pytest
 
 
@@ -102,18 +103,16 @@ class _DummySearchClient:
         self.payload = payload
         return {}
 
-
-@pytest.mark.asyncio
-async def test_query_generator_injects_user_id_into_filters():
+def test_query_generator_injects_user_id_into_filters():
     search_client = _DummySearchClient()
-    agent = QueryGeneratorAgent(openai_client=object(), search_client=search_client)
+    agent = QueryGeneratorAgent(search_client=search_client)
     input_data = {
         "intent": "any_intent",
         "entities": {"foo": "bar"},
         "context": {"user_id": 99, "filters": {}},
     }
 
-    result = await agent._process_implementation(input_data)
+    result = asyncio.run(agent._process_implementation(input_data))
 
     assert result["search_request"]["filters"]["user_id"] == 99
 


### PR DESCRIPTION
## Summary
- Allow BaseFinancialAgent and QueryGeneratorAgent to work without an OpenAI client
- Skip AssistantAgent creation when OpenAI is unavailable
- Update query generator tests to run without async plugin or OpenAI dependency

## Testing
- `pytest tests/test_agents/test_query_optimizer.py::test_query_generator_injects_user_id_into_filters -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'prometheus_client'; pydantic core validation error for REDIS_URL; AttributeError: module 'httpx' has no attribute 'Response')*


------
https://chatgpt.com/codex/tasks/task_e_68a73b0d0720832087b4f6e849328049