### PR TITLE
Add conversation service app factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ Pour un benchmark d'intention, consultez [README_intent_benchmark.md](README_int
 The conversation service now performs a full agent health check during
 startup. If any agent reports an unhealthy status, initialization fails and
 the process exits instead of running in a degraded state.
+### Usage
+
+Run the conversation service with [Uvicorn](https://www.uvicorn.org/):
+
+```bash
+uvicorn conversation_service.main:app --reload
+```
+
+The FastAPI app is built by `create_app()` in `conversation_service/main.py`.
+
 
 ## Local data seed
 

--- a/conversation_service/api/routes.py
+++ b/conversation_service/api/routes.py
@@ -2,12 +2,12 @@ from fastapi import APIRouter
 from fastapi.responses import PlainTextResponse
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
-from conversation_service.api.routes import router as conversation_router
 from core.metrics_collector import metrics_collector
+from . import websocket
 
 
 router = APIRouter()
-router.include_router(conversation_router, prefix="/conversation")
+router.include_router(websocket.router)
 
 
 @router.get("/metrics", include_in_schema=False)

--- a/conversation_service/main.py
+++ b/conversation_service/main.py
@@ -1,0 +1,32 @@
+"""Application entry point for the conversation service."""
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from config import get_settings
+from conversation_service.api.middleware import setup_middleware
+from conversation_service.api.routes import router as api_router
+
+
+def create_app() -> FastAPI:
+    """Build and configure the FastAPI application."""
+    settings = get_settings()
+
+    app = FastAPI(title="Conversation Service")
+
+    origins = [o.strip() for o in settings.CORS_ORIGINS.split(",") if o.strip()]
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    setup_middleware(app)
+    app.include_router(api_router)
+
+    return app
+
+
+app = create_app()


### PR DESCRIPTION
## Summary
- add `create_app` factory returning a configured FastAPI app for the conversation service
- wire middleware and API routes for metrics, health and websockets
- document how to run the conversation service with Uvicorn

## Testing
- `PYTHONPATH=conversation_service pytest` *(fails: ModuleNotFoundError: teams.team_orchestrator)*
- `PYTHONPATH=conversation_service pytest conversation_service/tests` *(fails: ModuleNotFoundError: conversation_service.models.core_models)*

------
https://chatgpt.com/codex/tasks/task_e_68a83913bafc8320b84725661b56bfea