### PR TITLE
Refactor conversation history retrieval

### DIFF
--- a/teams/team_orchestrator.py
+++ b/teams/team_orchestrator.py
@@ -234,8 +234,6 @@ class TeamOrchestrator:
 
         conv_id = uuid.uuid4().hex
         conv = ConversationRepository(db).create(user_id, conv_id)
-        history = ConversationMessageRepository(db).list_models(conv_id)
-        ConversationRepository(db).create(user_id, conv_id)
         try:
             history = ConversationMessageRepository(db).list_models(conv_id)
         except sqlalchemy.exc.ProgrammingError:
@@ -257,7 +255,10 @@ class TeamOrchestrator:
         repo = ConversationRepository(db)
         if repo.get_by_conversation_id(conversation_id) is None:
             return None
-        return ConversationMessageRepository(db).list_models(conversation_id)
+        try:
+            return ConversationMessageRepository(db).list_models(conversation_id)
+        except sqlalchemy.exc.ProgrammingError:
+            return []
 
     def get_error_metrics(self) -> Dict[str, float]:
         return {


### PR DESCRIPTION
## Summary
- simplify conversation creation and history loading
- handle missing conversation tables gracefully when fetching history

## Testing
- `pytest -q` *(fails: TypeError: 'NoneType' object is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_68a7fbe822808320a7c5da1f6a7c0b8a