### PR TITLE
feat: re-export conversation service core modules

### DIFF
--- a/conversation_service/api/routes.py
+++ b/conversation_service/api/routes.py
@@ -20,7 +20,7 @@ from ..models.conversation_models import (
     ConversationStartResponse,
 )
 
-from conversation_service.core.conversation_service import ConversationService
+from conversation_service.core import ConversationService
 from teams.team_orchestrator import TeamOrchestrator
 
 logger = logging.getLogger(__name__)

--- a/conversation_service/core/README.md
+++ b/conversation_service/core/README.md
@@ -1,0 +1,20 @@
+# Conversation Service Core
+
+This directory contains the core components that power the conversation
+service such as the high level ``ConversationService`` and the
+database ``transaction_manager`` helper.
+
+These modules are specific to the conversation domain.  Generic helpers
+shared by multiple services live in the top-level `core/` package and are
+intentionally kept separate to avoid circular dependencies and to provide
+clearer boundaries between shared utilities and service-specific logic.
+
+Projects importing conversation-related primitives should use the
+re-exported classes from this package:
+
+```python
+from conversation_service.core import ConversationService
+```
+
+This keeps the service's public API explicit while retaining a clean
+separation from the shared `core/` helpers.

--- a/conversation_service/core/__init__.py
+++ b/conversation_service/core/__init__.py
@@ -1,0 +1,15 @@
+"""Core utilities for the conversation service.
+
+This package houses the core conversation persistence primitives and
+transaction helpers used by the conversation service.  It re-exports the
+primary entry points for convenience.
+
+The top-level :mod:`core` package contains shared utilities that are used
+across multiple services.  Those modules remain untouched here to keep a
+clear separation between generic helpers and conversation-specific logic.
+"""
+
+from .conversation_service import ConversationService
+from .transaction_manager import transaction_manager
+
+__all__ = ["ConversationService", "transaction_manager"]

--- a/teams/team_orchestrator.py
+++ b/teams/team_orchestrator.py
@@ -22,7 +22,7 @@ from conversation_service.agents.query_generator_agent import (
 from conversation_service.agents.response_generator_agent import (
     ResponseGeneratorAgent,
 )
-from conversation_service.core.conversation_service import ConversationService
+from conversation_service.core import ConversationService
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_conversation_integration.py
+++ b/tests/test_conversation_integration.py
@@ -4,7 +4,7 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from conversation_service.core.conversation_service import ConversationService
+from conversation_service.core import ConversationService
 from conversation_service.message_repository import ConversationMessageRepository
 from db_service.base import Base
 from db_service.models.conversation import Conversation, ConversationMessage

--- a/tests/test_conversation_service.py
+++ b/tests/test_conversation_service.py
@@ -9,7 +9,7 @@ from db_service.models.conversation import (
 )
 from db_service.models.user import User
 
-from conversation_service.core.conversation_service import ConversationService
+from conversation_service.core import ConversationService
 from conversation_service.message_repository import ConversationMessageRepository
 
 

--- a/tests/test_conversation_transactions.py
+++ b/tests/test_conversation_transactions.py
@@ -6,7 +6,7 @@ from psycopg2.errors import InFailedSqlTransaction
 from db_service.base import Base
 from db_service.models.conversation import Conversation, ConversationMessage
 from db_service.models.user import User
-from conversation_service.core.conversation_service import ConversationService
+from conversation_service.core import ConversationService
 from conversation_service.message_repository import ConversationMessageRepository
 from conversation_service.repository import ConversationRepository
 from teams.team_orchestrator import TeamOrchestrator

--- a/tests/test_team_orchestrator_query_agents.py
+++ b/tests/test_team_orchestrator_query_agents.py
@@ -8,7 +8,7 @@ from db_service.base import Base
 from db_service.models.user import User
 from conversation_service.message_repository import ConversationMessageRepository
 from teams.team_orchestrator import TeamOrchestrator
-from conversation_service.core.conversation_service import ConversationService
+from conversation_service.core import ConversationService
 
 
 class DummyResponder:


### PR DESCRIPTION
## Summary
- expose ConversationService and transaction_manager via conversation_service.core
- update imports to use conversation_service.core re-export
- document separation between shared `core/` utilities and conversation service core

## Testing
- `pytest tests/test_conversation_service.py tests/test_conversation_transactions.py tests/test_team_orchestrator_query_agents.py tests/test_conversation_integration.py` *(fails: NameError and other errors)*


------
https://chatgpt.com/codex/tasks/task_e_68a82d36f9a08320856d4a4409fd4b8c