### PR TITLE
Use integer conversation IDs for conversation messages

### DIFF
--- a/alembic/versions/c2805ce5b2d9_use_integer_conversation_id_in_.py
+++ b/alembic/versions/c2805ce5b2d9_use_integer_conversation_id_in_.py
@@ -1,0 +1,62 @@
+"""use integer conversation_id in conversation_messages
+
+Revision ID: c2805ce5b2d9
+Revises: 6eb09f813ccf
+Create Date: 2025-08-21 21:00:10.618671
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c2805ce5b2d9'
+down_revision: Union[str, None] = '6eb09f813ccf'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table('conversation_messages') as batch_op:
+        batch_op.drop_index('ix_conversation_messages_conversation_id')
+        batch_op.drop_constraint(
+            'conversation_messages_conversation_id_fkey', type_='foreignkey'
+        )
+        batch_op.drop_column('conversation_id')
+        batch_op.add_column(sa.Column('conversation_id', sa.Integer(), nullable=False))
+        batch_op.create_foreign_key(
+            'conversation_messages_conversation_id_fkey',
+            'conversations',
+            ['conversation_id'],
+            ['id'],
+            ondelete='CASCADE',
+        )
+        batch_op.create_index(
+            'ix_conversation_messages_conversation_id', ['conversation_id']
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table('conversation_messages') as batch_op:
+        batch_op.drop_index('ix_conversation_messages_conversation_id')
+        batch_op.drop_constraint(
+            'conversation_messages_conversation_id_fkey', type_='foreignkey'
+        )
+        batch_op.drop_column('conversation_id')
+        batch_op.add_column(
+            sa.Column('conversation_id', sa.String(length=255), nullable=False)
+        )
+        batch_op.create_foreign_key(
+            'conversation_messages_conversation_id_fkey',
+            'conversations',
+            ['conversation_id'],
+            ['conversation_id'],
+            ondelete='CASCADE',
+        )
+        batch_op.create_index(
+            'ix_conversation_messages_conversation_id', ['conversation_id']
+        )

--- a/db_service/models/conversation.py
+++ b/db_service/models/conversation.py
@@ -202,8 +202,8 @@ class ConversationMessage(Base, TimestampMixin):
 
     id = Column(Integer, primary_key=True, index=True)
     conversation_id = Column(
-        String(255),
-        ForeignKey("conversations.conversation_id", ondelete="CASCADE"),
+        Integer,
+        ForeignKey("conversations.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )

--- a/tests/test_conversation_message_repository.py
+++ b/tests/test_conversation_message_repository.py
@@ -1,0 +1,38 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from db_service.base import Base
+from db_service.models.conversation import Conversation
+from db_service.models.user import User
+from conversation_service.message_repository import ConversationMessageRepository
+
+
+def test_add_and_list_messages_with_int_conversation_id():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+
+    with Session() as session:
+        user = User(email="u@example.com", password_hash="x")
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+
+        conv = Conversation(user_id=user.id, conversation_id="conv1")
+        session.add(conv)
+        session.commit()
+        session.refresh(conv)
+
+        repo = ConversationMessageRepository(session)
+        repo.add(
+            conversation_id=conv.conversation_id,
+            conversation_db_id=conv.id,
+            user_id=user.id,
+            role="user",
+            content="hello",
+        )
+
+        messages = repo.list_models(conv.conversation_id)
+        assert len(messages) == 1
+        assert messages[0].conversation_id == conv.conversation_id
+        assert messages[0].content == "hello"


### PR DESCRIPTION
## Summary
- Switch `conversation_messages.conversation_id` to an integer FK toward `conversations.id`
- Accept conversation database IDs in `ConversationMessageRepository.add` and propagate through `TeamOrchestrator`
- Add Alembic migration and unit test for message repository

## Testing
- `pytest` *(fails: TypeError: 'NoneType' object is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_68a787f91a2c8320acd41b0bde3a0fde