### PR TITLE
Utilisation du ConversationService pour sauvegarder les tours

### DIFF
--- a/conversation_service/core/conversation_service.py
+++ b/conversation_service/core/conversation_service.py
@@ -32,6 +32,28 @@ class ConversationService:
         return conv
 
     # --- Persistence ----------------------------------------------------------
+    def save_conversation_turn(
+        self,
+        *,
+        conversation: Conversation,
+        user_message: str,
+        agent_messages: Iterable[Tuple[str, str]] = (),
+        assistant_reply: str,
+    ) -> None:
+        """Persist a complete conversation turn.
+
+        This method delegates to :meth:`save_conversation_turn_atomic` to
+        perform the actual database operations. It exists as a public API
+        that hides the implementation detail of atomic transactions.
+        """
+
+        self.save_conversation_turn_atomic(
+            conversation=conversation,
+            user_message=user_message,
+            agent_messages=agent_messages,
+            assistant_reply=assistant_reply,
+        )
+
     def save_conversation_turn_atomic(
         self,
         *,


### PR DESCRIPTION
## Summary
- Utilise `ConversationService.save_conversation_turn` pour persister un tour de conversation dans `TeamOrchestrator`
- Récupère l'historique via `ConversationService` et retire les imports inutiles
- Ajoute la méthode `save_conversation_turn` dans `ConversationService`

## Testing
- `pytest` *(échoue: IndentationError dans conversation_service/api/routes.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a816827974832098d9515f72ee702f