### PR TITLE
Inject user id into query filters

### DIFF
--- a/conversation_service/agents/query_generator.py
+++ b/conversation_service/agents/query_generator.py
@@ -37,8 +37,7 @@ class QueryGeneratorAgent(BaseFinancialAgent):
 
         context = input_data.get("context", {})
         user_id = context.get("user_id")
-        filters = dict(context.get("filters", {}))
-        filters["user_id"] = user_id
+        filters = {**dict(context.get("filters", {})), "user_id": user_id}
 
         payload = {
             "user_id": user_id,

--- a/conversation_service/tests/test_agents/test_query_optimizer.py
+++ b/conversation_service/tests/test_agents/test_query_optimizer.py
@@ -1,5 +1,6 @@
 import sys
 import types
+import asyncio
 from enum import Enum
 import pytest
 
@@ -10,6 +11,28 @@ sys.modules.setdefault("conversation_service.core.cache_manager", types.SimpleNa
 sys.modules.setdefault("conversation_service.core.metrics_collector", types.SimpleNamespace(MetricsCollector=object))
 sys.modules.setdefault("conversation_service.utils.logging", types.SimpleNamespace(get_structured_logger=lambda name: None))
 
+_clients_pkg = types.ModuleType("conversation_service.clients")
+_clients_pkg.__path__ = []  # type: ignore[attr-defined]
+sys.modules.setdefault("conversation_service.clients", _clients_pkg)
+
+_openai_client_module = types.ModuleType("conversation_service.clients.openai_client")
+_openai_client_module.OpenAIClient = object
+sys.modules.setdefault("conversation_service.clients.openai_client", _openai_client_module)
+
+_search_client_module = types.ModuleType("conversation_service.clients.search_client")
+_search_client_module.SearchClient = object
+sys.modules.setdefault("conversation_service.clients.search_client", _search_client_module)
+
+_cache_client_module = types.ModuleType("conversation_service.clients.cache_client")
+_cache_client_module.CacheClient = object
+sys.modules.setdefault("conversation_service.clients.cache_client", _cache_client_module)
+
+_clients_pkg.OpenAIClient = _openai_client_module.OpenAIClient
+_clients_pkg.SearchClient = _search_client_module.SearchClient
+_clients_pkg.CacheClient = _cache_client_module.CacheClient
+
+sys.modules.setdefault("openai", types.SimpleNamespace(AsyncOpenAI=object))
+
 import conversation_service.models.core_models as core_models
 
 class QueryType(str, Enum):
@@ -17,12 +40,14 @@ class QueryType(str, Enum):
 
 core_models.QueryType = QueryType
 
-agent_module = pytest.importorskip("conversation_service.agents.query_generator")
+agent_module = pytest.importorskip("conversation_service.agents.query_generator_agent")
 QueryOptimizer = getattr(agent_module, "QueryOptimizer", None)
 if QueryOptimizer is None:  # pragma: no cover - missing implementation
     pytest.skip("QueryOptimizer not available", allow_module_level=True)
 
 from conversation_service.models.core_models import IntentType
+
+from conversation_service.agents.query_generator_agent import QueryGeneratorAgent
 
 
 def test_query_optimizer_applies_merchant_rule():
@@ -31,3 +56,32 @@ def test_query_optimizer_applies_merchant_rule():
 
     assert optimized["search_parameters"]["limit"] == 15
     assert "sort" in optimized["search_parameters"]
+
+
+class _DummySearchClient:
+    def __init__(self):
+        self.payload = None
+
+    async def search(self, user_id, payload):
+        self.payload = payload
+        return {}
+
+
+def test_query_generator_injects_user_id_into_filters():
+    search_client = _DummySearchClient()
+    agent = QueryGeneratorAgent(search_client=search_client)
+    input_data = {
+        "intent": "any_intent",
+        "entities": {"foo": "bar"},
+        "context": {
+            "user_id": 99,
+            "filters": {"user_id": 1, "other": "value"},
+        },
+    }
+
+    result = asyncio.run(agent._process_implementation(input_data))
+
+    assert search_client.payload["filters"]["user_id"] == 99
+    assert search_client.payload["filters"]["other"] == "value"
+    assert result["search_request"]["filters"]["user_id"] == 99
+    assert result["search_request"]["filters"]["other"] == "value"

--- a/tests/test_agents/test_query_optimizer.py
+++ b/tests/test_agents/test_query_optimizer.py
@@ -111,6 +111,8 @@ def test_query_generator_injects_user_id_into_filters():
 
     result = asyncio.run(agent._process_implementation(input_data))
 
+    assert search_client.payload["filters"]["user_id"] == 99
+    assert search_client.payload["filters"]["other"] == "value"
     assert result["search_request"]["filters"]["user_id"] == 99
     assert result["search_request"]["filters"]["other"] == "value"
 


### PR DESCRIPTION
## Summary
- inject `user_id` from context into query filters before hitting search
- expand tests to verify user_id filter is sent to search

## Testing
- `pytest tests/test_agents/test_query_optimizer.py conversation_service/tests/test_agents/test_query_optimizer.py`

------
https://chatgpt.com/codex/tasks/task_e_68a765d37a808320936ae96996927934