### PR TITLE
Document cache key formats and TTL for agent caches

### DIFF
--- a/conversation_service/agents/entity_extractor_agent.py
+++ b/conversation_service/agents/entity_extractor_agent.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import time
 from typing import Dict, List, Optional, Tuple
 
+# Default cache time-to-live for entity extraction results (seconds)
+DEFAULT_TTL = 180
+
 try:  # pragma: no cover - optional runtime dependency
     from .entity_extractor import EntityExtractorAgent  # type: ignore
 except Exception:  # pragma: no cover - dependency not available
@@ -14,7 +17,13 @@ from ..models.core_models import FinancialEntity
 
 
 class EntityExtractionCache:
-    """Simple in-memory cache for extracted entities."""
+    """Simple in-memory cache for extracted entities.
+
+    Cache keys include the ``user_id``, ``intent`` and original ``message``
+    separated by colons (``"{user_id}:{intent}:{message}"``).  Cached
+    entries expire after ``DEFAULT_TTL`` seconds unless a different
+    ``ttl`` is specified when setting or retrieving.
+    """
 
     def __init__(self) -> None:
         # Cache extracted entities along with the timestamp they were cached
@@ -29,7 +38,7 @@ class EntityExtractionCache:
         return f"{user_id}:{intent}:{message}"
 
     def get(
-        self, user_id: str, message: str, intent: str, ttl: int = 180
+        self, user_id: str, message: str, intent: str, ttl: int = DEFAULT_TTL
     ) -> Optional[Dict[str, object]]:
         key = self._make_key(user_id, message, intent)
         entry = self._store.get(key)
@@ -48,7 +57,7 @@ class EntityExtractionCache:
         message: str,
         intent: str,
         entities: List[FinancialEntity],
-        ttl: int = 180,
+        ttl: int = DEFAULT_TTL,
     ) -> None:
         key = self._make_key(user_id, message, intent)
         self._store[key] = (entities, time.time())


### PR DESCRIPTION
## Summary
- Document cache key formats and default TTLs for intent and entity caches
- Add constants for cache TTLs in agent cache helpers

## Testing
- `pytest tests/test_agents/test_intent_classification_cache.py::test_intent_cache_store_and_retrieve tests/test_agents/test_intent_classification_cache.py::test_intent_cache_ttl_expiry tests/test_agents/test_entity_extraction_cache.py::test_entity_cache_store_and_retrieve tests/test_agents/test_entity_extraction_cache.py::test_entity_cache_ttl_expiry -q`


------
https://chatgpt.com/codex/tasks/task_e_68a76ddf5804832090aefa5a31f5fa2d