### PR TITLE
chore: expose agent modules

### DIFF
--- a/conversation_service/agents/__init__.py
+++ b/conversation_service/agents/__init__.py
@@ -1,18 +1,31 @@
 """Core conversation agents and utilities."""
 
+# Import submodules to expose them at package level
+from . import (
+    base_agent,
+    context_manager,
+    entity_extractor_agent,
+    intent_classifier_agent,
+    query_generator,
+    response_generator_agent,
+)
+
 from .base_agent import BaseFinancialAgent, CacheManager
-from .intent_classifier_agent import IntentClassificationCache, IntentClassifierAgent
+from .context_manager import ContextManager
 from .entity_extractor_agent import EntityExtractionCache, EntityExtractorAgent
+from .intent_classifier_agent import IntentClassificationCache, IntentClassifierAgent
 from .query_generator import QueryGeneratorAgent
 from .response_generator_agent import ResponseGeneratorAgent
 
 __all__ = [
     "BaseFinancialAgent",
     "CacheManager",
-    "IntentClassificationCache",
+    "ContextManager",
     "IntentClassifierAgent",
-    "EntityExtractionCache",
+    "IntentClassificationCache",
     "EntityExtractorAgent",
+    "EntityExtractionCache",
     "QueryGeneratorAgent",
     "ResponseGeneratorAgent",
 ]
+


### PR DESCRIPTION
## Summary
- expose agent submodules for package-level access
- add `ContextManager` and caches to `__all__`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a765a58b68832085886013d58ec783