### PR TITLE
Refine conversation access validation

### DIFF
--- a/conversation_service/api/routes.py
+++ b/conversation_service/api/routes.py
@@ -19,8 +19,6 @@ from ..models.conversation_models import (
     ConversationStartResponse,
 )
 
-from conversation_service.repository import ConversationRepository
-
 from conversation_service.core.conversation_service import ConversationService
 from teams.team_orchestrator import TeamOrchestrator
 
@@ -52,22 +50,6 @@ async def get_history(
     """Return the message history for a conversation."""
     service = ConversationService(db)
     if service.get_for_user(conversation_id, current_user.id) is None:
-    """Return the message history for a conversation.
-
-    Args:
-        conversation_id: Identifier of the conversation to retrieve history for.
-        current_user: Authenticated user associated with the request.
-        db: Database session dependency.
-
-    Returns:
-        ConversationHistoryResponse containing the conversation history.
-
-    Raises:
-        HTTPException: If the conversation does not exist for the user.
-    """
-    repo = ConversationRepository(db)
-    conv = repo.get_by_conversation_id(conversation_id)
-    if conv is None or conv.user_id != current_user.id:
         logger.error(
             "Conversation not found",
             extra={"conversation_id": conversation_id, "user_id": current_user.id},
@@ -110,11 +92,7 @@ async def query_agents(
 ) -> AgentQueryResponse:
     """Send a message to the agent team and return their response."""
     service = ConversationService(db)
-    conv = service.get_for_user(conversation_id, current_user.id)
-    if conv is None:
-    repo = ConversationRepository(db)
-    conv = repo.get_by_conversation_id(conversation_id)
-    if conv is None or conv.user_id != current_user.id:
+    if service.get_for_user(conversation_id, current_user.id) is None:
         logger.error(
             "Conversation not found",
             extra={"conversation_id": conversation_id, "user_id": current_user.id},

--- a/tests/test_integration/test_conversation_api.py
+++ b/tests/test_integration/test_conversation_api.py
@@ -82,3 +82,28 @@ def test_get_history_unknown_conversation_returns_404(app_and_session):
     client = TestClient(app)
     resp = client.get("/conversation/unknown/history")
     assert resp.status_code == 404
+
+
+def test_get_history_foreign_conversation_returns_404(app_and_session):
+    app, SessionLocal, user = app_and_session
+    with SessionLocal() as session:
+        other = User(email="other@example.com", password_hash="x")
+        session.add(other)
+        session.commit()
+        session.refresh(other)
+        conv = ConversationRepository(session).create(other.id, "c2")
+        session.commit()
+        conv_id = conv.conversation_id
+
+    client = TestClient(app)
+    resp = client.get(f"/conversation/{conv_id}/history")
+    assert resp.status_code == 404
+
+
+def test_query_unknown_conversation_returns_404(app_and_session):
+    app, _, _ = app_and_session
+    client = TestClient(app)
+    resp = client.post(
+        "/conversation/unknown/query", json={"message": "hi"}
+    )
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- rely on `ConversationService.get_for_user` to authorize conversation access
- return `HTTPException(404)` when conversation is missing
- cover access checks in integration tests

## Testing
- `pytest tests/test_integration/test_conversation_api.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a819080b088320a17c66b291b376cf