### PR TITLE
Add docstrings and examples for search and user models

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,15 @@ This script runs `search_service/scripts/seed_transactions.py` and requires an
 Elasticsearch instance accessible via the `BONSAI_URL` environment variable
 or a local node at `http://localhost:9200`.
 
+## Search Service models
+
+Les modèles Pydantic exposés par le Search Service se trouvent dans le dossier
+[`search_service/models`](search_service/models). Le fichier
+[`request.py`](search_service/models/request.py) décrit la forme attendue des
+requêtes tandis que [`response.py`](search_service/models/response.py) détaille
+la réponse standardisée. Chaque modèle inclut un exemple complet de payload via
+`json_schema_extra`.
+
 ## Authentication
 
 Most endpoints, including `/conversation/chat`, require an OAuth2 Bearer token.

--- a/search_service/models/__init__.py
+++ b/search_service/models/__init__.py
@@ -1,3 +1,5 @@
+"""Expose les modèles publics du Search Service."""
+
 from .request import SearchRequest
 from .response import SearchResponse, SearchResult
 

--- a/search_service/models/request.py
+++ b/search_service/models/request.py
@@ -1,3 +1,5 @@
+"""Schémas de requêtes pour le service de recherche."""
+
 from pydantic import BaseModel, Field, field_validator, ConfigDict
 from typing import Dict, Any, Optional
 

--- a/search_service/models/response.py
+++ b/search_service/models/response.py
@@ -1,3 +1,5 @@
+"""Schémas de réponse pour le service de recherche."""
+
 from pydantic import BaseModel, Field, ConfigDict
 from typing import List, Optional, Dict, Any
 
@@ -29,6 +31,29 @@ class SearchResult(BaseModel):
     # Métadonnées de recherche
     score: Optional[float] = Field(None, description="Score de pertinence")
     highlights: Optional[Dict[str, List[str]]] = Field(None, description="Surlignade des termes")
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "transaction_id": "user_34_tx_12345",
+                "user_id": 34,
+                "account_id": 101,
+                "amount": -45.67,
+                "amount_abs": 45.67,
+                "currency_code": "EUR",
+                "transaction_type": "debit",
+                "date": "2024-01-15",
+                "month_year": "2024-01",
+                "weekday": "Monday",
+                "primary_description": "RESTAURANT LE BISTROT",
+                "merchant_name": "Le Bistrot",
+                "category_name": "Restaurant",
+                "operation_type": "card_payment",
+                "score": 1.0,
+                "highlights": {"primary_description": ["bistrot"]}
+            }
+        }
+    )
 
 class SearchResponse(BaseModel):
     """Réponse standardisée du service de recherche"""
@@ -70,14 +95,17 @@ class SearchResponse(BaseModel):
                         "merchant_name": "Le Bistrot",
                         "category_name": "Restaurant",
                         "operation_type": "card_payment",
-                        "score": 1.0
+                        "score": 1.0,
+                        "highlights": {"primary_description": ["bistrot"]}
                     }
                 ],
                 "total_results": 156,
                 "returned_results": 1,
                 "processing_time_ms": 45,
                 "elasticsearch_took": 23,
-                "cache_hit": False
+                "cache_hit": False,
+                "aggregations": {"category_name": {"buckets": [{"key": "Restaurant", "doc_count": 120}]}},
+                "query_info": {"raw_query": "restaurant italien"}
             }
         }
     )

--- a/user_service/schemas/bridge.py
+++ b/user_service/schemas/bridge.py
@@ -1,23 +1,38 @@
-from pydantic import BaseModel, Field, field_validator, ConfigDict
+"""Schémas pour l'API Bridge Connect."""
+
 from typing import Optional
-from pydantic import BaseModel, Field, field_validator
-from typing import Optional, List
+
+from pydantic import BaseModel, Field, field_validator, ConfigDict
 
 
 class ConnectSessionRequest(BaseModel):
-    callback_url: Optional[str] = None
-    country_code: Optional[str] = "FR"
-    account_types: Optional[str] = "payment"
-    context: Optional[str] = None
-    provider_id: Optional[int] = None
-    item_id: Optional[int] = None
+    """Modèle de requête pour initialiser une session Bridge Connect."""
 
-    @field_validator('context')
-    def context_length(cls, v):
+    callback_url: Optional[str] = Field(
+        default=None, description="URL de rappel après la connexion"
+    )
+    country_code: Optional[str] = Field(
+        default="FR", description="Code pays ISO à deux lettres"
+    )
+    account_types: Optional[str] = Field(
+        default="payment", description="Types de comptes demandés"
+    )
+    context: Optional[str] = Field(
+        default=None, description="Contexte opaque renvoyé après la session"
+    )
+    provider_id: Optional[int] = Field(
+        default=None, description="Identifiant du fournisseur Bridge"
+    )
+    item_id: Optional[int] = Field(
+        default=None, description="Identifiant de l'item existant"
+    )
+
+    @field_validator("context")
     @classmethod
-    def context_length(cls, v: Optional[str]):
+    def context_length(cls, v: Optional[str]) -> Optional[str]:
+        """Valide la longueur du champ `context`."""
         if v and len(v) > 100:
-            raise ValueError('context must be 100 characters or less')
+            raise ValueError("context must be 100 characters or less")
         return v
 
     model_config = ConfigDict(
@@ -26,11 +41,24 @@ class ConnectSessionRequest(BaseModel):
                 "callback_url": "https://votre-app.com/callback",
                 "country_code": "FR",
                 "account_types": "payment",
-                "context": "user-session-123"
+                "context": "user-session-123",
+                "provider_id": 12,
+                "item_id": 34,
             }
         }
     )
 
 
 class ConnectSessionResponse(BaseModel):
-    connect_url: str
+    """Réponse contenant l'URL Bridge Connect à utiliser."""
+
+    connect_url: str = Field(..., description="URL de redirection Bridge Connect")
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "connect_url": "https://connect.bridgeapi.io/session/abc123"
+            }
+        }
+    )
+


### PR DESCRIPTION
## Summary
- document search service models with module docstrings and example payloads
- clean up Bridge connect schemas with field descriptions and examples
- mention search models in README

## Testing
- `pytest` *(fails: async functions not supported; ModuleNotFoundError: pydantic_settings)*

------
https://chatgpt.com/codex/tasks/task_e_68a8aa8b890483209c74995ce23e7f6f