### PR TITLE
Add core conversation models and agent config

### DIFF
--- a/conversation_service/agents/base_agent.py
+++ b/conversation_service/agents/base_agent.py
@@ -40,8 +40,8 @@ except Exception:  # pragma: no cover - dependency not available
     OpenAIClient = Any  # type: ignore
 
 # Local imports
-from ..models.agent_models import AgentConfig, AgentResponse
-from ..models.core_models import FinancialEntity
+from ..models.agent_models import AgentConfig
+from ..models.core_models import AgentResponse
 from ..utils.logging import get_structured_logger
 
 __all__ = ["BaseFinancialAgent", "AgentPerformanceTracker", "PromptOptimizer"]

--- a/conversation_service/models/agent_models.py
+++ b/conversation_service/models/agent_models.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class AgentConfig:
+    """Configuration container for conversation agents."""
+
+    name: str
+    system_message: str
+    model_name: str
+    temperature: float = 0.7
+    max_tokens: int = 512
+    timeout_seconds: int = 30
+    few_shot_examples: Optional[List[Dict[str, str]]] = None
+
+
+__all__ = ["AgentConfig"]

--- a/conversation_service/models/core_models.py
+++ b/conversation_service/models/core_models.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, Optional
+
+
+class IntentType(str, Enum):
+    """Supported high level user intents."""
+
+    BALANCE_INQUIRY = "BALANCE_INQUIRY"
+    MERCHANT_ANALYSIS = "MERCHANT_ANALYSIS"
+    UNKNOWN = "UNKNOWN"
+
+
+class EntityType(str, Enum):
+    """Types of financial entities extracted from user messages."""
+
+    MERCHANT = "MERCHANT"
+    BENEFICIARY = "BENEFICIARY"
+    AMOUNT = "AMOUNT"
+
+
+@dataclass
+class FinancialEntity:
+    """Structured representation of an entity extracted from text."""
+
+    entity_type: EntityType
+    raw_value: str
+    normalized_value: str
+    confidence: float
+
+    def is_action_related(self) -> bool:
+        """Return ``True`` if this entity is related to an actionable item."""
+
+        return self.entity_type in {EntityType.BENEFICIARY, EntityType.MERCHANT}
+
+    def to_search_filter(self) -> Dict[str, Any]:
+        """Convert the entity into a dictionary usable as a search filter."""
+
+        if self.entity_type == EntityType.AMOUNT:
+            amount = float(self.normalized_value)
+            return {
+                "range": {"amount_abs": {"gte": amount * 0.9, "lte": amount * 1.1}}
+            }
+        if self.entity_type == EntityType.MERCHANT:
+            return {
+                "bool": {
+                    "should": [{"match": {"merchant_name": self.normalized_value}}]
+                }
+            }
+        return {"match": {self.entity_type.value.lower(): self.normalized_value}}
+
+
+@dataclass
+class IntentResult:
+    """Result returned by the intent classification agent."""
+
+    intent: IntentType
+    confidence: float
+    reasoning: Optional[str] = None
+
+
+@dataclass
+class AgentResponse:
+    """Standard response object returned by conversation agents."""
+
+    agent_name: str
+    success: bool
+    result: Optional[Any] = None
+    processing_time_ms: int = 0
+    error_message: Optional[str] = None
+    tokens_used: int = 0
+    cached: bool = False
+
+
+__all__ = [
+    "FinancialEntity",
+    "IntentResult",
+    "IntentType",
+    "AgentResponse",
+    "EntityType",
+]


### PR DESCRIPTION
## Summary
- Introduce core models for conversation service (IntentType, FinancialEntity, IntentResult, AgentResponse)
- Add agent configuration model
- Update base agent imports to use new models

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pytest conversation_service/tests/test_teams/test_financial_entity.py -q`
- `pytest conversation_service/tests/test_agents/test_query_optimizer.py -q` *(fails: TypeError: object() takes no arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68a8390089308320ba1da0f216c66154