### PR TITLE
Use timezone-aware now function in migration test

### DIFF
--- a/tests/test_phase_0/test_migration_conversation.py
+++ b/tests/test_phase_0/test_migration_conversation.py
@@ -1,7 +1,7 @@
 import json
 import os
 import tempfile
-import datetime
+from datetime import datetime, UTC
 import pytest
 from sqlalchemy import create_engine, text, inspect
 from sqlalchemy.orm import sessionmaker
@@ -43,7 +43,7 @@ def test_migration_conversation_preserves_data_and_defaults():
             spec.loader.exec_module(migration)
             with engine.begin() as connection:
                 connection.connection.create_function(
-                    "now", 0, lambda: datetime.datetime.utcnow().isoformat()
+                    "now", 0, lambda: datetime.now(UTC).isoformat()
                 )
                 ctx = MigrationContext.configure(connection)
                 migration.op = Operations(ctx)


### PR DESCRIPTION
## Summary
- switch SQLite now function to timezone-aware datetime
- update imports for timezone handling

## Testing
- `pytest tests/test_phase_0/test_migration_conversation.py`

------
https://chatgpt.com/codex/tasks/task_e_68a856852310832085c2bab03476bac1