### PR TITLE
Expose core conversation agents from package

### DIFF
--- a/conversation_service/agents/__init__.py
+++ b/conversation_service/agents/__init__.py
@@ -1,31 +1,22 @@
-"""Core conversation agents and utilities."""
+"""Expose conversation agents for easy imports.
 
-# Import submodules to expose them at package level
-from . import (
-    base_agent,
-    context_manager,
-    entity_extractor_agent,
-    intent_classifier_agent,
-    query_generator,
-    response_generator_agent,
-)
+This package aggregates the primary agent classes used throughout the
+conversation service so they can be imported directly from
+``conversation_service.agents``.
+"""
 
-from .base_agent import BaseFinancialAgent, CacheManager
-from .context_manager import ContextManager
 from .entity_extractor_agent import EntityExtractionCache, EntityExtractorAgent
 from .intent_classifier_agent import IntentClassificationCache, IntentClassifierAgent
-from .query_generator import QueryGeneratorAgent
+from .query_generator_agent import QueryGeneratorAgent, QueryOptimizer
 from .response_generator_agent import ResponseGeneratorAgent
 
 __all__ = [
-    "BaseFinancialAgent",
-    "CacheManager",
-    "ContextManager",
     "IntentClassifierAgent",
     "IntentClassificationCache",
     "EntityExtractorAgent",
     "EntityExtractionCache",
     "QueryGeneratorAgent",
+    "QueryOptimizer",
     "ResponseGeneratorAgent",
 ]
 


### PR DESCRIPTION
## Summary
- simplify `conversation_service.agents` to expose main agent classes
- export `QueryOptimizer` alongside agent classes

## Testing
- `pytest conversation_service/tests/test_agents/test_package_import.py -q`
- `pytest conversation_service/tests/test_agents -q` *(fails: No module named 'conversation_service.agents.agent_team')*


------
https://chatgpt.com/codex/tasks/task_e_68a76dd851ec8320840db96f814db717