### PR TITLE
Persist conversation history across sessions

### DIFF
--- a/models/conversation_models.py
+++ b/models/conversation_models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Pydantic models for conversation API."""
 
 from datetime import datetime
-from typing import List, Literal, Optional
+from typing import List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -44,10 +44,13 @@ class AgentQueryResponse(BaseModel):
 
 
 class ConversationMessage(BaseModel):
-    """Single message in the conversation history."""
+    """Single message persisted in the conversation history."""
 
-    role: Literal["user", "assistant"]
+    user_id: int
+    conversation_id: str
+    role: str
     content: str
+    timestamp: datetime
 
 
 class ConversationHistoryResponse(BaseModel):

--- a/teams/team_orchestrator.py
+++ b/teams/team_orchestrator.py
@@ -119,13 +119,13 @@ class TeamOrchestrator:
         self, conversation_id: str, message: str, user_id: int, db: Session
     ) -> str:
         start = time.time()
-        repo = ConversationMessageRepository(db)
-        history_models = repo.list_models(conversation_id)
+        history_models = self.get_history(conversation_id, db) or []
         context: Dict[str, Any] = {
             "user_message": message,
             "user_id": user_id,
             "history": [m.model_dump() for m in history_models],
         }
+        repo = ConversationMessageRepository(db)
         repo.add(
             conversation_id=conversation_id,
             user_id=user_id,


### PR DESCRIPTION
## Summary
- Add ConversationMessage pydantic model with user, conversation and timestamp metadata
- Persist and expose timestamped user/assistant messages through repository
- Load prior conversation history at session start and store user and agent exchanges

## Testing
- `pytest` *(fails: 6 errors during collection)*
- `pytest conversation_service/tests/test_teams/test_financial_entity.py`


------
https://chatgpt.com/codex/tasks/task_e_68a73f85bb8c8320abfd73199492c05c