### PR TITLE
feat: add phase 2 conversation models

### DIFF
--- a/conversation_service/models/__init__.py
+++ b/conversation_service/models/__init__.py
@@ -1,0 +1,21 @@
+from .conversation_models import (
+    ConversationRequest,
+    ConversationResponse,
+    ConversationMetadata,
+    ConversationContext,
+)
+from .conversation_db_models import (
+    Conversation,
+    ConversationSummary,
+    ConversationTurn,
+)
+
+__all__ = [
+    "ConversationRequest",
+    "ConversationResponse",
+    "ConversationMetadata",
+    "ConversationContext",
+    "Conversation",
+    "ConversationSummary",
+    "ConversationTurn",
+]

--- a/conversation_service/models/conversation_db_models.py
+++ b/conversation_service/models/conversation_db_models.py
@@ -1,0 +1,178 @@
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field, ConfigDict
+
+
+class Conversation(BaseModel):
+    """Représente une conversation utilisateur.
+
+    Example:
+        {
+            "id": 1,
+            "conversation_id": "conv_123",
+            "user_id": 42,
+            "title": "Budget 2024",
+            "status": "active",
+            "language": "fr",
+            "domain": "finance",
+            "total_turns": 2,
+            "max_turns": 50,
+            "last_activity_at": "2024-06-01T12:00:00Z",
+            "conversation_metadata": {"topic": "budget"},
+            "user_preferences": {"tone": "friendly"},
+            "session_metadata": {"browser": "firefox"},
+            "created_at": "2024-06-01T12:00:00Z",
+            "updated_at": "2024-06-01T12:05:00Z"
+        }
+    """
+
+    id: int
+    conversation_id: str
+    user_id: int
+    title: Optional[str] = None
+    status: str
+    language: str
+    domain: str
+    total_turns: int
+    max_turns: int
+    last_activity_at: datetime
+    conversation_metadata: Dict[str, Any] = Field(default_factory=dict)
+    user_preferences: Dict[str, Any] = Field(default_factory=dict)
+    session_metadata: Dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "id": 1,
+            "conversation_id": "conv_123",
+            "user_id": 42,
+            "title": "Budget 2024",
+            "status": "active",
+            "language": "fr",
+            "domain": "finance",
+            "total_turns": 2,
+            "max_turns": 50,
+            "last_activity_at": "2024-06-01T12:00:00Z",
+            "conversation_metadata": {"topic": "budget"},
+            "user_preferences": {"tone": "friendly"},
+            "session_metadata": {"browser": "firefox"},
+            "created_at": "2024-06-01T12:00:00Z",
+            "updated_at": "2024-06-01T12:05:00Z"
+        }
+    })
+
+
+class ConversationSummary(BaseModel):
+    """Résumé partiel d'une conversation.
+
+    Example:
+        {
+            "id": 1,
+            "conversation_id": 1,
+            "start_turn": 1,
+            "end_turn": 4,
+            "summary_text": "...",
+            "key_topics": ["budget", "économie"],
+            "important_entities": [{"name": "Paris", "type": "city"}],
+            "summary_method": "llm",
+            "created_at": "2024-06-01T12:00:00Z",
+            "updated_at": "2024-06-01T12:05:00Z"
+        }
+    """
+
+    id: int
+    conversation_id: int
+    start_turn: int
+    end_turn: int
+    summary_text: str
+    key_topics: List[str] = Field(default_factory=list)
+    important_entities: List[Dict[str, Any]] = Field(default_factory=list)
+    summary_method: str
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "id": 1,
+            "conversation_id": 1,
+            "start_turn": 1,
+            "end_turn": 4,
+            "summary_text": "Résumé des échanges...",
+            "key_topics": ["budget", "économie"],
+            "important_entities": [{"name": "Paris", "type": "city"}],
+            "summary_method": "llm",
+            "created_at": "2024-06-01T12:00:00Z",
+            "updated_at": "2024-06-01T12:05:00Z"
+        }
+    })
+
+
+class ConversationTurn(BaseModel):
+    """Tour de conversation entre l'utilisateur et l'assistant.
+
+    Example:
+        {
+            "id": 10,
+            "turn_id": "turn_0010",
+            "conversation_id": 1,
+            "turn_number": 3,
+            "user_message": "Quel est mon solde ?",
+            "assistant_response": "Votre solde est de 50€.",
+            "processing_time_ms": 120.5,
+            "confidence_score": 0.98,
+            "error_occurred": false,
+            "error_message": null,
+            "intent_result": {"name": "check_balance"},
+            "agent_chain": [{"agent": "retrieval", "status": "ok"}],
+            "search_query_used": "balance account",
+            "search_results_count": 3,
+            "search_execution_time_ms": 50.2,
+            "turn_metadata": {"debug": true},
+            "created_at": "2024-06-01T12:00:00Z",
+            "updated_at": "2024-06-01T12:00:01Z"
+        }
+    """
+
+    id: int
+    turn_id: str
+    conversation_id: int
+    turn_number: int
+    user_message: str
+    assistant_response: str
+    processing_time_ms: Optional[float] = None
+    confidence_score: Optional[float] = None
+    error_occurred: bool
+    error_message: Optional[str] = None
+    intent_result: Optional[Dict[str, Any]] = None
+    agent_chain: List[Dict[str, Any]] = Field(default_factory=list)
+    search_query_used: Optional[str] = None
+    search_results_count: int
+    search_execution_time_ms: Optional[float] = None
+    turn_metadata: Dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "id": 10,
+            "turn_id": "turn_0010",
+            "conversation_id": 1,
+            "turn_number": 3,
+            "user_message": "Quel est mon solde ?",
+            "assistant_response": "Votre solde est de 50€.",
+            "processing_time_ms": 120.5,
+            "confidence_score": 0.98,
+            "error_occurred": False,
+            "error_message": None,
+            "intent_result": {"name": "check_balance"},
+            "agent_chain": [{"agent": "retrieval", "status": "ok"}],
+            "search_query_used": "balance account",
+            "search_results_count": 3,
+            "search_execution_time_ms": 50.2,
+            "turn_metadata": {"debug": True},
+            "created_at": "2024-06-01T12:00:00Z",
+            "updated_at": "2024-06-01T12:00:01Z"
+        }
+    })

--- a/conversation_service/models/conversation_models.py
+++ b/conversation_service/models/conversation_models.py
@@ -1,178 +1,89 @@
-from datetime import datetime
-from typing import Any, Dict, List, Optional
+from __future__ import annotations
 
-from pydantic import BaseModel, Field, ConfigDict
+from uuid import UUID
+from pydantic import BaseModel, Field, ConfigDict, field_validator
 
 
-class Conversation(BaseModel):
-    """Représente une conversation utilisateur.
+class ConversationMetadata(BaseModel):
+    """Metadata about the conversation such as intent and confidence."""
 
-    Example:
-        {
-            "id": 1,
-            "conversation_id": "conv_123",
-            "user_id": 42,
-            "title": "Budget 2024",
-            "status": "active",
+    intent: str | None = None
+    confidence_score: float | None = Field(default=None, ge=0.0, le=1.0)
+
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "intent": "greeting",
+            "confidence_score": 0.95,
+        }
+    })
+
+
+class ConversationContext(BaseModel):
+    """Contextual information for the conversation."""
+
+    conversation_id: UUID | None = None
+    turn_number: int = Field(ge=1)
+
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "conversation_id": "550e8400-e29b-41d4-a716-446655440000",
+            "turn_number": 1,
+        }
+    })
+
+
+class ConversationRequest(BaseModel):
+    """User request sent to the conversation service."""
+
+    message: str = Field(min_length=1)
+    language: str = Field(min_length=2, max_length=2)
+    context: ConversationContext
+
+    model_config = ConfigDict(str_strip_whitespace=True, json_schema_extra={
+        "example": {
+            "message": "Bonjour",
             "language": "fr",
-            "domain": "finance",
-            "total_turns": 2,
-            "max_turns": 50,
-            "last_activity_at": "2024-06-01T12:00:00Z",
-            "conversation_metadata": {"topic": "budget"},
-            "user_preferences": {"tone": "friendly"},
-            "session_metadata": {"browser": "firefox"},
-            "created_at": "2024-06-01T12:00:00Z",
-            "updated_at": "2024-06-01T12:05:00Z"
+            "context": {
+                "conversation_id": "550e8400-e29b-41d4-a716-446655440000",
+                "turn_number": 1,
+            },
         }
-    """
+    })
 
-    id: int
-    conversation_id: str
-    user_id: int
-    title: Optional[str] = None
-    status: str
-    language: str
-    domain: str
-    total_turns: int
-    max_turns: int
-    last_activity_at: datetime
-    conversation_metadata: Dict[str, Any] = Field(default_factory=dict)
-    user_preferences: Dict[str, Any] = Field(default_factory=dict)
-    session_metadata: Dict[str, Any] = Field(default_factory=dict)
-    created_at: datetime
-    updated_at: datetime
+    @field_validator("language")
+    @classmethod
+    def validate_language(cls, v: str) -> str:
+        if len(v) != 2 or not v.isalpha():
+            raise ValueError("language must be a 2-letter ISO code")
+        return v.lower()
 
-    model_config = ConfigDict(json_schema_extra={
+
+class ConversationResponse(BaseModel):
+    """Assistant response returned by the conversation service."""
+
+    response: str = Field(min_length=1)
+    language: str = Field(min_length=2, max_length=2)
+    context: ConversationContext
+    metadata: ConversationMetadata | None = None
+
+    model_config = ConfigDict(str_strip_whitespace=True, json_schema_extra={
         "example": {
-            "id": 1,
-            "conversation_id": "conv_123",
-            "user_id": 42,
-            "title": "Budget 2024",
-            "status": "active",
+            "response": "Bonjour! Comment puis-je vous aider?",
             "language": "fr",
-            "domain": "finance",
-            "total_turns": 2,
-            "max_turns": 50,
-            "last_activity_at": "2024-06-01T12:00:00Z",
-            "conversation_metadata": {"topic": "budget"},
-            "user_preferences": {"tone": "friendly"},
-            "session_metadata": {"browser": "firefox"},
-            "created_at": "2024-06-01T12:00:00Z",
-            "updated_at": "2024-06-01T12:05:00Z"
+            "context": {
+                "conversation_id": "550e8400-e29b-41d4-a716-446655440000",
+                "turn_number": 1,
+            },
+            "metadata": {
+                "intent": "greeting",
+                "confidence_score": 0.95,
+            },
         }
     })
 
-
-class ConversationSummary(BaseModel):
-    """Résumé partiel d'une conversation.
-
-    Example:
-        {
-            "id": 1,
-            "conversation_id": 1,
-            "start_turn": 1,
-            "end_turn": 4,
-            "summary_text": "...",
-            "key_topics": ["budget", "économie"],
-            "important_entities": [{"name": "Paris", "type": "city"}],
-            "summary_method": "llm",
-            "created_at": "2024-06-01T12:00:00Z",
-            "updated_at": "2024-06-01T12:05:00Z"
-        }
-    """
-
-    id: int
-    conversation_id: int
-    start_turn: int
-    end_turn: int
-    summary_text: str
-    key_topics: List[str] = Field(default_factory=list)
-    important_entities: List[Dict[str, Any]] = Field(default_factory=list)
-    summary_method: str
-    created_at: datetime
-    updated_at: datetime
-
-    model_config = ConfigDict(json_schema_extra={
-        "example": {
-            "id": 1,
-            "conversation_id": 1,
-            "start_turn": 1,
-            "end_turn": 4,
-            "summary_text": "Résumé des échanges...",
-            "key_topics": ["budget", "économie"],
-            "important_entities": [{"name": "Paris", "type": "city"}],
-            "summary_method": "llm",
-            "created_at": "2024-06-01T12:00:00Z",
-            "updated_at": "2024-06-01T12:05:00Z"
-        }
-    })
-
-
-class ConversationTurn(BaseModel):
-    """Tour de conversation entre l'utilisateur et l'assistant.
-
-    Example:
-        {
-            "id": 10,
-            "turn_id": "turn_0010",
-            "conversation_id": 1,
-            "turn_number": 3,
-            "user_message": "Quel est mon solde ?",
-            "assistant_response": "Votre solde est de 50€.",
-            "processing_time_ms": 120.5,
-            "confidence_score": 0.98,
-            "error_occurred": false,
-            "error_message": null,
-            "intent_result": {"name": "check_balance"},
-            "agent_chain": [{"agent": "retrieval", "status": "ok"}],
-            "search_query_used": "balance account",
-            "search_results_count": 3,
-            "search_execution_time_ms": 50.2,
-            "turn_metadata": {"debug": true},
-            "created_at": "2024-06-01T12:00:00Z",
-            "updated_at": "2024-06-01T12:00:01Z"
-        }
-    """
-
-    id: int
-    turn_id: str
-    conversation_id: int
-    turn_number: int
-    user_message: str
-    assistant_response: str
-    processing_time_ms: Optional[float] = None
-    confidence_score: Optional[float] = None
-    error_occurred: bool
-    error_message: Optional[str] = None
-    intent_result: Optional[Dict[str, Any]] = None
-    agent_chain: List[Dict[str, Any]] = Field(default_factory=list)
-    search_query_used: Optional[str] = None
-    search_results_count: int
-    search_execution_time_ms: Optional[float] = None
-    turn_metadata: Dict[str, Any] = Field(default_factory=dict)
-    created_at: datetime
-    updated_at: datetime
-
-    model_config = ConfigDict(json_schema_extra={
-        "example": {
-            "id": 10,
-            "turn_id": "turn_0010",
-            "conversation_id": 1,
-            "turn_number": 3,
-            "user_message": "Quel est mon solde ?",
-            "assistant_response": "Votre solde est de 50€.",
-            "processing_time_ms": 120.5,
-            "confidence_score": 0.98,
-            "error_occurred": False,
-            "error_message": None,
-            "intent_result": {"name": "check_balance"},
-            "agent_chain": [{"agent": "retrieval", "status": "ok"}],
-            "search_query_used": "balance account",
-            "search_results_count": 3,
-            "search_execution_time_ms": 50.2,
-            "turn_metadata": {"debug": True},
-            "created_at": "2024-06-01T12:00:00Z",
-            "updated_at": "2024-06-01T12:00:01Z"
-        }
-    })
+    @field_validator("language")
+    @classmethod
+    def validate_language(cls, v: str) -> str:
+        if len(v) != 2 or not v.isalpha():
+            raise ValueError("language must be a 2-letter ISO code")
+        return v.lower()

--- a/tests/test_conversation_models_phase2.py
+++ b/tests/test_conversation_models_phase2.py
@@ -1,0 +1,56 @@
+import pytest
+from uuid import uuid4
+from pydantic import ValidationError
+
+from conversation_service.models import (
+    ConversationRequest,
+    ConversationResponse,
+    ConversationMetadata,
+    ConversationContext,
+)
+
+
+def test_conversation_request_valid():
+    ctx = ConversationContext(conversation_id=uuid4(), turn_number=1)
+    req = ConversationRequest(message="Hello", language="en", context=ctx)
+    assert req.context.turn_number == 1
+
+
+def test_user_message_not_empty():
+    with pytest.raises(ValidationError):
+        ConversationRequest(message="", language="en", context={"turn_number": 1})
+
+
+def test_language_two_letters():
+    with pytest.raises(ValidationError):
+        ConversationRequest(message="Hi", language="eng", context={"turn_number": 1})
+
+
+def test_conversation_id_uuid():
+    with pytest.raises(ValidationError):
+        ConversationRequest(
+            message="Hi",
+            language="en",
+            context={"conversation_id": "not-a-uuid", "turn_number": 1},
+        )
+
+
+def test_confidence_score_range():
+    with pytest.raises(ValidationError):
+        ConversationMetadata(intent="greeting", confidence_score=1.5)
+    with pytest.raises(ValidationError):
+        ConversationMetadata(intent="greeting", confidence_score=-0.1)
+
+
+def test_turn_number_positive():
+    with pytest.raises(ValidationError):
+        ConversationContext(conversation_id=uuid4(), turn_number=0)
+
+
+def test_conversation_response_valid():
+    ctx = ConversationContext(conversation_id=uuid4(), turn_number=2)
+    meta = ConversationMetadata(intent="greeting", confidence_score=0.8)
+    resp = ConversationResponse(
+        response="Hello!", language="en", context=ctx, metadata=meta
+    )
+    assert resp.metadata.confidence_score == 0.8


### PR DESCRIPTION
## Summary
- move existing conversation models to `conversation_db_models`
- add request/response/context/metadata models with validation
- cover conversation model validation with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a8aa80674c8320a88003cd8084f6fc