### PR TITLE
fix autogen config naming

### DIFF
--- a/conversation_service/api/dependencies.py
+++ b/conversation_service/api/dependencies.py
@@ -10,7 +10,7 @@ from typing import Optional
 from fastapi import HTTPException, WebSocket, status
 
 from ..clients import CacheClient, OpenAIClient, SearchClient
-from config.autogen_config import AutogenConfig, autogen_settings
+from config.autogen_config import AutoGenConfig, autogen_settings
 from config_service.config import settings
 from openai_config import openai_config
 
@@ -73,7 +73,7 @@ async def get_cache_client() -> CacheClient:
     return _cache_client
 
 
-def get_autogen_config() -> AutogenConfig:
+def get_autogen_config() -> AutoGenConfig:
     """Provide AutoGen configuration settings."""
 
     return autogen_settings

--- a/tests/test_conversation_service_dependencies_import.py
+++ b/tests/test_conversation_service_dependencies_import.py
@@ -49,10 +49,10 @@ sys.modules.setdefault("fastapi", fastapi_module)
 config_pkg = types.ModuleType("config")
 config_pkg.__path__ = []  # mark as package
 autogen_mod = types.ModuleType("config.autogen_config")
-class AutogenConfig:  # simple placeholder
+class AutoGenConfig:  # simple placeholder
     pass
-autogen_settings = AutogenConfig()
-autogen_mod.AutogenConfig = AutogenConfig
+autogen_settings = AutoGenConfig()
+autogen_mod.AutoGenConfig = AutoGenConfig
 autogen_mod.autogen_settings = autogen_settings
 config_pkg.autogen_config = autogen_mod
 sys.modules.setdefault("config", config_pkg)


### PR DESCRIPTION
## Summary
- use `AutoGenConfig` in conversation service dependencies
- adjust test scaffolding to provide `AutoGenConfig`

## Testing
- `pytest tests/test_conversation_service_dependencies_import.py -q`
- `pytest -q` *(fails: ImportError: cannot import name 'autogen_settings' from 'config.autogen_config', ModuleNotFoundError: No module named 'psycopg2', ImportError: cannot import name 'APIRouter' from 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68a82ff989148320b210915965df50a0