### PR TITLE
Add configuration package for conversation service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,7 +63,10 @@ coverage.xml
 secrets.json
 config.json
 !alembic/versions/.gitkeep
+# Markdown files are ignored by default, but keep documentation for
+# the conversation service configuration.
 *.md
+!conversation_service/config/README.md
 
 
 # Dossiers de données locales ou volumineuses

--- a/conversation_service/config/README.md
+++ b/conversation_service/config/README.md
@@ -1,0 +1,29 @@
+# Configuration du service de conversation
+
+Ce module centralise la configuration liée aux agents et à l'utilisation
+de l'API OpenAI.
+
+## Variables d'environnement
+
+| Variable            | Description                                                 |
+|--------------------|-------------------------------------------------------------|
+| `OPENAI_API_KEY`    | Clé d'API OpenAI utilisée par les agents.                   |
+| `OPENAI_BASE_URL`   | URL de base de l'API (défaut `https://api.openai.com/v1`).  |
+| `REDIS_URL`         | URL de connexion Redis.                                     |
+| `REDIS_PASSWORD`    | Mot de passe Redis optionnel.                               |
+| `LOG_LEVEL`         | Niveau de log (`INFO`, `DEBUG`, ...).                       |
+| `LOG_FORMAT`        | Format de log compatible `logging`.                         |
+
+La fonction `reload_settings()` permet de recharger ces variables à chaud
+sans redémarrer le service.
+
+## Configuration des agents
+
+Le fichier [`autogen_config.py`](autogen_config.py) définit deux agents
+par défaut :
+
+- **assistant** : modèle `gpt-4o-mini`.
+- **reasoner** : modèle `gpt-4o` avec température plus basse.
+
+Les détails des modèles (coûts, limites de rate‑limiting, modèle de
+secours) sont documentés dans [`openai_config.py`](openai_config.py).

--- a/conversation_service/config/__init__.py
+++ b/conversation_service/config/__init__.py
@@ -1,0 +1,21 @@
+"""Configuration utilities for the conversation service.
+
+This package centralises OpenAI, Redis and logging configuration for
+:mod:`conversation_service`.  It exposes :data:`settings` and a
+:func:`reload_settings` helper to hot‑reload environment variables at
+runtime.
+"""
+
+from .settings import Settings, settings, reload_settings
+from .openai_config import OpenAIConfig, ModelConfig
+from .autogen_config import AutoGenConfig, AgentConfig
+
+__all__ = [
+    "Settings",
+    "settings",
+    "reload_settings",
+    "OpenAIConfig",
+    "ModelConfig",
+    "AutoGenConfig",
+    "AgentConfig",
+]

--- a/conversation_service/config/autogen_config.py
+++ b/conversation_service/config/autogen_config.py
@@ -1,0 +1,35 @@
+"""Configuration des agents Autogen utilisés par le service.
+
+Chaque agent est associé à un modèle OpenAI.  Cette configuration est
+séparée de :mod:`openai_config` afin de pouvoir adapter facilement les
+modèles utilisés par les agents sans modifier la configuration globale
+OpenAI.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from pydantic import BaseModel, Field
+
+
+class AgentConfig(BaseModel):
+    """Configuration d'un agent individuel."""
+
+    model: str = Field(..., description="Nom du modèle OpenAI")
+    temperature: float = Field(0.7, ge=0, le=2, description="Température du modèle")
+    max_tokens: int = Field(512, ge=1, description="Nombre maximal de tokens")
+
+
+class AutoGenConfig(BaseModel):
+    """Configuration complète pour tous les agents Autogen."""
+
+    agents: Dict[str, AgentConfig] = Field(default_factory=dict)
+
+
+DEFAULT_AUTOGEN_CONFIG = AutoGenConfig(
+    agents={
+        "assistant": AgentConfig(model="gpt-4o-mini"),
+        "reasoner": AgentConfig(model="gpt-4o", temperature=0.2, max_tokens=1024),
+    }
+)

--- a/conversation_service/config/openai_config.py
+++ b/conversation_service/config/openai_config.py
@@ -1,0 +1,78 @@
+"""OpenAI model configuration for the conversation service.
+
+The configuration describes available models, their costs, rate limits
+and fallbacks.  It is intentionally static and can be imported by other
+modules to perform budgeting or model selection.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ModelConfig(BaseModel):
+    """Detailed configuration for a single OpenAI model."""
+
+    name: str = Field(..., description="Model identifier as used by the API")
+    prompt_cost_per_million: float = Field(
+        ..., ge=0, description="USD cost for one million prompt tokens"
+    )
+    completion_cost_per_million: float = Field(
+        ..., ge=0, description="USD cost for one million completion tokens"
+    )
+    rpm_limit: int = Field(..., ge=0, description="Requests per minute limit")
+    tpm_limit: int = Field(..., ge=0, description="Tokens per minute limit")
+    fallback: Optional[str] = Field(
+        None, description="Fallback model name if this model is unavailable"
+    )
+
+
+class BudgetConfig(BaseModel):
+    """Soft and hard budget limits for OpenAI usage."""
+
+    soft_limit_usd: float = Field(10.0, ge=0, description="Warning threshold")
+    hard_limit_usd: float = Field(50.0, ge=0, description="Maximum allowed cost")
+
+
+class OpenAIConfig(BaseModel):
+    """Aggregated configuration for OpenAI usage."""
+
+    models: Dict[str, ModelConfig] = Field(default_factory=dict)
+    budget: BudgetConfig = BudgetConfig()
+
+    def get_model(self, name: str) -> ModelConfig:
+        """Return the configuration for *name* or raise ``KeyError``."""
+
+        return self.models[name]
+
+    def get_fallback(self, name: str) -> Optional[ModelConfig]:
+        """Return the fallback model for *name* if defined."""
+
+        model = self.get_model(name)
+        if model.fallback:
+            return self.models.get(model.fallback)
+        return None
+
+
+# Default configuration with a couple of common models.
+DEFAULT_OPENAI_CONFIG = OpenAIConfig(
+    models={
+        "gpt-4o-mini": ModelConfig(
+            name="gpt-4o-mini",
+            prompt_cost_per_million=0.15,
+            completion_cost_per_million=0.60,
+            rpm_limit=10000,
+            tpm_limit=200000,
+        ),
+        "gpt-4o": ModelConfig(
+            name="gpt-4o",
+            prompt_cost_per_million=5.00,
+            completion_cost_per_million=15.00,
+            rpm_limit=5000,
+            tpm_limit=300000,
+            fallback="gpt-4o-mini",
+        ),
+    },
+)

--- a/conversation_service/config/settings.py
+++ b/conversation_service/config/settings.py
@@ -1,0 +1,42 @@
+"""Application settings for the conversation service.
+
+The settings rely on environment variables and can be reloaded at
+runtime by calling :func:`reload_settings`.  Only a minimal subset of
+variables required by the service are defined here.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Pydantic settings for environment‑driven configuration."""
+
+    model_config = SettingsConfigDict(env_file=".env", case_sensitive=False)
+
+    # OpenAI
+    OPENAI_API_KEY: str = ""
+    OPENAI_BASE_URL: str = "https://api.openai.com/v1"
+
+    # Redis
+    REDIS_URL: str = "redis://localhost:6379/0"
+    REDIS_PASSWORD: Optional[str] = None
+
+    # Logging
+    LOG_LEVEL: str = "INFO"
+    LOG_FORMAT: str = "[%(asctime)s] %(levelname)s in %(name)s: %(message)s"
+
+
+settings = Settings()
+"""Instance global de configuration."""
+
+
+def reload_settings() -> Settings:
+    """Reload settings from the environment and return the new instance."""
+
+    global settings
+    settings = Settings()  # type: ignore[assignment]
+    return settings


### PR DESCRIPTION
## Summary
- add `conversation_service.config` package for OpenAI, Redis and logging settings
- define `OpenAIConfig` with model costs, budget limits, rate limiting and fallbacks
- provide Autogen agent configuration and documentation of expected environment variables

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a88003b43c83209344aee67d5fe218