### PR TITLE
Add run method for TeamOrchestrator and update AgentRuntime

### DIFF
--- a/agent_runtime.py
+++ b/agent_runtime.py
@@ -15,9 +15,8 @@ class AgentRuntime:
     async def run(self, message: str) -> str:
         """Execute the agent pipeline for a user message."""
 
-        result = await self.team.run(task=message)
-        final_message = result.messages[-1]
-        return getattr(final_message, "content", "")
+        response = await self.team.run(task=message)
+        return getattr(response.chat_message, "content", "")
 
     def get_context(self) -> dict[str, str]:
         """Return the shared context accumulated by the team."""


### PR DESCRIPTION
## Summary
- implement `TeamOrchestrator.run` to delegate to `query_agents` and wrap the reply in a `Response`
- track conversation info in `start_conversation`
- adjust `AgentRuntime.run` to consume the new `Response` structure

## Testing
- `pytest` *(fails: Conversation not initialised, async functions not supported without plugin, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a771f4309c8320a4c53241b16dcd8f