### PR TITLE
Refactor TeamOrchestrator conversation start

### DIFF
--- a/conversation_service/teams/team_orchestrator.py
+++ b/conversation_service/teams/team_orchestrator.py
@@ -24,6 +24,7 @@ from conversation_service.agents.response_generator_agent import (
     ResponseGeneratorAgent,
 )
 from conversation_service.core import ConversationService
+from conversation_service.repository import ConversationRepository
 
 logger = logging.getLogger(__name__)
 
@@ -214,19 +215,17 @@ class TeamOrchestrator:
             raise
 
         service = self._conversation_service_cls(db)
-        conv = service.create_conversation(user_id)
-        history = service.list_history(conv.conversation_id)
+        history = service.list_history(conv_id)
 
         self.context = {
             "user_id": user_id,
             "history": [m.model_dump() for m in history],
         }
-        self._conversation_id = conv.conversation_id
         self._conversation_id = conv_id
         self._conversation_db_id = conv_db_id
         self._user_id = user_id
         self._db = db
-        return conv.conversation_id
+        return conv_id
 
     def get_history(
         self, conversation_id: str, db: Session


### PR DESCRIPTION
## Summary
- ensure conversation creation uses ConversationRepository as single ID source
- simplify start_conversation logic and set conversation id once
- add missing ConversationRepository import

## Testing
- `pytest tests/test_team_orchestrator_query_agents.py::test_query_agents_saves_full_turn -q` *(fails: ImportError: cannot import name 'MessageCreate' from 'conversation_service.models.conversation_models')*

------
https://chatgpt.com/codex/tasks/task_e_68a838f53e1c8320aefe2c0954fbd54c