### PR TITLE
Add SQLAlchemy Session import to team orchestrator

### DIFF
--- a/teams/team_orchestrator.py
+++ b/teams/team_orchestrator.py
@@ -2,6 +2,8 @@
 
 from typing import Any, Dict, List
 
+from sqlalchemy.orm import Session
+
 from agent_types import ChatMessage, TaskResult
 
 


### PR DESCRIPTION
## Summary
- import `Session` from SQLAlchemy so `query_agents` type hints resolve

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a74fcc04b48320bcbf76935b6a9926