### PR TITLE
Use declarative_base from sqlalchemy.orm

### DIFF
--- a/db_service/base.py
+++ b/db_service/base.py
@@ -1,10 +1,18 @@
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from sqlalchemy import Column, DateTime
 from sqlalchemy.sql import func
 
+
 Base = declarative_base()
+
 
 class TimestampMixin:
     """Mixin qui ajoute des champs de timestamp à tous les modèles."""
+
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )


### PR DESCRIPTION
## Summary
- import `declarative_base` from `sqlalchemy.orm`
- verify all SQLAlchemy models still inherit from `Base`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8568376e8832089a9f5e67b742d5a