### PR TITLE
Allow agents to run without OpenAI client

### DIFF
--- a/conversation_service/agents/base_agent.py
+++ b/conversation_service/agents/base_agent.py
@@ -333,7 +333,21 @@ class BaseFinancialAgent(ABC):
         cache_manager: Optional[CacheManager] = None,
         metrics_collector: Optional[MetricsCollector] = None,
     ):
-        """Initialize base financial agent."""
+        """Initialize base financial agent.
+
+        Parameters
+        ----------
+        config:
+            Agent configuration describing model and behavioural settings.
+        openai_client:
+            Optional OpenAI client instance. When ``None`` no AutoGen
+            ``AssistantAgent`` will be created and direct OpenAI calls are
+            disabled.
+        cache_manager:
+            Optional cache manager instance.
+        metrics_collector:
+            Optional metrics collector instance.
+        """
 
         self.config = config
         self.openai_client = openai_client
@@ -345,6 +359,7 @@ class BaseFinancialAgent(ABC):
         self.prompt_optimizer = PromptOptimizer()
 
         # Create AutoGen AssistantAgent only when an OpenAI client is provided
+        self.agent = None
         if self.openai_client is not None and AssistantAgent is not None:
             self.agent = AssistantAgent(
                 name=config.name,
@@ -356,8 +371,6 @@ class BaseFinancialAgent(ABC):
                     "timeout": config.timeout_seconds,
                 },
             )
-        else:
-            self.agent = None
         
         # Agent state
         self.is_initialized = True

--- a/conversation_service/agents/query_generator.py
+++ b/conversation_service/agents/query_generator.py
@@ -7,7 +7,7 @@ from pydantic import ValidationError
 from .base_agent import BaseFinancialAgent
 from ..models.agent_models import AgentConfig
 from ..prompts import query_prompts
-from ..clients import SearchClient
+from ..clients import SearchClient, OpenAIClient
 from search_service.models import SearchRequest
 
 
@@ -17,8 +17,19 @@ class QueryGeneratorAgent(BaseFinancialAgent):
     def __init__(
         self,
         search_client: SearchClient,
-        openai_client: Optional[Any] = None,
+        openai_client: Optional[OpenAIClient] = None,
     ):
+        """Create a new :class:`QueryGeneratorAgent`.
+
+        Parameters
+        ----------
+        search_client:
+            Client used to execute search queries.
+        openai_client:
+            Optional OpenAI client instance forwarded to
+            :class:`BaseFinancialAgent`. When ``None``, the base class will not
+            create an AutoGen ``AssistantAgent``.
+        """
         config = AgentConfig(
             name="query_generator",
             system_message=query_prompts.get_prompt(),

--- a/tests/test_agents/test_query_optimizer.py
+++ b/tests/test_agents/test_query_optimizer.py
@@ -99,7 +99,8 @@ class _DummySearchClient:
 
 def test_query_generator_injects_user_id_into_filters():
     search_client = _DummySearchClient()
-    agent = QueryGeneratorAgent(search_client=search_client)
+    agent = QueryGeneratorAgent(search_client=search_client, openai_client=None)
+    assert agent.agent is None
     input_data = {
         "intent": "any_intent",
         "entities": {"foo": "bar"},


### PR DESCRIPTION
## Summary
- make `BaseFinancialAgent` accept optional OpenAI client and avoid creating an AssistantAgent when not provided
- propagate optional `openai_client` to `QueryGeneratorAgent`
- update query generator tests to verify no assistant is created without a client

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a765d984cc8320bb62be7addcca406