### PR TITLE
Ensure query generator injects user id into search filters

### DIFF
--- a/conversation_service/agents/query_generator.py
+++ b/conversation_service/agents/query_generator.py
@@ -48,14 +48,15 @@ class QueryGeneratorAgent(BaseFinancialAgent):
 
         context = input_data.get("context", {})
         user_id = context.get("user_id")
-        filters = {**dict(context.get("filters", {})), "user_id": user_id}
 
         payload = {
             "user_id": user_id,
             "query": context.get("query", ""),
-            "filters": filters,
+            "filters": context.get("filters") or {},
             "aggregations": context.get("aggregations"),
         }
+
+        payload["filters"]["user_id"] = user_id
 
         try:
             search_request = SearchRequest(**payload)


### PR DESCRIPTION
## Summary
- ensure user id is added to search filters before calling search service
- simplify QueryGeneratorAgent to a single `_process_implementation`

## Testing
- `pytest conversation_service/tests -q` *(fails: ModuleNotFoundError: No module named 'conversation_service.agents.agent_team')*
- `pytest conversation_service/tests/test_prompts/test_query_prompts.py -q`
- `pytest conversation_service/tests/test_agents/test_response_generator_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a76de76820832085128935e53a23ba