### PR TITLE
refactor: update team imports to new namespace

### DIFF
--- a/agent_runtime.py
+++ b/agent_runtime.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from agent_types import AssistantAgent
 from sqlalchemy.orm import Session
-from teams.team_orchestrator import TeamOrchestrator
+from conversation_service.teams.team_orchestrator import TeamOrchestrator
 
 
 class AgentRuntime:

--- a/heroku_app.py
+++ b/heroku_app.py
@@ -119,7 +119,7 @@ class ServiceLoader:
             logger.info(f"🔑 OPENAI_API_KEY configurée: {openai_key[:20]}...")
 
             # Initialisation simplifiée du service de conversation
-            from teams.team_orchestrator import TeamOrchestrator
+            from conversation_service.teams.team_orchestrator import TeamOrchestrator
 
             logger.info("⚙️ Initialisation du service de conversation...")
 

--- a/tests/test_conversation_transactions.py
+++ b/tests/test_conversation_transactions.py
@@ -9,7 +9,7 @@ from db_service.models.user import User
 from conversation_service.core import ConversationService
 from conversation_service.message_repository import ConversationMessageRepository
 from conversation_service.repository import ConversationRepository
-from teams.team_orchestrator import TeamOrchestrator
+from conversation_service.teams.team_orchestrator import TeamOrchestrator
 
 
 def _setup_session():

--- a/tests/test_team_orchestrator_query_agents.py
+++ b/tests/test_team_orchestrator_query_agents.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import sessionmaker
 from db_service.base import Base
 from db_service.models.user import User
 from conversation_service.message_repository import ConversationMessageRepository
-from teams.team_orchestrator import TeamOrchestrator
+from conversation_service.teams.team_orchestrator import TeamOrchestrator
 from conversation_service.core import ConversationService
 
 

--- a/tests/test_teams/test_financial_team.py
+++ b/tests/test_teams/test_financial_team.py
@@ -1,6 +1,6 @@
 import pytest
 
-from teams.financial_team import FinancialTeam
+from conversation_service.teams.financial_team import FinancialTeam
 from conversation_service.agents.context_manager import ContextManager
 from conversation_service.models.core_models import AgentResponse
 


### PR DESCRIPTION
## Summary
- import team orchestrator and financial team from `conversation_service.teams`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68a83c87eabc8320910f7968422881ac