### PR TITLE
feat: add transactional message repository

### DIFF
--- a/conversation_service/message_repository.py
+++ b/conversation_service/message_repository.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import logging
 from contextlib import contextmanager
 from typing import List, Sequence
-from typing import Iterable, List, Sequence
 
 from sqlalchemy.orm import Session
 
@@ -18,11 +17,25 @@ from conversation_service.models.conversation_models import (
 )
 
 
+logger = logging.getLogger(__name__)
+
+
 class ConversationMessageRepository:
     """Handle CRUD operations for :class:`ConversationMessage`."""
 
     def __init__(self, db: Session) -> None:
         self._db = db
+
+    @contextmanager
+    def transaction(self):
+        """Context manager to commit or roll back the current session."""
+        try:
+            yield
+            self._db.commit()
+        except Exception:
+            logger.exception("Transaction failed")
+            self._db.rollback()
+            raise
 
     def add_batch(
         self,
@@ -59,22 +72,6 @@ class ConversationMessageRepository:
                 instances.append(msg)
 
         return instances
-        """Persist multiple messages without committing the transaction."""
-
-        objs = [
-            ConversationMessageDB(
-                conversation_id=conversation_db_id,
-                user_id=user_id,
-                role=m.role,
-                content=m.content,
-            )
-            for m in messages
-        ]
-        self._db.add_all(objs)
-        self._db.flush()
-        for obj in objs:
-            self._db.refresh(obj)
-        return objs
 
     def list_by_conversation(self, conversation_id: str) -> List[ConversationMessageDB]:
         """Return ORM messages for ``conversation_id`` ordered chronologically."""
@@ -101,6 +98,21 @@ class ConversationMessageRepository:
             for m in self.list_by_conversation(conversation_id)
             if m.role in {"user", "assistant"}
         ]
+
+    def _validate(
+        self,
+        *,
+        conversation_db_id: int,
+        user_id: int,
+        content: str,
+    ) -> None:
+        """Validate message content and identifiers.
+
+        Currently ensures that the message content is not empty. Additional
+        domain-specific validation can be added here.
+        """
+        if not content.strip():
+            raise ValueError("content must not be empty")
 
 
 __all__ = ["ConversationMessageRepository"]


### PR DESCRIPTION
## Summary
- add transaction context manager with commit and rollback for conversation messages
- wrap batch message insertions in the transactional context
- test message repository success path and rollback with logged errors

## Testing
- `pytest tests/test_message_repository.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a80c7b4e408320980b345597494c25