### PR TITLE
feat: add backup and monitoring for migrations

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -15,6 +15,9 @@ from sqlalchemy import engine_from_config, MetaData
 from sqlalchemy import pool
 from alembic import context
 
+# Sauvegarde de la base avant migration
+from scripts.db_backup import backup_database
+
 # Configurer le logger
 logger = logging.getLogger("alembic")
 
@@ -129,6 +132,8 @@ def run_migrations_online() -> None:
         )
 
         with context.begin_transaction():
+            # Sauvegarde automatique avant la migration
+            backup_database(database_url)
             logger.info("Exécution des migrations en mode online")
             context.run_migrations()
 

--- a/alembic/versions/1f72abc4d3e9_add_openai_cost_columns.py
+++ b/alembic/versions/1f72abc4d3e9_add_openai_cost_columns.py
@@ -1,0 +1,47 @@
+"""add openai cost and query time columns
+
+Revision ID: 1f72abc4d3e9
+Revises: c2805ce5b2d9
+Create Date: 2025-01-29 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision: str = "1f72abc4d3e9"
+down_revision: Union[str, None] = "c2805ce5b2d9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add monitoring columns and grant permissions."""
+    op.add_column("conversation_turns", sa.Column("openai_cost", sa.Float(), nullable=True))
+    op.add_column("conversation_turns", sa.Column("db_query_time_ms", sa.Float(), nullable=True))
+
+    # Grant read access on new columns to application role
+    op.execute(
+        "GRANT SELECT (openai_cost, db_query_time_ms) ON conversation_turns TO harena_user;"
+    )
+
+    # Verify that the grant has been applied
+    bind = op.get_bind()
+    check_sql = text(
+        """
+        SELECT 1 FROM information_schema.column_privileges
+        WHERE table_name='conversation_turns'
+          AND column_name='openai_cost'
+          AND grantee='harena_user'
+        """
+    )
+    if bind.execute(check_sql).scalar() is None:
+        raise RuntimeError("Permissions not set for openai_cost on harena_user")
+
+
+def downgrade() -> None:
+    """Rollback monitoring columns."""
+    op.drop_column("conversation_turns", "db_query_time_ms")
+    op.drop_column("conversation_turns", "openai_cost")

--- a/monitoring/performance.py
+++ b/monitoring/performance.py
@@ -1,0 +1,26 @@
+"""Simple performance monitoring utilities."""
+from __future__ import annotations
+
+import contextlib
+import logging
+import time
+
+logger = logging.getLogger("performance")
+
+@contextlib.contextmanager
+def track_operation(name: str):
+    """Context manager to measure and log operation duration in ms."""
+    start = time.perf_counter()
+    try:
+        yield
+    finally:
+        duration = (time.perf_counter() - start) * 1000
+        logger.info("%s took %.2fms", name, duration)
+
+_total_openai_cost = 0.0
+
+def record_openai_cost(cost: float) -> None:
+    """Record and log cumulative OpenAI API cost."""
+    global _total_openai_cost
+    _total_openai_cost += float(cost)
+    logger.info("OpenAI cost +%.4f -> total %.4f", cost, _total_openai_cost)

--- a/scripts/check_column_permissions.py
+++ b/scripts/check_column_permissions.py
@@ -1,0 +1,25 @@
+"""Script to verify privileges on monitoring columns."""
+from __future__ import annotations
+
+from sqlalchemy import create_engine, text
+from config_service.config import settings
+
+
+def check_permissions() -> None:
+    engine = create_engine(settings.DATABASE_URL)
+    query = text(
+        """
+        SELECT grantee, privilege_type, column_name
+        FROM information_schema.column_privileges
+        WHERE table_name='conversation_turns'
+          AND column_name IN ('openai_cost', 'db_query_time_ms')
+        """
+    )
+    with engine.connect() as conn:
+        rows = conn.execute(query).fetchall()
+    for row in rows:
+        print(f"{row.column_name}: {row.grantee} -> {row.privilege_type}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    check_permissions()

--- a/scripts/db_backup.py
+++ b/scripts/db_backup.py
@@ -1,0 +1,54 @@
+"""Utility to create a timestamped database backup before running migrations."""
+from __future__ import annotations
+
+import datetime
+import logging
+import pathlib
+import subprocess
+from typing import Optional
+
+from config_service.config import settings
+
+logger = logging.getLogger("db_backup")
+
+
+def backup_database(db_url: Optional[str] = None) -> pathlib.Path | None:
+    """Create a compressed backup of the database using ``pg_dump``.
+
+    Parameters
+    ----------
+    db_url:
+        Database URL. If ``None`` uses ``settings.DATABASE_URL``.
+
+    Returns
+    -------
+    pathlib.Path | None
+        Path to the created backup file or ``None`` if backup failed.
+    """
+    url = db_url or settings.DATABASE_URL
+    if not url:
+        logger.error("No database URL provided; skipping backup")
+        return None
+
+    # Ensure URL is compatible with ``pg_dump``
+    if url.startswith("postgres://"):
+        url = url.replace("postgres://", "postgresql://", 1)
+
+    timestamp = datetime.datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    backups_dir = pathlib.Path("backups")
+    backups_dir.mkdir(exist_ok=True)
+    backup_path = backups_dir / f"backup_{timestamp}.sql.gz"
+
+    cmd = f"pg_dump {url} | gzip > {backup_path}"
+    logger.info("Creating database backup at %s", backup_path)
+    try:
+        subprocess.run(["bash", "-c", cmd], check=True)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Database backup failed: %s", exc)
+        return None
+
+    return backup_path
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    backup_database()


### PR DESCRIPTION
## Summary
- backup database automatically before migrations
- add migration with rollback and permission checks
- track query time and OpenAI usage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a84c6295748320983a923d2d9182ea