### PR TITLE
Clean up model exports and validations

### DIFF
--- a/conversation_service/models/__init__.py
+++ b/conversation_service/models/__init__.py
@@ -1,12 +1,13 @@
-from .agent_models import AgentStep, AgentTrace
-from .conversation_models import Conversation, ConversationSummary, ConversationTurn
+"""Public exports for conversation service models."""
 
-__all__ = [
-    "AgentStep",
-    "AgentTrace",
-    "Conversation",
-    "ConversationSummary",
-    "ConversationTurn",
+from .agent_models import (
+    AgentStep,
+    AgentTrace,
+    AgentConfig,
+    IntentResult,
+    DynamicFinancialEntity,
+    AgentResponse,
+)
 from .conversation_models import (
     ConversationRequest,
     ConversationResponse,
@@ -14,21 +15,24 @@ from .conversation_models import (
     ConversationContext,
 )
 from .conversation_db_models import (
-"""Expose Pydantic models for external use."""
-
-from .agent_models import (
-    AgentConfig,
-    IntentResult,
-    DynamicFinancialEntity,
-    AgentResponse,
-)
-from .conversation_models import (
     Conversation,
     ConversationSummary,
     ConversationTurn,
 )
+from .enums import (
+    IntentType,
+    EntityType,
+    QueryType,
+    ConfidenceThreshold,
+)
 
 __all__ = [
+    "AgentStep",
+    "AgentTrace",
+    "AgentConfig",
+    "IntentResult",
+    "DynamicFinancialEntity",
+    "AgentResponse",
     "ConversationRequest",
     "ConversationResponse",
     "ConversationMetadata",
@@ -36,19 +40,6 @@ __all__ = [
     "Conversation",
     "ConversationSummary",
     "ConversationTurn",
-    "AgentConfig",
-    "IntentResult",
-    "DynamicFinancialEntity",
-    "AgentResponse",
-    "Conversation",
-    "ConversationSummary",
-    "ConversationTurn",
-
-"""Exports publics du package `conversation_service.models`."""
-
-from .enums import ConfidenceThreshold, EntityType, IntentType, QueryType
-
-__all__ = [
     "IntentType",
     "EntityType",
     "QueryType",

--- a/conversation_service/models/agent_models.py
+++ b/conversation_service/models/agent_models.py
@@ -1,8 +1,10 @@
-"""Models describing agent execution traces."""
+"""Pydantic models related to agent configuration and execution."""
+
+from __future__ import annotations
 
 from typing import List
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class AgentStep(BaseModel):
@@ -37,14 +39,6 @@ class AgentTrace(BaseModel):
         if not self.steps:
             raise ValueError("steps cannot be empty")
         return self
-
-from __future__ import annotations
-
-"""Pydantic models for agent configuration and responses."""
-
-from typing import List
-
-from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class AgentConfig(BaseModel):

--- a/conversation_service/models/conversation_db_models.py
+++ b/conversation_service/models/conversation_db_models.py
@@ -1,31 +1,15 @@
+"""Pydantic models representing conversation data persisted in the database."""
+
+from __future__ import annotations
+
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class Conversation(BaseModel):
-    """Représente une conversation utilisateur.
-
-    Example:
-        {
-            "id": 1,
-            "conversation_id": "conv_123",
-            "user_id": 42,
-            "title": "Budget 2024",
-            "status": "active",
-            "language": "fr",
-            "domain": "finance",
-            "total_turns": 2,
-            "max_turns": 50,
-            "last_activity_at": "2024-06-01T12:00:00Z",
-            "conversation_metadata": {"topic": "budget"},
-            "user_preferences": {"tone": "friendly"},
-            "session_metadata": {"browser": "firefox"},
-            "created_at": "2024-06-01T12:00:00Z",
-            "updated_at": "2024-06-01T12:05:00Z"
-        }
-    """
+    """Représente une conversation utilisateur."""
 
     id: int
     conversation_id: str
@@ -59,28 +43,30 @@ class Conversation(BaseModel):
             "user_preferences": {"tone": "friendly"},
             "session_metadata": {"browser": "firefox"},
             "created_at": "2024-06-01T12:00:00Z",
-            "updated_at": "2024-06-01T12:05:00Z"
+            "updated_at": "2024-06-01T12:05:00Z",
         }
     })
 
+    @field_validator("user_id")
+    @classmethod
+    def user_id_positive(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("user_id must be positive")
+        return v
+
+    @model_validator(mode="after")
+    def validate_consistency(self) -> "Conversation":
+        if self.total_turns > self.max_turns:
+            raise ValueError("total_turns cannot exceed max_turns")
+        if self.updated_at < self.created_at:
+            raise ValueError("updated_at must be after created_at")
+        if self.last_activity_at < self.created_at:
+            raise ValueError("last_activity_at must be after created_at")
+        return self
+
 
 class ConversationSummary(BaseModel):
-    """Résumé partiel d'une conversation.
-
-    Example:
-        {
-            "id": 1,
-            "conversation_id": 1,
-            "start_turn": 1,
-            "end_turn": 4,
-            "summary_text": "...",
-            "key_topics": ["budget", "économie"],
-            "important_entities": [{"name": "Paris", "type": "city"}],
-            "summary_method": "llm",
-            "created_at": "2024-06-01T12:00:00Z",
-            "updated_at": "2024-06-01T12:05:00Z"
-        }
-    """
+    """Résumé partiel d'une conversation."""
 
     id: int
     conversation_id: int
@@ -104,36 +90,26 @@ class ConversationSummary(BaseModel):
             "important_entities": [{"name": "Paris", "type": "city"}],
             "summary_method": "llm",
             "created_at": "2024-06-01T12:00:00Z",
-            "updated_at": "2024-06-01T12:05:00Z"
+            "updated_at": "2024-06-01T12:05:00Z",
         }
     })
 
+    @field_validator("conversation_id", "start_turn", "end_turn")
+    @classmethod
+    def positive_numbers(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("must be positive")
+        return v
+
+    @model_validator(mode="after")
+    def validate_turns(self) -> "ConversationSummary":
+        if self.end_turn < self.start_turn:
+            raise ValueError("end_turn must be >= start_turn")
+        return self
+
 
 class ConversationTurn(BaseModel):
-    """Tour de conversation entre l'utilisateur et l'assistant.
-
-    Example:
-        {
-            "id": 10,
-            "turn_id": "turn_0010",
-            "conversation_id": 1,
-            "turn_number": 3,
-            "user_message": "Quel est mon solde ?",
-            "assistant_response": "Votre solde est de 50€.",
-            "processing_time_ms": 120.5,
-            "confidence_score": 0.98,
-            "error_occurred": false,
-            "error_message": null,
-            "intent_result": {"name": "check_balance"},
-            "agent_chain": [{"agent": "retrieval", "status": "ok"}],
-            "search_query_used": "balance account",
-            "search_results_count": 3,
-            "search_execution_time_ms": 50.2,
-            "turn_metadata": {"debug": true},
-            "created_at": "2024-06-01T12:00:00Z",
-            "updated_at": "2024-06-01T12:00:01Z"
-        }
-    """
+    """Tour de conversation entre l'utilisateur et l'assistant."""
 
     id: int
     turn_id: str
@@ -173,6 +149,26 @@ class ConversationTurn(BaseModel):
             "search_execution_time_ms": 50.2,
             "turn_metadata": {"debug": True},
             "created_at": "2024-06-01T12:00:00Z",
-            "updated_at": "2024-06-01T12:00:01Z"
+            "updated_at": "2024-06-01T12:00:01Z",
         }
     })
+
+    @field_validator("conversation_id", "turn_number", "search_results_count")
+    @classmethod
+    def non_negative(cls, v: int) -> int:
+        if v < 0:
+            raise ValueError("must be non-negative")
+        return v
+
+    @field_validator("processing_time_ms", "search_execution_time_ms", "confidence_score")
+    @classmethod
+    def positive_floats(cls, v: Optional[float]) -> Optional[float]:
+        if v is not None and v < 0:
+            raise ValueError("must be non-negative")
+        return v
+
+    @model_validator(mode="after")
+    def validate_dates(self) -> "ConversationTurn":
+        if self.updated_at < self.created_at:
+            raise ValueError("updated_at must be after created_at")
+        return self


### PR DESCRIPTION
## Summary
- Simplify `conversation_service.models` package exports
- Rebuild agent and conversation models with proper structure
- Add validation rules for conversation database models

## Testing
- `pytest tests/conversation_service/models/test_*`


------
https://chatgpt.com/codex/tasks/task_e_68a8b5d457ec832084ade23e6e0287ee