### PR TITLE
test: update CacheManager import

### DIFF
--- a/tests/test_cache_manager.py
+++ b/tests/test_cache_manager.py
@@ -1,7 +1,7 @@
 import asyncio
 import pytest
 
-from cache_manager import CacheManager
+from conversation_service.core import CacheManager
 
 
 class DummyRedis:
@@ -89,7 +89,7 @@ from typing import Optional
 import pytest
 from pydantic import BaseModel, ValidationError
 
-from conversation_service.core import CacheManager, MetricsCollector
+from conversation_service.core import MetricsCollector
 
 
 class FakeCacheClient:


### PR DESCRIPTION
## Summary
- update test cache manager to import CacheManager from conversation_service.core
- drop redundant re-import of CacheManager

## Testing
- `pytest tests/test_cache_manager.py` *(fails: CacheManager.__init__() got an unexpected keyword argument 'redis_client')*

------
https://chatgpt.com/codex/tasks/task_e_68a89d7462a88320874889d69afaf87c