### PR TITLE
feat: add cached response generation agent

### DIFF
--- a/conversation_service/agents/response_generator_agent.py
+++ b/conversation_service/agents/response_generator_agent.py
@@ -1,20 +1,92 @@
-"""Wrapper module for response generation utilities.
+"""Lightweight response generator agent with in-memory caching.
 
-This simply re-exports :class:`ResponseGeneratorAgent` and ``stream_response``
-from the ``response_generator`` module so tests can import a consistent public
-API without pulling in heavier dependencies.
+This module provides a minimal :class:`ResponseGeneratorAgent` used in tests.
+It analyses provided search results and context, generates a text response via a
+configured LLM client (``self.agent``) and caches results for 60 seconds to
+avoid repeated work.
 """
 
-# The response generator depends on optional libraries; import lazily to avoid
-# failing when those dependencies are absent.  A minimal ``stream_response``
-# fallback is provided to keep the public API stable for tests.
-try:  # pragma: no cover - defensive import
-    from .response_generator import ResponseGeneratorAgent, stream_response  # type: ignore
-except Exception:  # pragma: no cover - dependency not available
-    ResponseGeneratorAgent = None  # type: ignore
+from __future__ import annotations
 
-    async def stream_response(message: str):  # type: ignore[override]
-        """Fallback async generator returning the message directly."""
-        yield f"Response: {message}"
+import hashlib
+import json
+import time
+from typing import Any, AsyncGenerator, Dict, List, Tuple
+
+
+class ResponseGeneratorAgent:
+    """Generate natural language responses from search results.
+
+    Parameters
+    ----------
+    agent:
+        LLM client exposing an ``async generate(prompt: str) -> str`` method.
+    ttl:
+        Cache time-to-live in seconds. Defaults to ``60``.
+    """
+
+    def __init__(self, agent: Any, ttl: int = 60) -> None:
+        self.agent = agent
+        self.ttl = ttl
+        self._cache: Dict[str, Tuple[float, str]] = {}
+
+    @staticmethod
+    def _make_cache_key(
+        user_id: str, search_results: List[Dict[str, Any]], context: Dict[str, Any]
+    ) -> str:
+        """Create a stable cache key for the inputs."""
+
+        payload = json.dumps(
+            {"user": user_id, "results": search_results, "context": context},
+            sort_keys=True,
+            ensure_ascii=False,
+        )
+        return hashlib.sha256(payload.encode()).hexdigest()
+
+    async def generate(
+        self, user_id: str, search_results: List[Dict[str, Any]], context: Dict[str, Any]
+    ) -> str:
+        """Return a response for ``search_results`` within ``context``.
+
+        The method analyses the top search result alongside basic context
+        information and delegates response creation to ``self.agent``. Results
+        are cached for ``ttl`` seconds.
+        """
+
+        key = self._make_cache_key(user_id, search_results, context)
+        now = time.time()
+        cached = self._cache.get(key)
+        if cached and now - cached[0] < self.ttl:
+            return cached[1]
+
+        # --- Analyse search results and context to build a prompt ------------
+        result_count = len(search_results)
+        top_result = search_results[0] if search_results else {}
+        snippet = (
+            top_result.get("summary")
+            or top_result.get("snippet")
+            or top_result.get("title")
+            or json.dumps(top_result, ensure_ascii=False)
+        )
+        user_name = context.get("user_profile", {}).get("name", "client")
+        prompt = (
+            f"Utilisateur: {user_name}. Résultats: {result_count}. "
+            f"Principal: {snippet}. Fournis une réponse appropriée."
+        )
+
+        # --- LLM generation -------------------------------------------------
+        response = await self.agent.generate(prompt)
+
+        # --- Cache storage --------------------------------------------------
+        self._cache[key] = (now, response)
+        return response
+
+
+async def stream_response(message: str) -> AsyncGenerator[str, None]:
+    """Fallback async generator returning the message directly."""
+
+    yield f"Response: {message}"
+
 
 __all__ = ["ResponseGeneratorAgent", "stream_response"]
+

--- a/conversation_service/tests/test_agents/test_response_generator_agent.py
+++ b/conversation_service/tests/test_agents/test_response_generator_agent.py
@@ -1,8 +1,55 @@
+import asyncio
 import pytest
 
-agent_module = pytest.importorskip("conversation_service.agents.response_generator")
+agent_module = pytest.importorskip("conversation_service.agents.response_generator_agent")
+ResponseGeneratorAgent = agent_module.ResponseGeneratorAgent
 
 
-@pytest.mark.skip(reason="Response generator agent dependencies incomplete")
-def test_placeholder():
-    assert agent_module is not None
+class DummyLLM:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def generate(self, prompt: str) -> str:  # pragma: no cover - trivial
+        self.calls.append(prompt)
+        return f"LLM:{len(self.calls)}"
+
+
+def test_generation_and_cache():
+    async def run_test():
+        llm = DummyLLM()
+        agent = ResponseGeneratorAgent(llm)
+
+        search_results = [{"summary": "Balance is 100€"}]
+        context = {"user_profile": {"name": "Alice"}}
+
+        first = await agent.generate("user1", search_results, context)
+        assert first.startswith("LLM:")
+        assert len(llm.calls) == 1
+        assert "Balance is 100€" in llm.calls[0]
+        assert "Alice" in llm.calls[0]
+
+        second = await agent.generate("user1", search_results, context)
+        assert second == first
+        assert len(llm.calls) == 1
+
+    asyncio.run(run_test())
+
+
+def test_cache_expiry():
+    async def run_test():
+        llm = DummyLLM()
+        agent = ResponseGeneratorAgent(llm, ttl=1)
+
+        search_results = [{"summary": "Balance is 100€"}]
+        context = {}
+
+        await agent.generate("user1", search_results, context)
+        await agent.generate("user1", search_results, context)
+        assert len(llm.calls) == 1
+
+        await asyncio.sleep(1.1)
+        await agent.generate("user1", search_results, context)
+        assert len(llm.calls) == 2
+
+    asyncio.run(run_test())
+

--- a/tests/test_agents/test_response_generator_agent.py
+++ b/tests/test_agents/test_response_generator_agent.py
@@ -1,8 +1,56 @@
+import asyncio
+
 import pytest
 
 agent_module = pytest.importorskip("conversation_service.agents.response_generator_agent")
+ResponseGeneratorAgent = agent_module.ResponseGeneratorAgent
 
 
-@pytest.mark.skip(reason="Response generator agent dependencies incomplete")
-def test_placeholder():
-    assert agent_module is not None
+class DummyLLM:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def generate(self, prompt: str) -> str:  # pragma: no cover - trivial
+        self.calls.append(prompt)
+        return f"LLM:{len(self.calls)}"
+
+
+def test_generation_and_cache():
+    async def run_test():
+        llm = DummyLLM()
+        agent = ResponseGeneratorAgent(llm)
+
+        search_results = [{"summary": "Balance is 100€"}]
+        context = {"user_profile": {"name": "Alice"}}
+
+        first = await agent.generate("user1", search_results, context)
+        assert first.startswith("LLM:")
+        assert len(llm.calls) == 1
+        assert "Balance is 100€" in llm.calls[0]
+        assert "Alice" in llm.calls[0]
+
+        second = await agent.generate("user1", search_results, context)
+        assert second == first
+        assert len(llm.calls) == 1  # cached
+
+    asyncio.run(run_test())
+
+
+def test_cache_expiry():
+    async def run_test():
+        llm = DummyLLM()
+        agent = ResponseGeneratorAgent(llm, ttl=1)
+
+        search_results = [{"summary": "Balance is 100€"}]
+        context = {}
+
+        await agent.generate("user1", search_results, context)
+        await agent.generate("user1", search_results, context)
+        assert len(llm.calls) == 1  # cached
+
+        await asyncio.sleep(1.1)
+        await agent.generate("user1", search_results, context)
+        assert len(llm.calls) == 2  # cache expired
+
+    asyncio.run(run_test())
+


### PR DESCRIPTION
## Summary
- add lightweight ResponseGeneratorAgent that analyses search results and context, uses an LLM client, and caches responses for 60 seconds
- test response generation, cache reuse, and expiry

## Testing
- `pytest tests/test_agents/test_response_generator_agent.py conversation_service/tests/test_agents/test_response_generator_agent.py -q`
- `pytest tests/test_agents/test_agent_imports.py::test_agent_modules_expose_symbols -q`


------
https://chatgpt.com/codex/tasks/task_e_68a73f8a02308320895d159b191a2617