### PR TITLE
Add two-level cache manager with metrics and validation

### DIFF
--- a/conversation_service/core/__init__.py
+++ b/conversation_service/core/__init__.py
@@ -1,0 +1,7 @@
+"""Core utilities for the conversation service."""
+
+from .cache_manager import CacheManager
+from .metrics_collector import MetricsCollector
+from .validators import validate_model
+
+__all__ = ["CacheManager", "MetricsCollector", "validate_model"]

--- a/conversation_service/core/cache_manager.py
+++ b/conversation_service/core/cache_manager.py
@@ -1,0 +1,101 @@
+"""Two-level cache manager with in-memory and Redis backends."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Optional, Tuple, Type
+
+from cache_client import CacheClient
+
+from .metrics_collector import MetricsCollector
+from .validators import validate_model
+
+
+class CacheManager:
+    """Manage an L1 in-memory cache backed by an L2 Redis cache."""
+
+    def __init__(
+        self,
+        client: CacheClient,
+        *,
+        l1_ttl: int = 5,
+        l2_ttl: int = 60,
+        metrics: Optional[MetricsCollector] = None,
+    ) -> None:
+        self._client = client
+        self._l1_ttl = l1_ttl
+        self._l2_ttl = l2_ttl
+        self._l1_cache: Dict[Tuple[int, str], Tuple[Any, float]] = {}
+        self._metrics = metrics or MetricsCollector()
+
+    # ------------------------------------------------------------------
+    async def get(self, user_id: int, key: str, model: Optional[Type] = None) -> Any:
+        """Retrieve ``key`` for ``user_id`` from cache."""
+
+        now = time.time()
+        l1_key = (user_id, key)
+        start = time.perf_counter()
+        entry = self._l1_cache.get(l1_key)
+        if entry and entry[1] > now:
+            self._metrics.record_hit("l1")
+            self._metrics.record_latency("l1", time.perf_counter() - start)
+            value = entry[0]
+            return validate_model(model, value) if model else value
+        if entry:
+            # Expired entry
+            del self._l1_cache[l1_key]
+            self._metrics.record_size("l1", len(self._l1_cache))
+        self._metrics.record_miss("l1")
+        self._metrics.record_latency("l1", time.perf_counter() - start)
+
+        # Fetch from L2
+        start = time.perf_counter()
+        data = await self._client.get(user_id, key)
+        self._metrics.record_latency("l2", time.perf_counter() - start)
+        if data is None:
+            self._metrics.record_miss("l2")
+            return None
+        self._metrics.record_hit("l2")
+        value = validate_model(model, data) if model else data
+        # store in L1
+        self._l1_cache[l1_key] = (value, now + self._l1_ttl)
+        self._metrics.record_size("l1", len(self._l1_cache))
+        return value
+
+    async def set(
+        self,
+        user_id: int,
+        key: str,
+        value: Any,
+        *,
+        model: Optional[Type] = None,
+        l1_ttl: Optional[int] = None,
+        l2_ttl: Optional[int] = None,
+    ) -> None:
+        """Store ``value`` in both cache levels."""
+
+        if model is not None:
+            validated = validate_model(model, value)
+            l1_value = validated
+            l2_value = validated.dict()
+        else:
+            l1_value = l2_value = value
+
+        l1_ttl = l1_ttl or self._l1_ttl
+        l2_ttl = l2_ttl or self._l2_ttl
+
+        self._l1_cache[(user_id, key)] = (l1_value, time.time() + l1_ttl)
+        self._metrics.record_size("l1", len(self._l1_cache))
+
+        start = time.perf_counter()
+        await self._client.set(user_id, key, l2_value, ttl=l2_ttl)
+        self._metrics.record_latency("l2", time.perf_counter() - start)
+
+    async def invalidate(self, user_id: int, key: str) -> None:
+        """Remove ``key`` for ``user_id`` from both caches."""
+
+        self._l1_cache.pop((user_id, key), None)
+        self._metrics.record_size("l1", len(self._l1_cache))
+        start = time.perf_counter()
+        await self._client.delete(user_id, key)
+        self._metrics.record_latency("l2", time.perf_counter() - start)

--- a/conversation_service/core/metrics_collector.py
+++ b/conversation_service/core/metrics_collector.py
@@ -1,0 +1,33 @@
+"""Simple in-memory metrics collector for cache operations."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+class MetricsCollector:
+    """Collect metrics about cache usage."""
+
+    def __init__(self) -> None:
+        self.hits: Dict[str, int] = {"l1": 0, "l2": 0}
+        self.misses: Dict[str, int] = {"l1": 0, "l2": 0}
+        self.latency: Dict[str, List[float]] = {"l1": [], "l2": []}
+        self.size: Dict[str, int] = {"l1": 0, "l2": 0}
+
+    # Recording helpers -------------------------------------------------
+    def record_hit(self, level: str) -> None:
+        self.hits[level] += 1
+
+    def record_miss(self, level: str) -> None:
+        self.misses[level] += 1
+
+    def record_latency(self, level: str, seconds: float) -> None:
+        self.latency[level].append(seconds)
+
+    def record_size(self, level: str, size: int) -> None:
+        self.size[level] = size
+
+    # Query helpers -----------------------------------------------------
+    def avg_latency(self, level: str) -> float:
+        times = self.latency[level]
+        return sum(times) / len(times) if times else 0.0

--- a/conversation_service/core/validators.py
+++ b/conversation_service/core/validators.py
@@ -1,0 +1,27 @@
+"""Pydantic validation helpers for cached objects."""
+
+from __future__ import annotations
+
+from typing import Any, Type, TypeVar
+
+from pydantic import BaseModel
+
+T = TypeVar("T", bound=BaseModel)
+
+
+def validate_model(model: Type[T], data: Any) -> T:
+    """Validate ``data`` against ``model``.
+
+    If ``data`` is already an instance of ``model`` it is returned as-is.
+    Otherwise ``model.parse_obj`` is used to construct and validate an instance.
+    """
+
+    if isinstance(data, model):
+        return data
+    try:
+        return model.parse_obj(data)  # Pydantic v1
+    except AttributeError:  # pragma: no cover - support for Pydantic v2
+        try:
+            return model.model_validate(data)  # type: ignore[attr-defined]
+        except AttributeError:
+            return model(**data)

--- a/tests/test_cache_manager.py
+++ b/tests/test_cache_manager.py
@@ -1,0 +1,68 @@
+import asyncio
+import time
+from typing import Optional
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from conversation_service.core import CacheManager, MetricsCollector
+
+
+class FakeCacheClient:
+    """Simple in-memory stand-in for ``CacheClient`` supporting TTL."""
+
+    def __init__(self) -> None:
+        self.store = {}
+
+    async def get(self, user_id: int, key: str):
+        item = self.store.get((user_id, key))
+        if not item:
+            return None
+        value, expire = item
+        if expire and expire < time.time():
+            del self.store[(user_id, key)]
+            return None
+        return value
+
+    async def set(self, user_id: int, key: str, value, ttl: Optional[int] = None):
+        expire = time.time() + ttl if ttl else None
+        self.store[(user_id, key)] = (value, expire)
+
+    async def delete(self, user_id: int, key: str):
+        self.store.pop((user_id, key), None)
+
+
+class Item(BaseModel):
+    value: int
+
+
+@pytest.mark.asyncio
+async def test_two_level_cache_with_validation_and_metrics():
+    client = FakeCacheClient()
+    metrics = MetricsCollector()
+    manager = CacheManager(client, l1_ttl=0.1, l2_ttl=0.3, metrics=metrics)
+
+    await manager.set(1, "k", {"value": 1}, model=Item)
+
+    # Immediate access -> L1 hit
+    item = await manager.get(1, "k", model=Item)
+    assert item.value == 1
+    assert metrics.hits["l1"] == 1
+
+    # After L1 TTL expires but before L2 TTL -> L1 miss, L2 hit
+    await asyncio.sleep(0.15)
+    item = await manager.get(1, "k", model=Item)
+    assert item.value == 1
+    assert metrics.misses["l1"] == 1
+    assert metrics.hits["l2"] == 1
+
+    # After L2 TTL expires -> total miss
+    await asyncio.sleep(0.2)
+    item = await manager.get(1, "k", model=Item)
+    assert item is None
+    assert metrics.misses["l2"] == 1
+    assert metrics.size["l1"] == 0
+
+    # Validation errors surface
+    with pytest.raises(ValidationError):
+        await manager.set(1, "bad", {"wrong": 1}, model=Item)


### PR DESCRIPTION
## Summary
- implement CacheManager with L1 in-memory and L2 Redis layers, distinct TTLs and invalidation
- add MetricsCollector tracking cache hits, misses, latency and size
- provide Pydantic validation helpers and comprehensive tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a8800a56948320b8768ffbb8496e51