### PR TITLE
Add cache and search clients with centralized settings

### DIFF
--- a/conversation_service/clients/__init__.py
+++ b/conversation_service/clients/__init__.py
@@ -1,0 +1,6 @@
+"""Client utilities for the conversation service."""
+
+from .cache_client import CacheClient
+from .search_client import SearchClient
+
+__all__ = ["CacheClient", "SearchClient"]

--- a/conversation_service/clients/cache_client.py
+++ b/conversation_service/clients/cache_client.py
@@ -1,0 +1,63 @@
+"""Asynchronous Redis cache client for the conversation service."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+import redis.asyncio as redis
+
+from conversation_service.settings import settings
+
+
+class CacheClient:
+    """Simple wrapper around ``redis.asyncio`` with connection pooling."""
+
+    def __init__(self) -> None:
+        self._prefix = f"{settings.redis_cache_prefix}:"
+        self._pool = redis.ConnectionPool.from_url(
+            settings.redis_url,
+            password=settings.redis_password,
+            max_connections=settings.redis_max_connections,
+            health_check_interval=settings.redis_health_check_interval,
+            retry_on_timeout=settings.redis_retry_on_timeout,
+            decode_responses=True,
+        )
+        self._client = redis.Redis(connection_pool=self._pool)
+
+    def _format_key(self, user_id: int, key: str) -> str:
+        return f"{self._prefix}{user_id}:{key}"
+
+    async def get(self, user_id: int, key: str) -> Optional[Any]:
+        """Retrieve a value from Redis."""
+
+        raw = await self._client.get(self._format_key(user_id, key))
+        if raw is None:
+            return None
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            return raw
+
+    async def set(
+        self, user_id: int, key: str, value: Any, ttl: Optional[int] = None
+    ) -> None:
+        """Store ``value`` under ``key`` with an optional TTL in seconds."""
+
+        if not isinstance(value, str):
+            value = json.dumps(value)
+        await self._client.set(self._format_key(user_id, key), value, ex=ttl)
+
+    async def delete(self, user_id: int, key: str) -> None:
+        await self._client.delete(self._format_key(user_id, key))
+
+    async def ping(self) -> bool:
+        """Health check for the Redis connection."""
+
+        return await self._client.ping()
+
+    async def close(self) -> None:
+        """Close the client and its connection pool."""
+
+        await self._client.close()
+        await self._pool.disconnect(inuse_connections=True)

--- a/conversation_service/clients/search_client.py
+++ b/conversation_service/clients/search_client.py
@@ -1,0 +1,27 @@
+"""Minimal client for interacting with the search service."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import httpx
+
+from conversation_service.settings import settings
+
+
+class SearchClient:
+    """Asynchronous HTTP client for the search service."""
+
+    def __init__(self) -> None:
+        self._url = settings.search_service_url
+        self._client = httpx.AsyncClient()
+
+    async def search(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute a search request against the search service."""
+
+        response = await self._client.post(self._url, json=payload)
+        response.raise_for_status()
+        return response.json()
+
+    async def close(self) -> None:
+        await self._client.aclose()

--- a/conversation_service/settings.py
+++ b/conversation_service/settings.py
@@ -1,0 +1,29 @@
+"""Configuration for the conversation service."""
+
+from __future__ import annotations
+
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Environment-based settings."""
+
+    search_service_url: str = Field(
+        "http://localhost:8000/api/v1/search", env="SEARCH_SERVICE_URL"
+    )
+    redis_url: str = Field("redis://localhost:6379/0", env="REDIS_URL")
+    redis_password: str | None = Field(default=None, env="REDIS_PASSWORD")
+    redis_db: int = Field(default=0, env="REDIS_DB")
+    redis_max_connections: int = Field(10, env="REDIS_MAX_CONNECTIONS")
+    redis_health_check_interval: int = Field(30, env="REDIS_HEALTH_CHECK_INTERVAL")
+    redis_retry_on_timeout: bool = Field(True, env="REDIS_RETRY_ON_TIMEOUT")
+    redis_cache_prefix: str = Field("conversation_service", env="REDIS_CACHE_PREFIX")
+
+    class Config:
+        env_file = ".env"
+        extra = "ignore"
+        case_sensitive = False
+
+
+settings = Settings()


### PR DESCRIPTION
## Summary
- add Redis cache client with connection pooling and health checks
- add minimal HTTP client to call the search service
- centralize configuration in a dedicated settings module

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a88005dbcc8320be025613bd1b4799