### PR TITLE
Refactor logging to use extra parameter

### DIFF
--- a/clients/cache_client.py
+++ b/clients/cache_client.py
@@ -32,7 +32,10 @@ class CacheClient:
         if expires_at is not None and expires_at < time.time():
             # Expired entry
             self._store.pop(namespaced_key, None)
-            logger.debug("Cache miss due to expiration", key=namespaced_key)
+            logger.debug(
+                "Cache miss due to expiration",
+                extra={"key": namespaced_key},
+            )
             return None
         return value
 
@@ -41,7 +44,10 @@ class CacheClient:
         namespaced_key = self._format_key(user_id, key)
         expires_at = time.time() + ttl if ttl is not None else None
         self._store[namespaced_key] = (expires_at, value)
-        logger.debug("Cache set", key=namespaced_key, ttl=ttl)
+        logger.debug(
+            "Cache set",
+            extra={"key": namespaced_key, "ttl": ttl},
+        )
 
     async def clear(self) -> None:
         """Remove all items from the cache."""

--- a/conversation_service/agents/base_agent.py
+++ b/conversation_service/agents/base_agent.py
@@ -222,17 +222,21 @@ class AgentPerformanceTracker:
         if processing_time_ms > self.thresholds["max_processing_time_ms"]:
             logger.warning(
                 "Agent performance alert: high processing time",
-                agent_name=self.agent_name,
-                processing_time_ms=processing_time_ms,
-                threshold=self.thresholds["max_processing_time_ms"]
+                extra={
+                    "agent_name": self.agent_name,
+                    "processing_time_ms": processing_time_ms,
+                    "threshold": self.thresholds["max_processing_time_ms"],
+                },
             )
         
         if cost_usd > self.thresholds["max_cost_per_call"]:
             logger.warning(
                 "Agent cost alert: high cost per call",
-                agent_name=self.agent_name,
-                cost_usd=cost_usd,
-                threshold=self.thresholds["max_cost_per_call"]
+                extra={
+                    "agent_name": self.agent_name,
+                    "cost_usd": cost_usd,
+                    "threshold": self.thresholds["max_cost_per_call"],
+                },
             )
 
 # ================================
@@ -363,10 +367,12 @@ class BaseFinancialAgent(ABC):
         
         logger.info(
             "Base Financial Agent initialized",
-            agent_name=config.name,
-            model=config.model_name,
-            temperature=config.temperature,
-            max_tokens=config.max_tokens
+            extra={
+                "agent_name": config.name,
+                "model": config.model_name,
+                "temperature": config.temperature,
+                "max_tokens": config.max_tokens,
+            },
         )
     
     async def process(self, input_data: Dict[str, Any]) -> AgentResponse:
@@ -409,9 +415,11 @@ class BaseFinancialAgent(ABC):
                     
                     logger.debug(
                         "Cache hit for agent",
-                        agent_name=self.config.name,
-                        cache_key=cache_key[:16] + "...",
-                        processing_time_ms=processing_time_ms
+                        extra={
+                            "agent_name": self.config.name,
+                            "cache_key": cache_key[:16] + "...",
+                            "processing_time_ms": processing_time_ms,
+                        },
                     )
 
                     if self.metrics_collector:
@@ -469,10 +477,12 @@ class BaseFinancialAgent(ABC):
             
             logger.debug(
                 "Agent processing successful",
-                agent_name=self.config.name,
-                processing_time_ms=processing_time_ms,
-                tokens_used=tokens_used,
-                confidence=confidence
+                extra={
+                    "agent_name": self.config.name,
+                    "processing_time_ms": processing_time_ms,
+                    "tokens_used": tokens_used,
+                    "confidence": confidence,
+                },
             )
             
             return AgentResponse(
@@ -512,11 +522,13 @@ class BaseFinancialAgent(ABC):
             
             logger.error(
                 "Agent processing failed",
-                agent_name=self.config.name,
-                error=error_message,
-                processing_time_ms=processing_time_ms,
-                circuit_breaker_failures=self.circuit_breaker_failures,
-                exc_info=True
+                extra={
+                    "agent_name": self.config.name,
+                    "error": error_message,
+                    "processing_time_ms": processing_time_ms,
+                    "circuit_breaker_failures": self.circuit_breaker_failures,
+                },
+                exc_info=True,
             )
             
             return AgentResponse(
@@ -599,10 +611,12 @@ class BaseFinancialAgent(ABC):
         except Exception as e:
             logger.error(
                 "OpenAI API call failed",
-                agent_name=self.config.name,
-                model=self.config.model_name,
-                error=str(e),
-                exc_info=True
+                extra={
+                    "agent_name": self.config.name,
+                    "model": self.config.model_name,
+                    "error": str(e),
+                },
+                exc_info=True,
             )
             raise
     

--- a/conversation_service/clients/openai_client.py
+++ b/conversation_service/clients/openai_client.py
@@ -78,7 +78,8 @@ class OpenAIClient:
                 self.total_cost_usd += cost
 
                 logger.debug(
-                    "OpenAI call succeeded", model=model, tokens=tokens, cost=cost
+                    "OpenAI call succeeded",
+                    extra={"model": model, "tokens": tokens, "cost": cost},
                 )
                 return response
             except Exception as exc:  # pragma: no cover - network errors

--- a/openai_client.py
+++ b/openai_client.py
@@ -78,7 +78,8 @@ class OpenAIClient:
                 self.total_cost_usd += cost
 
                 logger.debug(
-                    "OpenAI call succeeded", model=model, tokens=tokens, cost=cost
+                    "OpenAI call succeeded",
+                    extra={"model": model, "tokens": tokens, "cost": cost},
                 )
                 return response
             except Exception as exc:  # pragma: no cover - network errors


### PR DESCRIPTION
## Summary
- standardize BaseFinancialAgent logging to pass context via `extra`
- propagate same logging style in in-memory cache client and OpenAI clients

## Testing
- `pytest -q` *(fails: TypeError in test_query_optimizer)*

------
https://chatgpt.com/codex/tasks/task_e_68a73f7272b4832097ffef40b73ccbdd