### PR TITLE
refactor: use model_dump for message history

### DIFF
--- a/teams/team_orchestrator.py
+++ b/teams/team_orchestrator.py
@@ -8,7 +8,6 @@ import json
 import logging
 import time
 import uuid
-from dataclasses import asdict
 from typing import Any, Dict, List, Optional
 
 import sqlalchemy
@@ -88,7 +87,7 @@ class TeamOrchestrator:
         history_models = self.get_history(conversation_id, db) or []
         ctx: Dict[str, Any] = {
             "user_id": user_id,
-            "history": [asdict(m) for m in history_models],
+            "history": [m.model_dump() for m in history_models],
         }
 
         repo = ConversationMessageRepository(db)
@@ -243,7 +242,7 @@ class TeamOrchestrator:
 
         self.context = {
             "user_id": user_id,
-            "history": [asdict(m) for m in history],
+            "history": [m.model_dump() for m in history],
         }
         self._conversation_id = conv_id
         self._conversation_db_id = conv.id


### PR DESCRIPTION
## Summary
- use `model_dump()` to serialize stored conversation messages
- drop unused `dataclasses` import in orchestrator

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7fbe315dc8320920e702a560d270f