### PR TITLE
Use transactions for conversation creation

### DIFF
--- a/conversation_service/repository.py
+++ b/conversation_service/repository.py
@@ -16,7 +16,10 @@ class ConversationRepository:
     def create(self, user_id: int, conversation_id: str) -> Conversation:
         conv = Conversation(user_id=user_id, conversation_id=conversation_id)
         self._db.add(conv)
-        self._db.commit()
+        # Flush the session so that an ID is assigned without committing the
+        # transaction.  The surrounding service is responsible for committing
+        # or rolling back the unit of work.
+        self._db.flush()
         self._db.refresh(conv)
         return conv
 

--- a/teams/team_orchestrator.py
+++ b/teams/team_orchestrator.py
@@ -227,7 +227,12 @@ class TeamOrchestrator:
         """
 
         conv_id = uuid.uuid4().hex
-        conv = ConversationRepository(db).create(user_id, conv_id)
+        # Use an explicit transaction so that higher-level services control
+        # when the session is committed.  This mirrors the approach used for
+        # message persistence.
+        with db.begin():
+            conv = ConversationRepository(db).create(user_id, conv_id)
+
         try:
             history = ConversationMessageRepository(db).list_models(conv_id)
         except sqlalchemy.exc.ProgrammingError:

--- a/tests/test_agents/test_agent_imports.py
+++ b/tests/test_agents/test_agent_imports.py
@@ -1,4 +1,6 @@
 import importlib
+import sys
+import types
 import pytest
 
 MODULES = [
@@ -14,6 +16,50 @@ MODULES = [
 
 @pytest.mark.parametrize("module_name, symbols", MODULES)
 def test_agent_modules_expose_symbols(module_name, symbols):
+    if module_name == "conversation_service.agents.query_generator_agent":
+        # Provide minimal stubs so that the module can be imported without the
+        # real HTTP and OpenAI dependencies present in production.
+        clients_pkg = types.ModuleType("conversation_service.clients")
+        clients_pkg.__path__ = []  # type: ignore[attr-defined]
+        sys.modules.setdefault("conversation_service.clients", clients_pkg)
+
+        openai_client_module = types.ModuleType(
+            "conversation_service.clients.openai_client"
+        )
+        openai_client_module.OpenAIClient = object
+        search_client_module = types.ModuleType(
+            "conversation_service.clients.search_client"
+        )
+        search_client_module.SearchClient = object
+        cache_client_module = types.ModuleType(
+            "conversation_service.clients.cache_client"
+        )
+        cache_client_module.CacheClient = object
+
+        sys.modules.setdefault(
+            "conversation_service.clients.openai_client", openai_client_module
+        )
+        sys.modules.setdefault(
+            "conversation_service.clients.search_client", search_client_module
+        )
+        sys.modules.setdefault(
+            "conversation_service.clients.cache_client", cache_client_module
+        )
+
+        clients_pkg.OpenAIClient = openai_client_module.OpenAIClient
+        clients_pkg.SearchClient = search_client_module.SearchClient
+        clients_pkg.CacheClient = cache_client_module.CacheClient
+
+        sys.modules.setdefault("openai", types.SimpleNamespace(AsyncOpenAI=object))
+        sys.modules.setdefault(
+            "aiohttp",
+            types.SimpleNamespace(
+                ClientSession=object,
+                ClientTimeout=lambda *args, **kwargs: None,
+                ClientError=Exception,
+            ),
+        )
+
     module = importlib.import_module(module_name)
     for symbol in symbols:
         assert hasattr(module, symbol)

--- a/tests/test_agents/test_query_optimizer.py
+++ b/tests/test_agents/test_query_optimizer.py
@@ -76,9 +76,12 @@ class QueryType(str, Enum):
 core_models.QueryType = QueryType
 
 
-from conversation_service.agents.query_generator_agent import QueryOptimizer
+import importlib
+import conversation_service.agents.query_generator_agent as qga
+importlib.reload(qga)
 from conversation_service.models.core_models import IntentType
-from conversation_service.agents.query_generator_agent import QueryGeneratorAgent
+QueryOptimizer = qga.QueryOptimizer
+QueryGeneratorAgent = qga.QueryGeneratorAgent
 
 
 def test_query_optimizer_applies_merchant_rule():


### PR DESCRIPTION
## Summary
- Avoid committing in `ConversationRepository.create`; flush and let caller manage transactions
- Start conversations within an explicit transaction in `TeamOrchestrator`
- Adjust agent tests to stub optional dependencies and reload modules

## Testing
- `REDIS_URL=redis://localhost:6379/0 pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8014e8f6c8320882d0b274b4aaedc