### PR TITLE
test: add DummyLogger for get_structured_logger patches

### DIFF
--- a/tests/test_agents/test_query_optimizer.py
+++ b/tests/test_agents/test_query_optimizer.py
@@ -10,17 +10,11 @@ class _DummyAssistantAgent:
         pass
 
 
-class _DummyLogger:
+class DummyLogger:
     def info(self, *args, **kwargs):
         pass
 
-    def debug(self, *args, **kwargs):
-        pass
-
-    def warning(self, *args, **kwargs):
-        pass
-
-    def error(self, *args, **kwargs):
+    def exception(self, *args, **kwargs):
         pass
 
 
@@ -31,7 +25,7 @@ sys.modules.setdefault("conversation_service.core.cache_manager", types.SimpleNa
 sys.modules.setdefault("conversation_service.core.metrics_collector", types.SimpleNamespace(MetricsCollector=object))
 sys.modules.setdefault(
     "conversation_service.utils.logging",
-    types.SimpleNamespace(get_structured_logger=lambda name: _DummyLogger()),
+    types.SimpleNamespace(get_structured_logger=lambda name: DummyLogger()),
 )
 
 _clients_pkg = types.ModuleType("conversation_service.clients")

--- a/tests/test_integration/test_conversation_scenario.py
+++ b/tests/test_integration/test_conversation_scenario.py
@@ -7,7 +7,20 @@ sys.modules.setdefault("conversation_service.models.agent_models", types.SimpleN
 sys.modules.setdefault("conversation_service.base_agent", types.SimpleNamespace(BaseFinancialAgent=object))
 sys.modules.setdefault("conversation_service.core.cache_manager", types.SimpleNamespace(CacheManager=object))
 sys.modules.setdefault("conversation_service.core.metrics_collector", types.SimpleNamespace(MetricsCollector=object))
-sys.modules.setdefault("conversation_service.utils.logging", types.SimpleNamespace(get_structured_logger=lambda name: None))
+
+
+class DummyLogger:
+    def info(self, *args, **kwargs):
+        pass
+
+    def exception(self, *args, **kwargs):
+        pass
+
+
+sys.modules.setdefault(
+    "conversation_service.utils.logging",
+    types.SimpleNamespace(get_structured_logger=lambda name: DummyLogger()),
+)
 
 import conversation_service.models.core_models as core_models
 


### PR DESCRIPTION
## Summary
- add DummyLogger with info and exception helpers
- use DummyLogger when patching get_structured_logger in tests

## Testing
- `pytest tests/test_agents/test_query_optimizer.py tests/test_integration/test_conversation_scenario.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a73f746eb88320a0bb0831e8bb8c63