### PR TITLE
Add flexible service data models

### DIFF
--- a/common_models/__init__.py
+++ b/common_models/__init__.py
@@ -1,0 +1,11 @@
+from .dynamic_search import DynamicSearchServiceQuery
+from .search_response import SearchServiceResponse
+from .user_profile import UserServiceProfile
+from .cache_key import DynamicCacheKey
+
+__all__ = [
+    "DynamicSearchServiceQuery",
+    "SearchServiceResponse",
+    "UserServiceProfile",
+    "DynamicCacheKey",
+]

--- a/common_models/cache_key.py
+++ b/common_models/cache_key.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Union
+
+from pydantic import BaseModel, Field, ConfigDict
+
+
+class DynamicCacheKey(BaseModel):
+    """Représente une clé de cache composée dynamiquement.
+
+    La clé peut être fournie sous forme de chaîne, de liste de segments ou
+    d'objet dictionnaire.  La méthode :meth:`render` permet de produire une
+    chaîne unique exploitable par les backends de cache.
+    """
+
+    key: Union[str, List[Any], Dict[str, Any]] = Field(
+        ..., description="Structure de la clé (str, liste ou dict)."
+    )
+    metadata: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Métadonnées additionnelles associées à la clé.",
+    )
+
+    def render(self) -> str:
+        """Convertit la clé en chaîne unique."""
+        if isinstance(self.key, str):
+            return self.key
+        if isinstance(self.key, list):
+            return ":".join(str(part) for part in self.key)
+        return json.dumps(self.key, sort_keys=True)
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "key": ["search", 1, {"q": "pizza"}],
+                "metadata": {"ttl": 60},
+            }
+        }
+    )

--- a/common_models/dynamic_search.py
+++ b/common_models/dynamic_search.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, Field, ConfigDict
+
+from .cache_key import DynamicCacheKey
+
+
+class DynamicSearchServiceQuery(BaseModel):
+    """Requête flexible pour le service de recherche.
+
+    Permet d'envoyer des paramètres arbitraires tout en imposant la présence
+    d'un ``user_id`` pour raisons de sécurité et de traçabilité.
+    """
+
+    user_id: int = Field(
+        ..., description="Identifiant utilisateur (obligatoire)", gt=0
+    )
+    query: str = Field("", description="Requête textuelle libre")
+    filters: Dict[str, Any] = Field(
+        default_factory=dict, description="Filtres additionnels optionnels"
+    )
+    metadata: Dict[str, Any] = Field(
+        default_factory=dict, description="Métadonnées optionnelles"
+    )
+    cache_key: Optional[DynamicCacheKey] = Field(
+        None, description="Clé de cache éventuellement fournie"
+    )
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "user_id": 42,
+                "query": "cafés à Paris",
+                "filters": {"category": "food"},
+                "metadata": {"debug": True},
+                "cache_key": {
+                    "key": ["search", 42, "cafes"],
+                    "metadata": {"ttl": 30},
+                },
+            }
+        }
+    )

--- a/common_models/search_response.py
+++ b/common_models/search_response.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+from http import HTTPStatus
+
+from pydantic import BaseModel, Field, ConfigDict
+
+
+class SearchServiceResponse(BaseModel):
+    """Réponse générique pour le service de recherche."""
+
+    status: HTTPStatus = Field(
+        ..., description="Code de statut HTTP de la réponse"
+    )
+    data: Dict[str, Any] = Field(
+        default_factory=dict, description="Données retournées par le service"
+    )
+    error: Optional[str] = Field(
+        None, description="Message d'erreur éventuel"
+    )
+    metadata: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Métadonnées additionnelles (source, timing, etc.)",
+    )
+
+    model_config = ConfigDict(
+        use_enum_values=True,
+        json_schema_extra={
+            "example": {
+                "status": 200,
+                "data": {"results": []},
+                "error": None,
+                "metadata": {"cache_hit": False},
+            }
+        },
+    )

--- a/common_models/user_profile.py
+++ b/common_models/user_profile.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, Field, ConfigDict, EmailStr
+
+
+class UserServiceProfile(BaseModel):
+    """Profil utilisateur retourné par le user service."""
+
+    user_id: int = Field(
+        ..., description="Identifiant unique de l'utilisateur", gt=0
+    )
+    email: Optional[EmailStr] = Field(
+        None, description="Adresse e-mail de l'utilisateur"
+    )
+    first_name: Optional[str] = Field(None, description="Prénom")
+    last_name: Optional[str] = Field(None, description="Nom")
+    metadata: Dict[str, Any] = Field(
+        default_factory=dict, description="Métadonnées flexibles"
+    )
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "user_id": 123,
+                "email": "user@example.com",
+                "first_name": "Alice",
+                "metadata": {"locale": "fr-FR"},
+            }
+        }
+    )


### PR DESCRIPTION
## Summary
- add dynamic search request model with required user ID and optional cache key
- introduce search service response model with HTTP status handling
- support flexible cache key and user profile models, exporting in package init

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8aa877a908320b78b010d33050f44