### PR TITLE
Update agent cache TTLs for new agent names

### DIFF
--- a/conversation_service/agents/base_agent.py
+++ b/conversation_service/agents/base_agent.py
@@ -54,10 +54,10 @@ logger = get_structured_logger(__name__)
 
 # Default cache TTL (seconds) per agent
 AGENT_CACHE_TTLS = {
-    "intent": 300,
-    "entity": 180,
-    "query": 120,
-    "response": 60,
+    "intent_classifier": 300,
+    "entity_extractor": 180,
+    "query_generator": 120,
+    "response_generator": 60,
 }
 
 # ================================


### PR DESCRIPTION
## Summary
- rename cache TTL mapping keys to intent_classifier, entity_extractor, query_generator, response_generator
- keep same TTL values 300/180/120/60 seconds for respective agents

## Testing
- `pytest tests/test_cache_client_isolation.py::test_cache_client_isolated_by_user_id -q`


------
https://chatgpt.com/codex/tasks/task_e_68a77b112c6c832094d53f39d8684359