### PR TITLE
Ensure atomic conversation turn persistence

### DIFF
--- a/conversation_service/models/conversation_models.py
+++ b/conversation_service/models/conversation_models.py
@@ -46,6 +46,24 @@ class AgentQueryResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class MessageCreate(BaseModel):
+    """Input model for creating a conversation message."""
+
+    role: Literal["user", "assistant"] = Field(
+        ..., description="Role of the message author"
+    )
+    content: str = Field(..., description="Message content")
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("content")
+    @classmethod
+    def validate_content(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("content must not be empty")
+        return v
+
+
 class ConversationMessage(BaseModel):
     """Single message persisted in the conversation history."""
 

--- a/conversation_service/service.py
+++ b/conversation_service/service.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+from conversation_service.message_repository import ConversationMessageRepository
+from conversation_service.models.conversation_models import MessageCreate
+
+
+class ConversationService:
+    """High level operations for conversations."""
+
+    def __init__(self, repo: ConversationMessageRepository) -> None:
+        self._repo = repo
+
+    def save_conversation_turn(
+        self,
+        *,
+        conversation_db_id: int,
+        user_id: int,
+        messages: Sequence[MessageCreate],
+    ) -> None:
+        """Persist a full conversation turn atomically.
+
+        Parameters
+        ----------
+        conversation_db_id:
+            Database identifier of the conversation.
+        user_id:
+            Identifier of the user owning the conversation.
+        messages:
+            Sequence of messages belonging to the turn, typically a user
+            message followed by the assistant response.
+        """
+
+        self._repo.add_batch(
+            conversation_db_id=conversation_db_id,
+            user_id=user_id,
+            messages=messages,
+        )
+
+
+__all__ = ["ConversationService"]

--- a/tests/test_conversation_message_repository.py
+++ b/tests/test_conversation_message_repository.py
@@ -1,3 +1,4 @@
+import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -5,6 +6,7 @@ from db_service.base import Base
 from db_service.models.conversation import Conversation
 from db_service.models.user import User
 from conversation_service.message_repository import ConversationMessageRepository
+from conversation_service.models.conversation_models import MessageCreate
 
 
 def test_add_and_list_messages_with_int_conversation_id():
@@ -35,3 +37,111 @@ def test_add_and_list_messages_with_int_conversation_id():
         assert len(messages) == 1
         assert messages[0].conversation_id == conv.conversation_id
         assert messages[0].content == "hello"
+
+
+def test_add_raises_on_invalid_ids():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+
+    with Session() as session:
+        user = User(email="u@example.com", password_hash="x")
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+
+        repo = ConversationMessageRepository(session)
+        with pytest.raises(ValueError):
+            repo.add(
+                conversation_db_id=0,
+                user_id=user.id,
+                role="user",
+                content="hi",
+            )
+
+
+def test_add_raises_on_empty_content():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+
+    with Session() as session:
+        user = User(email="u@example.com", password_hash="x")
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+
+        conv = Conversation(user_id=user.id, conversation_id="c1")
+        session.add(conv)
+        session.commit()
+        session.refresh(conv)
+
+        repo = ConversationMessageRepository(session)
+        with pytest.raises(ValueError):
+            repo.add(
+                conversation_db_id=conv.id,
+                user_id=user.id,
+                role="user",
+                content=" ",
+            )
+
+
+def test_add_batch_inserts_messages_atomically():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+
+    with Session() as session:
+        user = User(email="u@example.com", password_hash="x")
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+
+        conv = Conversation(user_id=user.id, conversation_id="c1")
+        session.add(conv)
+        session.commit()
+        session.refresh(conv)
+
+        repo = ConversationMessageRepository(session)
+        repo.add_batch(
+            conversation_db_id=conv.id,
+            user_id=user.id,
+            messages=[
+                MessageCreate(role="user", content="hi"),
+                MessageCreate(role="assistant", content="hello"),
+            ],
+        )
+
+        messages = repo.list_models(conv.conversation_id)
+        assert [m.role for m in messages] == ["user", "assistant"]
+
+
+def test_add_batch_rolls_back_on_failure():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+
+    with Session() as session:
+        user = User(email="u@example.com", password_hash="x")
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+
+        conv = Conversation(user_id=user.id, conversation_id="c1")
+        session.add(conv)
+        session.commit()
+        session.refresh(conv)
+
+        repo = ConversationMessageRepository(session)
+        with pytest.raises(ValueError):
+            repo.add_batch(
+                conversation_db_id=conv.id,
+                user_id=user.id,
+                messages=[
+                    MessageCreate(role="user", content="hi"),
+                    MessageCreate(role="assistant", content=""),
+                ],
+            )
+
+        messages = repo.list_models(conv.conversation_id)
+        assert messages == []

--- a/tests/test_conversation_service.py
+++ b/tests/test_conversation_service.py
@@ -1,0 +1,72 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from db_service.base import Base
+from db_service.models.conversation import Conversation
+from db_service.models.user import User
+from conversation_service.message_repository import ConversationMessageRepository
+from conversation_service.models.conversation_models import MessageCreate
+from conversation_service.service import ConversationService
+
+
+def _setup_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)
+
+
+def test_save_conversation_turn_persists_all_messages():
+    Session = _setup_session()
+    with Session() as session:
+        user = User(email="u@example.com", password_hash="x")
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+
+        conv = Conversation(user_id=user.id, conversation_id="c1")
+        session.add(conv)
+        session.commit()
+        session.refresh(conv)
+
+        repo = ConversationMessageRepository(session)
+        svc = ConversationService(repo)
+        svc.save_conversation_turn(
+            conversation_db_id=conv.id,
+            user_id=user.id,
+            messages=[
+                MessageCreate(role="user", content="hi"),
+                MessageCreate(role="assistant", content="hello"),
+            ],
+        )
+
+        messages = repo.list_models(conv.conversation_id)
+        assert [m.role for m in messages] == ["user", "assistant"]
+
+
+def test_save_conversation_turn_rolls_back_on_failure():
+    Session = _setup_session()
+    with Session() as session:
+        user = User(email="u@example.com", password_hash="x")
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+
+        conv = Conversation(user_id=user.id, conversation_id="c1")
+        session.add(conv)
+        session.commit()
+        session.refresh(conv)
+
+        repo = ConversationMessageRepository(session)
+        svc = ConversationService(repo)
+        with pytest.raises(ValueError):
+            svc.save_conversation_turn(
+                conversation_db_id=conv.id,
+                user_id=user.id,
+                messages=[
+                    MessageCreate(role="user", content="hi"),
+                    MessageCreate(role="assistant", content=""),
+                ],
+            )
+
+        assert repo.list_models(conv.conversation_id) == []

--- a/tests/test_team_orchestrator_query_agents.py
+++ b/tests/test_team_orchestrator_query_agents.py
@@ -1,0 +1,57 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from db_service.base import Base
+from db_service.models.user import User
+from conversation_service.message_repository import ConversationMessageRepository
+from teams.team_orchestrator import TeamOrchestrator
+
+
+class DummyResponder:
+    name = "dummy_responder"
+
+    async def process(self, payload):
+        return {"response": "pong"}
+
+
+@pytest.mark.asyncio
+async def test_query_agents_saves_full_turn():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+
+    with Session() as session:
+        user = User(email="u@example.com", password_hash="x")
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+
+        team = TeamOrchestrator(responder=DummyResponder())
+        conv_id = team.start_conversation(user.id, session)
+        await team.query_agents(conv_id, "ping", user.id, session)
+
+        repo = ConversationMessageRepository(session)
+        roles = [m.role for m in repo.list_models(conv_id)]
+        assert roles == ["user", "assistant"]
+
+
+@pytest.mark.asyncio
+async def test_query_agents_rollback_on_save_failure():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+
+    with Session() as session:
+        user = User(email="u@example.com", password_hash="x")
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+
+        team = TeamOrchestrator(responder=DummyResponder())
+        conv_id = team.start_conversation(user.id, session)
+        with pytest.raises(ValueError):
+            await team.query_agents(conv_id, "", user.id, session)
+
+        repo = ConversationMessageRepository(session)
+        assert repo.list_models(conv_id) == []


### PR DESCRIPTION
## Summary
- Add `MessageCreate` model with Pydantic validation for conversation messages.
- Support atomic batch insertion and ID/content validation in `ConversationMessageRepository`.
- Introduce `ConversationService` and integrate with `TeamOrchestrator` for transaction-safe conversation turns.
- Expand repository, service, and orchestrator tests for rollback and failure scenarios.

## Testing
- `pytest tests/test_conversation_message_repository.py tests/test_conversation_service.py tests/test_team_orchestrator_query_agents.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a8014968948320b3b465e7c21a8174