### PR TITLE
chore: ignore extra fields in config classes

### DIFF
--- a/config/autogen_config.py
+++ b/config/autogen_config.py
@@ -18,6 +18,8 @@ class AgentParameters:
     max_consecutive_auto_reply: int = 1
     description: str | None = None
 
+    model_config = SettingsConfigDict(extra="ignore")
+
 
 class AutoGenConfig(BaseSettings):
     """Configuration for AutoGen agents.
@@ -31,7 +33,9 @@ class AutoGenConfig(BaseSettings):
     max_consecutive_auto_reply: int = 1
     description: str = "Harena financial assistant"
 
-    model_config = SettingsConfigDict(env_prefix="AUTOGEN_", env_file=".env", extra="ignore")
+    model_config = SettingsConfigDict(
+        extra="ignore", env_prefix="AUTOGEN_", env_file=".env"
+    )
 
     def build_agent_params(
         self,

--- a/config/openai_config.py
+++ b/config/openai_config.py
@@ -16,7 +16,9 @@ class OpenAIConfig(BaseSettings):
     timeout: int = 30
 
     # Environment variables are prefixed with ``OPENAI_``
-    model_config = SettingsConfigDict(env_prefix="OPENAI_", env_file=".env", extra="ignore")
+    model_config = SettingsConfigDict(
+        extra="ignore", env_prefix="OPENAI_", env_file=".env"
+    )
 
 
 # ``get_openai_config`` in :mod:`config` should be used instead of creating

--- a/config/settings.py
+++ b/config/settings.py
@@ -16,7 +16,7 @@ class Settings(BaseSettings):
     BRIDGE_CLIENT_ID: str = ""
     BRIDGE_CLIENT_SECRET: str = ""
 
-    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+    model_config = SettingsConfigDict(extra="ignore", env_file=".env")
 
 
 # The ``get_settings`` accessor in :mod:`config` should be preferred over


### PR DESCRIPTION
## Summary
- ensure config classes ignore unknown environment vars
- tighten dataclass config defaults for agent parameters

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68a775f6ebe08320af9aba3cba6b4fa2