### PR TITLE
refactor: simplify cache get signature

### DIFF
--- a/conversation_service/agents/base_agent.py
+++ b/conversation_service/agents/base_agent.py
@@ -394,7 +394,11 @@ class BaseFinancialAgent(ABC):
             user_id = str(input_data.get("user_id", "anonymous"))
             if self.cache_manager:
                 cache_key = self._generate_cache_key(input_data)
-                cached_result_data = await self.cache_manager.get(cache_key, user_id)
+                cached_result_data = await self.cache_manager.get(
+                    self.config.name,
+                    user_id,
+                    cache_key,
+                )
 
                 if cached_result_data:
                     processing_time_ms = int((time.time() - start_time) * 1000)


### PR DESCRIPTION
## Summary
- update BaseFinancialAgent cache retrieval to use new get signature with agent name, user id, and cache key

## Testing
- `REDIS_URL=redis://localhost:6379/0 pytest` *(fails: TypeError: 'NoneType' object is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_68a73f7bf1408320af295bdfb66de072