### PR TITLE
Add contextual error logging to conversation routes

### DIFF
--- a/conversation_service/api/routes.py
+++ b/conversation_service/api/routes.py
@@ -1,7 +1,8 @@
-from __future__ import annotations
-
 """REST endpoints for conversation service."""
 
+from __future__ import annotations
+
+import logging
 from datetime import datetime
 
 from fastapi import APIRouter, HTTPException, Depends
@@ -20,6 +21,8 @@ from ..models.conversation_models import (
 from conversation_service.repository import ConversationRepository
 from teams.team_orchestrator import TeamOrchestrator
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(tags=["conversation"])
 
 orchestrator = TeamOrchestrator()
@@ -30,28 +33,54 @@ async def start_conversation(
     current_user: User = Depends(get_current_active_user),
     db: Session = Depends(get_db),
 ) -> ConversationStartResponse:
-    """Create a new conversation session for the authenticated user."""
+    """Create a new conversation session for the authenticated user.
+
+    Args:
+        current_user: Authenticated user associated with the request.
+        db: Database session dependency.
+
+    Returns:
+        ConversationStartResponse containing the new conversation identifier.
+    """
     conv_id = orchestrator.start_conversation(current_user.id, db)
     return ConversationStartResponse(
         conversation_id=conv_id, created_at=datetime.utcnow()
     )
 
 
-@router.get(
-    "/{conversation_id}/history", response_model=ConversationHistoryResponse
-)
+@router.get("/{conversation_id}/history", response_model=ConversationHistoryResponse)
 async def get_history(
     conversation_id: str,
     current_user: User = Depends(get_current_active_user),
     db: Session = Depends(get_db),
 ) -> ConversationHistoryResponse:
-    """Return the message history for a conversation."""
+    """Return the message history for a conversation.
+
+    Args:
+        conversation_id: Identifier of the conversation to retrieve history for.
+        current_user: Authenticated user associated with the request.
+        db: Database session dependency.
+
+    Returns:
+        ConversationHistoryResponse containing the conversation history.
+
+    Raises:
+        HTTPException: If the conversation does not exist for the user.
+    """
     repo = ConversationRepository(db)
     conv = repo.get_by_conversation_id(conversation_id)
     if conv is None or conv.user_id != current_user.id:
+        logger.error(
+            "Conversation not found",
+            extra={"conversation_id": conversation_id, "user_id": current_user.id},
+        )
         raise HTTPException(status_code=404, detail="Conversation not found")
     history = orchestrator.get_history(conversation_id, db)
     if history is None:
+        logger.error(
+            "Conversation history not found",
+            extra={"conversation_id": conversation_id, "user_id": current_user.id},
+        )
         raise HTTPException(status_code=404, detail="Conversation not found")
     return ConversationHistoryResponse(
         conversation_id=conversation_id, messages=history
@@ -65,10 +94,27 @@ async def query_agents(
     current_user: User = Depends(get_current_active_user),
     db: Session = Depends(get_db),
 ) -> AgentQueryResponse:
-    """Send a message to the agent team and return their response."""
+    """Send a message to the agent team and return their response.
+
+    Args:
+        conversation_id: Identifier of the conversation being queried.
+        payload: Request payload containing the message to send.
+        current_user: Authenticated user associated with the request.
+        db: Database session dependency.
+
+    Returns:
+        AgentQueryResponse with the agent team's reply.
+
+    Raises:
+        HTTPException: If the conversation does not exist for the user.
+    """
     repo = ConversationRepository(db)
     conv = repo.get_by_conversation_id(conversation_id)
     if conv is None or conv.user_id != current_user.id:
+        logger.error(
+            "Conversation not found",
+            extra={"conversation_id": conversation_id, "user_id": current_user.id},
+        )
         raise HTTPException(status_code=404, detail="Conversation not found")
     reply = await orchestrator.query_agents(
         conversation_id, payload.message, current_user.id, db


### PR DESCRIPTION
## Summary
- log conversation service errors with `conversation_id` and `user_id`
- document conversation endpoints and add structured logger

## Testing
- `ruff check conversation_service/api/routes.py`
- `black conversation_service/api/routes.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68a8014d74cc832090646b0e75ed2119