### PR TITLE
Check cache before processing in BaseFinancialAgent

### DIFF
--- a/conversation_service/agents/base_agent.py
+++ b/conversation_service/agents/base_agent.py
@@ -412,7 +412,51 @@ class BaseFinancialAgent(ABC):
             user_id = str(input_data.get("user_id", "anonymous"))
             if self.cache_manager:
                 cache_key = self._generate_cache_key(input_data)
-            
+                cached = await self.cache_manager.get(cache_key, user_id)
+                if cached is not None:
+                    processing_time_ms = int((time.time() - start_time) * 1000)
+                    confidence = cached.get("confidence") if isinstance(cached, dict) else None
+                    tokens_used = cached.get("tokens_used", 0) if isinstance(cached, dict) else 0
+
+                    self.performance_tracker.record_call(
+                        success=True,
+                        processing_time_ms=processing_time_ms,
+                        tokens_used=tokens_used,
+                        confidence=confidence,
+                        cached=True,
+                    )
+
+                    # Reset circuit breaker on cache hit
+                    self.circuit_breaker_failures = 0
+                    self.circuit_breaker_reset_time = None
+
+                    if self.metrics_collector:
+                        await self.metrics_collector.record_agent_call(
+                            agent_name=self.config.name,
+                            success=True,
+                            processing_time_ms=processing_time_ms,
+                            tokens_used=tokens_used,
+                            cached=True,
+                        )
+
+                    logger.debug(
+                        "Agent cache hit",
+                        extra={
+                            "agent_name": self.config.name,
+                            "cache_key": cache_key,
+                            "processing_time_ms": processing_time_ms,
+                        },
+                    )
+
+                    return AgentResponse(
+                        agent_name=self.config.name,
+                        success=True,
+                        result=cached,
+                        processing_time_ms=processing_time_ms,
+                        tokens_used=tokens_used,
+                        cached=True,
+                    )
+
             # Process with implementation
             result = await self._process_implementation(input_data)
             processing_time_ms = int((time.time() - start_time) * 1000)


### PR DESCRIPTION
## Summary
- Check cache for existing agent results before invoking processing logic
- Track cache hit metrics and return cached responses immediately

## Testing
- `pytest tests/test_agents/test_entity_extraction_cache.py tests/test_agents/test_intent_classification_cache.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'redis')*

------
https://chatgpt.com/codex/tasks/task_e_68a76b08a9f08320a3a5b1df12535aaf