### PR TITLE
feat: generate responses via OpenAI with caching

### DIFF
--- a/tests/test_agents/test_response_generator_agent.py
+++ b/tests/test_agents/test_response_generator_agent.py
@@ -2,6 +2,7 @@ import asyncio
 
 import importlib.util
 from pathlib import Path
+from typing import Any
 
 module_path = Path(__file__).resolve().parents[2] / "conversation_service" / "agents" / "response_generator_agent.py"
 spec = importlib.util.spec_from_file_location("response_generator_agent", module_path)
@@ -15,9 +16,9 @@ class DummyLLM:
     def __init__(self) -> None:
         self.calls = []
 
-    async def generate(self, prompt: str) -> str:  # pragma: no cover - trivial
-        self.calls.append(prompt)
-        return f"LLM:{len(self.calls)}"
+    async def chat_completion(self, *, model: str, messages: list, **_: Any) -> dict:
+        self.calls.append(messages)
+        return {"choices": [{"message": {"content": f"LLM:{len(self.calls)}"}}]}
 
 
 def test_generation_personalisation_and_cache():
@@ -40,7 +41,7 @@ def test_generation_personalisation_and_cache():
         first = await agent.generate("user1", search_results, context)
         assert first.startswith("LLM:")
         assert len(llm.calls) == 1
-        prompt = llm.calls[0]
+        prompt = llm.calls[0][0]["content"]
         assert "Balance is 100€" in prompt
         assert "Alice" in prompt
         assert "BALANCE_INQUIRY" in prompt
@@ -91,7 +92,7 @@ def test_cache_varies_with_context():
 
 
 class FailingLLM:
-    async def generate(self, prompt: str) -> str:  # pragma: no cover - trivial
+    async def chat_completion(self, *, model: str, messages: list, **_: Any) -> dict:  # pragma: no cover - trivial
         raise RuntimeError("boom")
 
 


### PR DESCRIPTION
## Summary
- generate conversation responses through OpenAI with user intent, entities, and preferences
- add in-memory cache with 60s TTL to avoid repeated OpenAI calls
- update tests for OpenAI-based agent

## Testing
- `pytest tests/test_agents/test_response_generator_agent.py conversation_service/tests/test_agents/test_response_generator_agent.py`
- `pytest` *(fails: PytestUnknownMarkWarning and collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a775f40c648320aaf71ba2f9c2021e