### PR TITLE
Ensure user ID is always included in search filters

### DIFF
--- a/conversation_service/agents/query_generator.py
+++ b/conversation_service/agents/query_generator.py
@@ -38,8 +38,8 @@ class QueryGeneratorAgent(BaseFinancialAgent):
         context = input_data.get("context", {})
         user_id = context.get("user_id")
         filters = dict(context.get("filters", {}))
-        if user_id is not None:
-            filters.setdefault("user_id", user_id)
+        filters["user_id"] = user_id
+
         payload = {
             "user_id": user_id,
             "query": context.get("query", ""),
@@ -48,18 +48,18 @@ class QueryGeneratorAgent(BaseFinancialAgent):
         }
 
         try:
-            request_model = SearchRequest(**payload)
+            search_request = SearchRequest(**payload)
         except ValidationError:
             # If validation fails we do not query the search service
             return None
 
         response = await self.search_client.search(
-            request_model.user_id, request_model.model_dump()
+            search_request.user_id, search_request.model_dump()
         )
 
         return {
             "input": input_data,
             "context": context,
-            "search_request": request_model.model_dump(),
+            "search_request": search_request.model_dump(),
             "search_response": response,
         }

--- a/tests/test_agents/test_query_optimizer.py
+++ b/tests/test_agents/test_query_optimizer.py
@@ -109,10 +109,14 @@ def test_query_generator_injects_user_id_into_filters():
     input_data = {
         "intent": "any_intent",
         "entities": {"foo": "bar"},
-        "context": {"user_id": 99, "filters": {}},
+        "context": {
+            "user_id": 99,
+            "filters": {"user_id": 1, "other": "value"},
+        },
     }
 
     result = asyncio.run(agent._process_implementation(input_data))
 
     assert result["search_request"]["filters"]["user_id"] == 99
+    assert result["search_request"]["filters"]["other"] == "value"
 


### PR DESCRIPTION
## Summary
- Always insert the context `user_id` into search filters and build the `SearchRequest` once
- Extend query generator test to confirm user ID override in filters

## Testing
- `pytest tests/test_agents/test_query_optimizer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a73f8187388320b9d90ca424479075