### PR TITLE
refactor: extract stream_response utility

### DIFF
--- a/conversation_service/agents/response_generator.py
+++ b/conversation_service/agents/response_generator.py
@@ -77,20 +77,3 @@ class ResponseGeneratorAgent(BaseFinancialAgent):
             "response": formatted,
             "insights": insights,
         }
-"""Lightweight response generation utilities.
-
-This module provides a minimal asynchronous generator used by the websocket
-endpoint to stream back responses. In the real application this would bridge
-with the more advanced ``ResponseGeneratorAgent``.
-"""
-
-from typing import AsyncGenerator
-
-
-async def stream_response(message: str) -> AsyncGenerator[str, None]:
-    """Yield a simple response for the provided message.
-
-    The implementation is intentionally lightweight to avoid heavy dependencies
-    during tests while illustrating how streaming would behave.
-    """
-    yield f"Response: {message}"

--- a/conversation_service/agents/response_generator_agent.py
+++ b/conversation_service/agents/response_generator_agent.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import hashlib
 import json
 import time
-from typing import Any, AsyncGenerator, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple
 
 
 class ResponseGeneratorAgent:
@@ -144,11 +144,5 @@ class ResponseGeneratorAgent:
         return text
 
 
-async def stream_response(message: str) -> AsyncGenerator[str, None]:
-    """Fallback async generator returning the message directly."""
-
-    yield f"Response: {message}"
-
-
-__all__ = ["ResponseGeneratorAgent", "stream_response"]
+__all__ = ["ResponseGeneratorAgent"]
 

--- a/conversation_service/utils/__init__.py
+++ b/conversation_service/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers for the conversation service."""
+
+from .streaming import stream_response
+
+__all__ = ["stream_response"]

--- a/conversation_service/utils/streaming.py
+++ b/conversation_service/utils/streaming.py
@@ -1,0 +1,20 @@
+"""Lightweight response streaming utilities.
+
+This module provides a minimal asynchronous generator used by the websocket
+endpoint to stream back responses. In the real application this would bridge
+with the more advanced ``ResponseGeneratorAgent``.
+"""
+
+from typing import AsyncGenerator
+
+
+async def stream_response(message: str) -> AsyncGenerator[str, None]:
+    """Yield a simple response for the provided message.
+
+    The implementation is intentionally lightweight to avoid heavy dependencies
+    during tests while illustrating how streaming would behave.
+    """
+    yield f"Response: {message}"
+
+
+__all__ = ["stream_response"]

--- a/tests/test_agents/test_agent_imports.py
+++ b/tests/test_agents/test_agent_imports.py
@@ -9,8 +9,9 @@ MODULES = [
     ("conversation_service.agents.query_generator_agent", ["QueryOptimizer"]),
     (
         "conversation_service.agents.response_generator_agent",
-        ["ResponseGeneratorAgent", "stream_response"],
+        ["ResponseGeneratorAgent"],
     ),
+    ("conversation_service.utils.streaming", ["stream_response"]),
 ]
 
 


### PR DESCRIPTION
## Summary
- move lightweight stream_response helper into dedicated utils module
- keep response generator agent modules focused on ResponseGeneratorAgent
- adjust tests to import the streaming helper from its new location

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68a8390e19448320ad692707339944fb