### PR TITLE
Batch persist conversation turns and refactor team orchestrator

### DIFF
--- a/conversation_service/core/conversation_service.py
+++ b/conversation_service/core/conversation_service.py
@@ -1,0 +1,51 @@
+"""Utilities for persisting conversation turns."""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Tuple
+
+from sqlalchemy.orm import Session
+
+from conversation_service.message_repository import ConversationMessageRepository
+
+__all__ = ["save_conversation_turn"]
+
+
+def save_conversation_turn(
+    db: Session,
+    *,
+    conversation_db_id: int,
+    user_id: int,
+    user_message: str,
+    agent_messages: Iterable[Tuple[str, str]],
+    assistant_reply: str,
+) -> None:
+    """Persist a full turn of a conversation.
+
+    Parameters
+    ----------
+    db:
+        SQLAlchemy session used for persistence.
+    conversation_db_id:
+        Database identifier of the conversation.
+    user_id:
+        Identifier of the user owning the conversation.
+    user_message:
+        The message sent by the user.
+    agent_messages:
+        Iterable of ``(role, content)`` pairs representing intermediate agent
+        outputs produced while handling the user's message.
+    assistant_reply:
+        Final reply returned to the user.
+    """
+
+    repo = ConversationMessageRepository(db)
+    messages: List[Tuple[str, str]] = [("user", user_message)]
+    messages.extend(agent_messages)
+    messages.append(("assistant", assistant_reply))
+    repo.add_batch(
+        conversation_db_id=conversation_db_id,
+        user_id=user_id,
+        messages=messages,
+    )
+    db.commit()

--- a/teams/team_orchestrator.py
+++ b/teams/team_orchestrator.py
@@ -8,7 +8,7 @@ import json
 import logging
 import time
 import uuid
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import sqlalchemy
 from sqlalchemy.orm import Session
@@ -27,6 +27,7 @@ from conversation_service.agents.response_generator_agent import (
     ResponseGeneratorAgent,
 )
 from conversation_service.core.metrics_collector import metrics_collector
+from conversation_service.core.conversation_service import save_conversation_turn
 from conversation_service.message_repository import ConversationMessageRepository
 from conversation_service.models.conversation_models import ConversationMessage
 from conversation_service.repository import ConversationRepository
@@ -81,6 +82,9 @@ class TeamOrchestrator:
     async def query_agents(
         self, conversation_id: str, message: str, user_id: int, db: Session
     ) -> str:
+        if not message.strip():
+            raise ValueError("message must not be empty")
+
         start = time.time()
         history_models = self.get_history(conversation_id, db) or []
         ctx: Dict[str, Any] = {
@@ -88,17 +92,7 @@ class TeamOrchestrator:
             "history": [m.model_dump() for m in history_models],
         }
 
-        repo = ConversationMessageRepository(db)
-        # Store the incoming user message so that subsequent calls have access to
-        # the full conversation history.
-        if self._conversation_db_id is None:
-            raise RuntimeError("Conversation database id not initialised")
-        repo.add(
-            conversation_db_id=self._conversation_db_id,
-            user_id=user_id,
-            role="user",
-            content=message,
-        )
+        agent_messages: List[Tuple[str, str]] = []
 
         self._total_calls += 1
         success = True
@@ -106,47 +100,39 @@ class TeamOrchestrator:
             tasks = []
             if self._classifier is not None:
                 tasks.append(
-                    self._call_agent(
+                    self._call_agent_safe(
                         self._classifier,
                         {"user_message": message},
                         ctx,
-                        repo,
-                        conversation_id,
-                        user_id,
+                        agent_messages,
                     )
                 )
             if self._extractor is not None:
                 tasks.append(
-                    self._call_agent(
+                    self._call_agent_safe(
                         self._extractor,
                         {"user_message": message},
                         ctx,
-                        repo,
-                        conversation_id,
-                        user_id,
+                        agent_messages,
                     )
                 )
             if tasks:
                 await asyncio.gather(*tasks)
 
-            ctx = await self._call_agent(
+            ctx = await self._call_agent_safe(
                 self._query_agent,
                 {
                     "intent": ctx.get("intent"),
                     "entities": ctx.get("entities"),
                 },
                 ctx,
-                repo,
-                conversation_id,
-                user_id,
+                agent_messages,
             )
-            ctx = await self._call_agent(
+            ctx = await self._call_agent_safe(
                 self._responder,
                 {"search_response": ctx.get("search_response")},
                 ctx,
-                repo,
-                conversation_id,
-                user_id,
+                agent_messages,
             )
             reply = ctx.get("response", "")
         except Exception:  # pragma: no cover - defensive
@@ -157,12 +143,16 @@ class TeamOrchestrator:
                 "Désolé, une erreur est survenue lors du traitement de votre demande."
             )
 
-        # Persist the assistant's reply as the last turn in the conversation.
-        repo.add(
+        if self._conversation_db_id is None:
+            raise RuntimeError("Conversation database id not initialised")
+
+        save_conversation_turn(
+            db,
             conversation_db_id=self._conversation_db_id,
             user_id=user_id,
-            role="assistant",
-            content=reply,
+            user_message=message,
+            agent_messages=agent_messages,
+            assistant_reply=reply,
         )
 
         duration = (time.time() - start) * 1000
@@ -172,43 +162,40 @@ class TeamOrchestrator:
         self.context = dict(ctx)
         return reply
 
-    async def _call_agent(
+    async def _call_agent_safe(
         self,
         agent: Optional[Any],
         payload: Dict[str, Any],
         context: Dict[str, Any],
-        repo: ConversationMessageRepository,
-        conversation_id: str,
-        user_id: int,
+        messages: List[Tuple[str, str]],
     ) -> Dict[str, Any]:
         if agent is None:
             return context
 
         payload["context"] = context
         start = time.time()
-        response = await agent.process(payload)  # type: ignore[call-arg]
-        duration_ms = int((time.time() - start) * 1000)
-
-        result: Dict[str, Any]
-        if hasattr(response, "result"):
-            result = response.result  # type: ignore[attr-defined]
-        else:
-            result = response or {}
-
-        context.update(result)
         name = getattr(agent, "name", agent.__class__.__name__)
-        if result:
-            if self._conversation_db_id is None:
-                raise RuntimeError("Conversation database id not initialised")
-            repo.add(
-                conversation_db_id=self._conversation_db_id,
-                user_id=user_id,
-                role=name,
-                content=json.dumps(result, ensure_ascii=False),
-            )
+        try:
+            response = await agent.process(payload)  # type: ignore[call-arg]
+            result: Dict[str, Any]
+            if hasattr(response, "result"):
+                result = response.result  # type: ignore[attr-defined]
+            else:
+                result = response or {}
+            context.update(result)
+            if result:
+                messages.append(
+                    (name, json.dumps(result, ensure_ascii=False))
+                )
+            success = True
+        except Exception:
+            result = {}
+            success = False
+            logger.exception("Agent %s failed", name)
 
+        duration_ms = int((time.time() - start) * 1000)
         await self._metrics.record_agent_call(
-            agent_name=name, success=True, processing_time_ms=duration_ms
+            agent_name=name, success=success, processing_time_ms=duration_ms
         )
         return context
 

--- a/tests/test_conversation_service_core.py
+++ b/tests/test_conversation_service_core.py
@@ -1,0 +1,64 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from db_service.base import Base
+from db_service.models.conversation import Conversation
+from db_service.models.user import User
+
+from conversation_service.core.conversation_service import save_conversation_turn
+from conversation_service.message_repository import ConversationMessageRepository
+from teams.team_orchestrator import TeamOrchestrator
+
+
+def _setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return Session
+
+
+def test_save_conversation_turn_persists_messages():
+    Session = _setup_db()
+    with Session() as session:
+        user = User(email="u@example.com", password_hash="x")
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+
+        conv = Conversation(user_id=user.id, conversation_id="conv1")
+        session.add(conv)
+        session.commit()
+        session.refresh(conv)
+
+        save_conversation_turn(
+            session,
+            conversation_db_id=conv.id,
+            user_id=user.id,
+            user_message="hello",
+            agent_messages=[("agent", "{}")],
+            assistant_reply="hi",
+        )
+
+        repo = ConversationMessageRepository(session)
+        messages = repo.list_by_conversation("conv1")
+        assert [m.role for m in messages] == ["user", "agent", "assistant"]
+        assert messages[0].content == "hello"
+        assert messages[2].content == "hi"
+
+
+@pytest.mark.asyncio
+async def test_query_agents_empty_message_raises_value_error():
+    Session = _setup_db()
+    with Session() as session:
+        user = User(email="u@example.com", password_hash="x")
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+
+        orchestrator = TeamOrchestrator()
+        conv_id = orchestrator.start_conversation(user.id, session)
+
+        with pytest.raises(ValueError):
+            await orchestrator.query_agents(conv_id, "", user.id, session)
+


### PR DESCRIPTION
## Summary
- Add `add_batch` to `ConversationMessageRepository` for grouped inserts
- Introduce `save_conversation_turn` service to commit user, agent, and assistant messages together
- Refactor `TeamOrchestrator` to buffer agent outputs, validate empty user messages, and use safe agent calls
- Cover new service and validation with tests

## Testing
- `pytest tests/test_conversation_message_repository.py tests/test_conversation_service_core.py -q`
- `pytest -q` *(fails: REDIS_URL environment variable missing; AttributeError: module 'httpx' has no attribute 'Response')*

------
https://chatgpt.com/codex/tasks/task_e_68a8013f23c883209e2f215f279414cf