### PR TITLE
docs: add web dependency installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Leur implémentation est désormais centralisée sous le package
 
 ## Tests unitaires
 
+Avant d'exécuter les tests, installez les dépendances Web de base :
+
+```bash
+pip install aiohttp fastapi sqlalchemy pydantic-settings
+```
+
 Les tests nécessitent l'extra `ag2[openai]`. Installez les dépendances puis
 cet extra :
 


### PR DESCRIPTION
## Summary
- document how to install aiohttp, fastapi, SQLAlchemy and pydantic-settings before running tests

## Testing
- `pip install aiohttp fastapi sqlalchemy pydantic-settings`
- `pytest` *(fails: 5 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a756be1b68832094ccbca8dacb413f