### PR TITLE
fix user filter injection in query generator

### DIFF
--- a/conversation_service/agents/query_generator.py
+++ b/conversation_service/agents/query_generator.py
@@ -44,7 +44,7 @@ class QueryGeneratorAgent(BaseFinancialAgent):
         """Build and execute a search request based on ``input_data``."""
 
         if input_data.get("intent") is None or input_data.get("entities") is None:
-            return {"error": "intent and entities are required"}
+            raise ValueError("intent and entities are required")
 
         context = input_data.get("context", {})
         user_id = context.get("user_id")
@@ -56,7 +56,7 @@ class QueryGeneratorAgent(BaseFinancialAgent):
             "aggregations": context.get("aggregations"),
         }
 
-        payload["filters"]["user_id"] = user_id
+        payload.setdefault("filters", {})["user_id"] = user_id
 
         try:
             search_request = SearchRequest(**payload)


### PR DESCRIPTION
## Summary
- ensure query generator injects user_id via `setdefault` when building payload filters
- raise `ValueError` when intent or entities are missing

## Testing
- `pytest -q` *(fails: Conversation not initialised, async plugin missing, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a775ed2618832088a4642af0ef4985