### PR TITLE
Parallelize classifier and extractor in TeamOrchestrator

### DIFF
--- a/teams/team_orchestrator.py
+++ b/teams/team_orchestrator.py
@@ -1,61 +1,76 @@
-"""Simple orchestrator that chains classification, extraction, querying and response."""
+"""Simple orchestrator chaining intent classification, entity extraction,
+query generation and response production.
+
+The first two stages (intent classification and entity extraction) are
+independent and therefore executed concurrently using ``asyncio.gather``.
+The results are then fed sequentially into the query and response
+generators.
+"""
 
 from __future__ import annotations
 
+import asyncio
 import json
-
 import logging
 import time
 import uuid
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy.orm import Session
-from agent_types import ChatMessage, TaskResult
-
-from sqlalchemy.orm import Session
 
 from agent_types import ChatMessage, TaskResult
-from conversation_service.agents.entity_extractor_agent import EntityExtractorAgent
-from conversation_service.agents.intent_classifier_agent import IntentClassifierAgent
-from conversation_service.agents.query_generator_agent import QueryGeneratorAgent
-from conversation_service.agents.response_generator_agent import ResponseGeneratorAgent
+from conversation_service.agents.entity_extractor_agent import (
+    EntityExtractorAgent,
+)
+from conversation_service.agents.intent_classifier_agent import (
+    IntentClassifierAgent,
+)
+from conversation_service.agents.query_generator_agent import (
+    QueryGeneratorAgent,
+)
+from conversation_service.agents.response_generator_agent import (
+    ResponseGeneratorAgent,
+)
 from conversation_service.core.metrics_collector import metrics_collector
 from conversation_service.message_repository import ConversationMessageRepository
 from conversation_service.repository import ConversationRepository
+
 
 logger = logging.getLogger(__name__)
 
 
 class TeamOrchestrator:
-    """Run a pipeline of assistant agents sequentially."""
+    """Run a pipeline of assistant agents.
+
+    Intent classification and entity extraction are launched concurrently
+    to reduce overall latency.  The shared ``ctx`` dictionary is updated by
+    each agent with its result.
+    """
 
     def __init__(
         self,
-        classifier: Optional[Any] = None,
-        extractor: Optional[Any] = None,
-        query_agent: Optional[Any] = None,
-        responder: Optional[Any] = None,
         classifier: Optional[IntentClassifierAgent] = None,
         extractor: Optional[EntityExtractorAgent] = None,
         query_agent: Optional[QueryGeneratorAgent] = None,
         responder: Optional[ResponseGeneratorAgent] = None,
     ) -> None:
-        """Initialise the orchestrator with optional agent instances."""
-
         self._classifier = classifier
         self._extractor = extractor
         self._query_agent = query_agent
         self._responder = responder
+
         self.context: Dict[str, Any] = {}
         self._metrics = metrics_collector
         self._total_calls = 0
         self._error_calls = 0
-        self._total_calls = 0
-        self._error_calls = 0
-        self._metrics = metrics_collector
 
     async def run(self, task: str) -> TaskResult:
-        """Execute the pipeline and return the resulting messages."""
+        """Execute the pipeline and return resulting messages.
+
+        This helper is used only in tests and mirrors the behaviour of the
+        main ``query_agents`` method but without persistence.
+        """
+
         messages: List[ChatMessage] = [ChatMessage(content=task, source="user")]
         self.context = {}
         for agent in [
@@ -73,10 +88,26 @@ class TeamOrchestrator:
             self.context[name] = msg.content
         return TaskResult(messages=messages)
 
+    def start_conversation(self, user_id: int, db: Session) -> str:
+        """Create a new conversation for ``user_id`` and return its ID."""
+
+        conversation_id = str(uuid.uuid4())
+        ConversationRepository(db).create(user_id, conversation_id)
+        return conversation_id
+
+    def get_history(
+        self, conversation_id: str, db: Session
+    ) -> Optional[List["ConversationMessage"]]:
+        """Return the persisted history for ``conversation_id`` if it exists."""
+
+        repo = ConversationRepository(db)
+        if repo.get_by_conversation_id(conversation_id) is None:
+            return None
+        return ConversationMessageRepository(db).list_models(conversation_id)
+
     async def query_agents(
         self, conversation_id: str, message: str, user_id: int, db: Session
     ) -> str:
-        """Run classification → extraction → query → response for a message."""
         """Run the agent pipeline for a user message and return the reply."""
 
         start = time.time()
@@ -85,6 +116,7 @@ class TeamOrchestrator:
             "user_id": user_id,
             "history": [m.model_dump() for m in history_models],
         }
+
         repo = ConversationMessageRepository(db)
         repo.add(
             conversation_id=conversation_id,
@@ -92,35 +124,41 @@ class TeamOrchestrator:
             role="user",
             content=message,
         )
-        self._total_calls += 1
-        try:
-            # 1. Intent classification
-            ctx = await self._call_agent(
-                self._classifier,
-                {"user_message": message},
-                ctx,
-                repo,
-                conversation_id,
-                user_id,
-            )
 
-            # 2. Entity extraction
-            ctx = await self._call_agent(
-                self._extractor,
-                {"user_message": message, "intent": ctx.get("intent")},
-                ctx,
-                repo,
-                conversation_id,
-                user_id,
-            )
+        self._total_calls += 1
+        success = True
+        try:
+            # 1 & 2. Classification and extraction in parallel
+            tasks = []
+            if self._classifier is not None:
+                tasks.append(
+                    self._call_agent(
+                        self._classifier,
+                        {"user_message": message},
+                        ctx,
+                        repo,
+                        conversation_id,
+                        user_id,
+                    )
+                )
+            if self._extractor is not None:
+                tasks.append(
+                    self._call_agent(
+                        self._extractor,
+                        {"user_message": message},
+                        ctx,
+                        repo,
+                        conversation_id,
+                        user_id,
+                    )
+                )
+            if tasks:
+                await asyncio.gather(*tasks)
 
             # 3. Query generation
             ctx = await self._call_agent(
                 self._query_agent,
-                {
-                    "intent": ctx.get("intent"),
-                    "entities": ctx.get("entities"),
-                },
+                {"intent": ctx.get("intent"), "entities": ctx.get("entities")},
                 ctx,
                 repo,
                 conversation_id,
@@ -139,21 +177,20 @@ class TeamOrchestrator:
 
             reply = ctx.get("response", "")
         except Exception:  # pragma: no cover - defensive
-            reply = context.get("response", "")
-            success = True
-        except Exception:
             success = False
             self._error_calls += 1
             logger.exception("Agent processing failed")
             reply = (
                 "Désolé, une erreur est survenue lors du traitement de votre demande."
             )
+
         repo.add(
             conversation_id=conversation_id,
             user_id=user_id,
             role="assistant",
             content=reply,
         )
+
         duration = (time.time() - start) * 1000
         self._metrics.record_orchestrator_call(
             operation="query_agents", success=success, processing_time_ms=duration
@@ -164,38 +201,16 @@ class TeamOrchestrator:
         self,
         agent: Optional[Any],
         payload: Dict[str, Any],
-    def start_conversation(self, user_id: int, db: Session) -> str:
-        """Create a new conversation for ``user_id`` and return its identifier."""
-
-        conversation_id = str(uuid.uuid4())
-        ConversationRepository(db).create(user_id, conversation_id)
-        return conversation_id
-
-    def get_history(
-        self, conversation_id: str, db: Session
-    ) -> Optional[List["ConversationMessage"]]:
-        """Return the persisted history for ``conversation_id`` if it exists."""
-
-        repo = ConversationRepository(db)
-        if repo.get_by_conversation_id(conversation_id) is None:
-            return None
-        return ConversationMessageRepository(db).list_models(conversation_id)
-
-    async def _call_agent(
-        self,
-        agent: Optional[object],
         context: Dict[str, Any],
         repo: ConversationMessageRepository,
         conversation_id: str,
         user_id: int,
     ) -> Dict[str, Any]:
         """Invoke ``agent`` with ``payload`` while updating/persisting context."""
-        """Execute ``agent`` with ``context`` and persist its output."""
 
         if agent is None:
             return context
 
-        # Propagate current context to the agent
         payload["context"] = context
         start = time.time()
         response = await agent.process(payload)  # type: ignore[call-arg]
@@ -207,7 +222,6 @@ class TeamOrchestrator:
         else:
             result = response or {}
 
-        # Update shared context and persist agent output
         context.update(result)
         name = getattr(agent, "name", agent.__class__.__name__)
         repo.add(
@@ -220,51 +234,7 @@ class TeamOrchestrator:
         await self._metrics.record_agent_call(
             agent_name=name, success=True, processing_time_ms=duration_ms
         )
-
         return context
-
-    def start_conversation(self, user_id: int, db: Session) -> str:
-        """Create and persist a new conversation session."""
-
-        conv_id = uuid.uuid4().hex
-        repo = ConversationRepository(db)
-        repo.create(user_id=user_id, conversation_id=conv_id)
-        return conv_id
-
-    def get_history(self, conversation_id: str, db: Session):
-        """Return persisted user/assistant message history."""
-
-        repo = ConversationMessageRepository(db)
-        return repo.list_models(conversation_id)
-        start = time.time()
-        agent_name = getattr(getattr(agent, "config", None), "name", None) or getattr(
-            agent, "name", agent.__class__.__name__
-        )
-        success = False
-        try:
-            response = await agent.process(context)
-            if not getattr(response, "success", False):
-                raise RuntimeError(getattr(response, "error_message", "agent error"))
-            result = getattr(response, "result", {}) or {}
-            context.update(result)
-            content = (
-                result.get("response")
-                or result.get("intent")
-                or str(result.get("entities", result))
-            )
-            repo.add(
-                conversation_id=conversation_id,
-                user_id=user_id,
-                role=agent_name,
-                content=str(content),
-            )
-            success = True
-            return context
-        finally:
-            duration = (time.time() - start) * 1000
-            self._metrics.record_orchestrator_call(
-                operation=agent_name, success=success, processing_time_ms=duration
-            )
 
     def get_error_metrics(self) -> Dict[str, float]:
         """Return counters summarising orchestrator errors."""
@@ -276,4 +246,7 @@ class TeamOrchestrator:
                 self._error_calls / self._total_calls if self._total_calls else 0.0
             ),
         }
+
+
+__all__ = ["TeamOrchestrator"]
 


### PR DESCRIPTION
## Summary
- Refactor `TeamOrchestrator` to launch intent classification and entity extraction concurrently using `asyncio.gather`
- Feed combined results into query and response generators for final reply

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'redis'; AttributeError: module 'httpx' has no attribute 'Response')*

------
https://chatgpt.com/codex/tasks/task_e_68a756c2963c83208570c87cdf852782