### PR TITLE
Ensure future annotations import follows module docstring

### DIFF
--- a/teams/team_orchestrator.py
+++ b/teams/team_orchestrator.py
@@ -1,7 +1,6 @@
-from __future__ import annotations
-
 """Simple orchestrator chaining intent classification, entity extraction,
 query generation and response production."""
+from __future__ import annotations
 
 import json
 import logging


### PR DESCRIPTION
## Summary
- move `from __future__ import annotations` below the module docstring in `team_orchestrator`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68a76b0b59108320be33ccb0108a70b8