### PR TITLE
Document autogen-agentchat dependency and stub path

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ Avant d'exécuter les tests, installez les dépendances Web de base :
 pip install aiohttp fastapi sqlalchemy pydantic-settings
 ```
 
+Assurez-vous également que la bibliothèque `autogen-agentchat` est disponible :
+
+```bash
+pip install autogen-agentchat
+```
+
+Si l'installation n'est pas possible, un stub minimal est fourni dans le dossier
+`autogen_agentchat/`. Ajoutez-le au `PYTHONPATH` pour qu'il soit pris en compte :
+
+```bash
+export PYTHONPATH="$PYTHONPATH:$(pwd)"
+```
+
 Les tests nécessitent l'extra `ag2[openai]`. Installez les dépendances puis
 cet extra :
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,14 @@ import pytest
 import json
 from collections import OrderedDict
 from typing import Any
+from pathlib import Path
+
+# Ensure local autogen_agentchat stub is importable when the real package is missing
+try:  # pragma: no cover - runtime dependency check
+    import autogen_agentchat  # type: ignore  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover - executed only when package absent
+    stub_dir = Path(__file__).resolve().parents[1] / "autogen_agentchat"
+    sys.path.insert(0, str(stub_dir))
 # Minimal settings stub to avoid external dependency
 
 class GlobalSettings:


### PR DESCRIPTION
## Summary
- Ensure local autogen_agentchat stub is on `PYTHONPATH` when package is missing
- Explain how to install or stub `autogen-agentchat` in the development guide

## Testing
- `pip install autogen-agentchat --quiet`
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy', aiohttp, pydantic_settings, fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68a76b0ca6388320b4d88682df2b7c6a