### PR TITLE
feat: add atomic conversation turn save

### DIFF
--- a/tests/test_conversation_service.py
+++ b/tests/test_conversation_service.py
@@ -63,6 +63,32 @@ def test_save_conversation_turn_persists_all_messages():
         assert conv.total_turns == 1
 
 
+def test_save_conversation_turn_alias_calls_atomic():
+    Session = _setup_session()
+    with Session() as session:
+        user = User(email="u@example.com", password_hash="x")
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+
+        conv = Conversation(user_id=user.id, conversation_id="c1")
+        session.add(conv)
+        session.commit()
+        session.refresh(conv)
+
+        svc = ConversationService(session)
+
+        svc.save_conversation_turn(
+            conversation=conv,
+            user_message="hi",
+            assistant_reply="hello",
+        )
+
+        msgs = ConversationMessageRepository(session).list_models(conv.conversation_id)
+        assert [m.role for m in msgs] == ["user", "assistant"]
+        session.refresh(conv)
+        assert conv.total_turns == 1
+
 def test_save_conversation_turn_rolls_back_on_failure():
     Session = _setup_session()
     with Session() as session:


### PR DESCRIPTION
## Summary
- add save_conversation_turn_atomic to validate and persist conversation turns atomically
- expose save_conversation_turn as backward compatible alias
- cover alias with dedicated test

## Testing
- `pytest tests/test_conversation_service.py -q`
- `pytest -q` *(fails: IndentationError: expected an indented block after 'if' statement on line 54 in conversation_service/api/routes.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a81675ee488320b3581c6a50317519