### PR TITLE
feat: add TTL cache for intent and entity agents

### DIFF
--- a/conversation_service/agents/intent_classifier_agent.py
+++ b/conversation_service/agents/intent_classifier_agent.py
@@ -18,10 +18,10 @@ from ..models.core_models import IntentResult
 class IntentClassificationCache:
     """Simple in-memory cache for intent classification results.
 
-    Cached entries are identified by the combination of ``user_id`` and
-    the original ``message`` (``"{user_id}:{message}"``) and expire after
-    ``DEFAULT_TTL`` seconds unless a different ``ttl`` is explicitly
-    provided when calling :meth:`set` or :meth:`get`.
+    Each entry stores the :class:`~conversation_service.models.core_models.IntentResult`
+    together with the timestamp of when it was cached. Entries are keyed by
+    ``"{user_id}:{message}"`` and are invalidated when the current time exceeds
+    ``timestamp + ttl``.
     """
 
     def __init__(self) -> None:

--- a/conversation_service/tests/test_agents/test_entity_extraction_cache.py
+++ b/conversation_service/tests/test_agents/test_entity_extraction_cache.py
@@ -22,12 +22,11 @@ def test_entity_cache_store_and_retrieve():
         normalized_value="Amazon",
         confidence=0.95,
     )
-    cache.set("user1", "Spent at Amazon", "MERCHANT_ANALYSIS", [entity])
+    cache.set("user1", "MERCHANT_ANALYSIS", "Spent at Amazon", [entity])
 
-    cached = cache.get("user1", "Spent at Amazon", "MERCHANT_ANALYSIS")
+    cached = cache.get("user1", "MERCHANT_ANALYSIS", "Spent at Amazon")
     assert cached is not None
-    assert cached["cached"] is True
-    assert len(cached["entities"]) == 1
+    assert len(cached) == 1
     assert cache.hits == 1
 
 
@@ -39,8 +38,8 @@ def test_entity_cache_ttl_expiry():
         normalized_value="Amazon",
         confidence=0.95,
     )
-    cache.set("user1", "Will this expire?", "MERCHANT_ANALYSIS", [entity], ttl=1)
+    cache.set("user1", "MERCHANT_ANALYSIS", "Will this expire?", [entity], ttl=1)
 
     time.sleep(1.1)
-    cached = cache.get("user1", "Will this expire?", "MERCHANT_ANALYSIS", ttl=1)
+    cached = cache.get("user1", "MERCHANT_ANALYSIS", "Will this expire?", ttl=1)
     assert cached is None

--- a/tests/test_agents/test_entity_extraction_cache.py
+++ b/tests/test_agents/test_entity_extraction_cache.py
@@ -17,12 +17,11 @@ def test_entity_cache_store_and_retrieve():
         normalized_value="Amazon",
         confidence=0.95
     )
-    cache.set("user1", "Spent at Amazon", "MERCHANT_ANALYSIS", [entity])
+    cache.set("user1", "MERCHANT_ANALYSIS", "Spent at Amazon", [entity])
 
-    cached = cache.get("user1", "Spent at Amazon", "MERCHANT_ANALYSIS")
+    cached = cache.get("user1", "MERCHANT_ANALYSIS", "Spent at Amazon")
     assert cached is not None
-    assert cached["cached"] is True
-    assert len(cached["entities"]) == 1
+    assert len(cached) == 1
     assert cache.hits == 1
 
 
@@ -34,8 +33,8 @@ def test_entity_cache_ttl_expiry():
         normalized_value="Amazon",
         confidence=0.95,
     )
-    cache.set("user1", "Will this expire?", "MERCHANT_ANALYSIS", [entity], ttl=1)
+    cache.set("user1", "MERCHANT_ANALYSIS", "Will this expire?", [entity], ttl=1)
 
     time.sleep(1.1)
-    cached = cache.get("user1", "Will this expire?", "MERCHANT_ANALYSIS", ttl=1)
+    cached = cache.get("user1", "MERCHANT_ANALYSIS", "Will this expire?", ttl=1)
     assert cached is None


### PR DESCRIPTION
## Summary
- add timestamp-aware cache for intent classification keyed by user and message
- introduce entity extraction cache keyed by user, intent and message
- adapt tests for new cache behavior

## Testing
- `pytest tests/test_agents/test_intent_classification_cache.py tests/test_agents/test_entity_extraction_cache.py conversation_service/tests/test_agents/test_intent_classification_cache.py conversation_service/tests/test_agents/test_entity_extraction_cache.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a775eba504832098b87e5a888f4641