### PR TITLE
refactor: drop conversation_id from message repository add

### DIFF
--- a/conversation_service/message_repository.py
+++ b/conversation_service/message_repository.py
@@ -34,7 +34,6 @@ class ConversationMessageRepository:
     def add(
         self,
         *,
-        conversation_id: str,
         conversation_db_id: int,
         user_id: int,
         role: str,
@@ -43,9 +42,9 @@ class ConversationMessageRepository:
         """Persist a new message to the database.
 
         Parameters mirror the columns of :class:`ConversationMessageDB` so
-        that callers can explicitly state the ``conversation_id`` and
-        ``user_id`` associated with the message along with its ``role`` and
-        textual ``content``.
+        that callers can explicitly state the ``conversation_id`` (via
+        ``conversation_db_id``) and ``user_id`` associated with the message
+        along with its ``role`` and textual ``content``.
 
         Returns
         -------
@@ -72,7 +71,9 @@ class ConversationMessageRepository:
 
         return (
             self._db.query(ConversationMessageDB)
-            .join(Conversation, Conversation.id == ConversationMessageDB.conversation_id)
+            .join(
+                Conversation, Conversation.id == ConversationMessageDB.conversation_id
+            )
             .filter(Conversation.conversation_id == conversation_id)
             # ``created_at`` is more explicit for chronological ordering than the
             # auto-incremented primary key.

--- a/teams/team_orchestrator.py
+++ b/teams/team_orchestrator.py
@@ -97,7 +97,6 @@ class TeamOrchestrator:
         if self._conversation_db_id is None:
             raise RuntimeError("Conversation database id not initialised")
         repo.add(
-            conversation_id=conversation_id,
             conversation_db_id=self._conversation_db_id,
             user_id=user_id,
             role="user",
@@ -163,7 +162,6 @@ class TeamOrchestrator:
 
         # Persist the assistant's reply as the last turn in the conversation.
         repo.add(
-            conversation_id=conversation_id,
             conversation_db_id=self._conversation_db_id,
             user_id=user_id,
             role="assistant",
@@ -206,7 +204,6 @@ class TeamOrchestrator:
             if self._conversation_db_id is None:
                 raise RuntimeError("Conversation database id not initialised")
             repo.add(
-                conversation_id=conversation_id,
                 conversation_db_id=self._conversation_db_id,
                 user_id=user_id,
                 role=name,

--- a/tests/test_conversation_message_repository.py
+++ b/tests/test_conversation_message_repository.py
@@ -25,7 +25,6 @@ def test_add_and_list_messages_with_int_conversation_id():
 
         repo = ConversationMessageRepository(session)
         repo.add(
-            conversation_id=conv.conversation_id,
             conversation_db_id=conv.id,
             user_id=user.id,
             role="user",


### PR DESCRIPTION
## Summary
- remove redundant `conversation_id` parameter from `ConversationMessageRepository.add`
- adjust orchestrator and tests to match new signature
- clarify docstring to reference `conversation_db_id`

## Testing
- `pytest tests/test_conversation_message_repository.py`
- `mypy conversation_service/message_repository.py teams/team_orchestrator.py tests/test_conversation_message_repository.py` *(fails: missing stubs and type errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68a7fbf223ec8320902b006297d01691