### PR TITLE
Ensure user ID filter is applied before search

### DIFF
--- a/conversation_service/agents/query_generator.py
+++ b/conversation_service/agents/query_generator.py
@@ -49,17 +49,16 @@ class QueryGeneratorAgent(BaseFinancialAgent):
         context = input_data.get("context", {})
         user_id = context.get("user_id")
 
-        payload = {
-            "user_id": user_id,
-            "query": context.get("query", ""),
-            "filters": context.get("filters") or {},
-            "aggregations": context.get("aggregations"),
-        }
-
-        payload.setdefault("filters", {})["user_id"] = user_id
+        filters = (context.get("filters") or {}).copy()
+        filters["user_id"] = user_id
 
         try:
-            search_request = SearchRequest(**payload)
+            search_request = SearchRequest(
+                user_id=user_id,
+                query=context.get("query", ""),
+                filters=filters,
+                aggregations=context.get("aggregations"),
+            )
         except ValidationError:
             # If validation fails we do not query the search service
             return None


### PR DESCRIPTION
## Summary
- ensure QueryGeneratorAgent adds user_id to filters before search call
- streamline _process_implementation to construct SearchRequest once and return results without dead code

## Testing
- `pytest tests/test_agents/test_query_optimizer.py conversation_service/tests/test_agents/test_query_optimizer.py`
- `pytest` *(fails: tests/test_agent_runtime.py, tests/test_config_files.py, tests/test_create_app.py, tests/test_search_engine_user_filter.py, tests/test_teams/test_sync_orchestrator.py, tests/test_websocket.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a77b17f45883209198f31390ff9a32