### PR TITLE
Refactor conversation models with strict validation

### DIFF
--- a/conversation_service/models/__init__.py
+++ b/conversation_service/models/__init__.py
@@ -1,56 +1,43 @@
-from .agent_models import AgentStep, AgentTrace
-from .conversation_models import Conversation, ConversationSummary, ConversationTurn
-
-__all__ = [
-    "AgentStep",
-    "AgentTrace",
-    "Conversation",
-    "ConversationSummary",
-    "ConversationTurn",
-from .conversation_models import (
-    ConversationRequest,
-    ConversationResponse,
-    ConversationMetadata,
-    ConversationContext,
-)
-from .conversation_db_models import (
 """Expose Pydantic models for external use."""
 
 from .agent_models import (
     AgentConfig,
-    IntentResult,
-    DynamicFinancialEntity,
     AgentResponse,
+    AgentStep,
+    AgentTrace,
+    DynamicFinancialEntity,
+    IntentResult,
 )
-from .conversation_models import (
+from .conversation_db_models import (
     Conversation,
     ConversationSummary,
     ConversationTurn,
 )
-
-__all__ = [
-    "ConversationRequest",
-    "ConversationResponse",
-    "ConversationMetadata",
-    "ConversationContext",
-    "Conversation",
-    "ConversationSummary",
-    "ConversationTurn",
-    "AgentConfig",
-    "IntentResult",
-    "DynamicFinancialEntity",
-    "AgentResponse",
-    "Conversation",
-    "ConversationSummary",
-    "ConversationTurn",
-
-"""Exports publics du package `conversation_service.models`."""
-
+from .conversation_models import (
+    ConversationContext,
+    ConversationMetadata,
+    ConversationRequest,
+    ConversationResponse,
+)
 from .enums import ConfidenceThreshold, EntityType, IntentType, QueryType
 
 __all__ = [
-    "IntentType",
-    "EntityType",
-    "QueryType",
+    "AgentConfig",
+    "AgentResponse",
+    "AgentStep",
+    "AgentTrace",
+    "DynamicFinancialEntity",
+    "IntentResult",
+    "Conversation",
+    "ConversationSummary",
+    "ConversationTurn",
+    "ConversationContext",
+    "ConversationMetadata",
+    "ConversationRequest",
+    "ConversationResponse",
     "ConfidenceThreshold",
+    "EntityType",
+    "IntentType",
+    "QueryType",
 ]
+

--- a/conversation_service/models/agent_models.py
+++ b/conversation_service/models/agent_models.py
@@ -1,8 +1,10 @@
-"""Models describing agent execution traces."""
+"""Pydantic models describing agent configurations and traces."""
+
+from __future__ import annotations
 
 from typing import List
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class AgentStep(BaseModel):
@@ -37,14 +39,6 @@ class AgentTrace(BaseModel):
         if not self.steps:
             raise ValueError("steps cannot be empty")
         return self
-
-from __future__ import annotations
-
-"""Pydantic models for agent configuration and responses."""
-
-from typing import List
-
-from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class AgentConfig(BaseModel):
@@ -174,3 +168,4 @@ class AgentResponse(BaseModel):
         if not 0.0 <= v <= 1.0:
             raise ValueError("confidence_score must be between 0.0 and 1.0")
         return v
+

--- a/conversation_service/models/conversation_db_models.py
+++ b/conversation_service/models/conversation_db_models.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class Conversation(BaseModel):
@@ -34,8 +36,8 @@ class Conversation(BaseModel):
     status: str
     language: str
     domain: str
-    total_turns: int
-    max_turns: int
+    total_turns: int = Field(ge=0)
+    max_turns: int = Field(ge=0)
     last_activity_at: datetime
     conversation_metadata: Dict[str, Any] = Field(default_factory=dict)
     user_preferences: Dict[str, Any] = Field(default_factory=dict)
@@ -63,6 +65,23 @@ class Conversation(BaseModel):
         }
     })
 
+    @field_validator("user_id")
+    @classmethod
+    def user_id_positive(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("user_id must be positive")
+        return v
+
+    @model_validator(mode="after")
+    def validate_consistency(self) -> "Conversation":
+        if self.total_turns > self.max_turns:
+            raise ValueError("total_turns cannot exceed max_turns")
+        if self.updated_at < self.created_at:
+            raise ValueError("updated_at must be after created_at")
+        if self.last_activity_at < self.created_at:
+            raise ValueError("last_activity_at must be after created_at")
+        return self
+
 
 class ConversationSummary(BaseModel):
     """Résumé partiel d'une conversation.
@@ -84,8 +103,8 @@ class ConversationSummary(BaseModel):
 
     id: int
     conversation_id: int
-    start_turn: int
-    end_turn: int
+    start_turn: int = Field(ge=1)
+    end_turn: int = Field(ge=1)
     summary_text: str
     key_topics: List[str] = Field(default_factory=list)
     important_entities: List[Dict[str, Any]] = Field(default_factory=list)
@@ -107,6 +126,21 @@ class ConversationSummary(BaseModel):
             "updated_at": "2024-06-01T12:05:00Z"
         }
     })
+
+    @field_validator("conversation_id", "start_turn", "end_turn")
+    @classmethod
+    def positive_numbers(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("must be positive")
+        return v
+
+    @model_validator(mode="after")
+    def validate_turns(self) -> "ConversationSummary":
+        if self.end_turn < self.start_turn:
+            raise ValueError("end_turn must be >= start_turn")
+        if self.updated_at < self.created_at:
+            raise ValueError("updated_at must be after created_at")
+        return self
 
 
 class ConversationTurn(BaseModel):
@@ -138,18 +172,18 @@ class ConversationTurn(BaseModel):
     id: int
     turn_id: str
     conversation_id: int
-    turn_number: int
-    user_message: str
-    assistant_response: str
-    processing_time_ms: Optional[float] = None
-    confidence_score: Optional[float] = None
+    turn_number: int = Field(ge=1)
+    user_message: str = Field(min_length=1)
+    assistant_response: str = Field(min_length=1)
+    processing_time_ms: Optional[float] = Field(default=None, ge=0.0)
+    confidence_score: Optional[float] = Field(default=None, ge=0.0, le=1.0)
     error_occurred: bool
     error_message: Optional[str] = None
     intent_result: Optional[Dict[str, Any]] = None
     agent_chain: List[Dict[str, Any]] = Field(default_factory=list)
     search_query_used: Optional[str] = None
-    search_results_count: int
-    search_execution_time_ms: Optional[float] = None
+    search_results_count: int = Field(ge=0)
+    search_execution_time_ms: Optional[float] = Field(default=None, ge=0.0)
     turn_metadata: Dict[str, Any] = Field(default_factory=dict)
     created_at: datetime
     updated_at: datetime
@@ -176,3 +210,16 @@ class ConversationTurn(BaseModel):
             "updated_at": "2024-06-01T12:00:01Z"
         }
     })
+
+    @field_validator("conversation_id")
+    @classmethod
+    def conversation_id_positive(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("conversation_id must be positive")
+        return v
+
+    @model_validator(mode="after")
+    def validate_times(self) -> "ConversationTurn":
+        if self.updated_at < self.created_at:
+            raise ValueError("updated_at must be after created_at")
+        return self

--- a/conversation_service/models/conversation_models.py
+++ b/conversation_service/models/conversation_models.py
@@ -1,66 +1,42 @@
+"""Pydantic models for the conversation service API (phase 2)."""
+
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from uuid import UUID
-from pydantic import BaseModel, Field, ConfigDict, field_validator
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class ConversationMetadata(BaseModel):
-    """Metadata about the conversation such as intent and confidence."""
+    """Optional metadata associated with a conversation."""
 
     intent: str | None = None
     confidence_score: float | None = Field(default=None, ge=0.0, le=1.0)
 
-    model_config = ConfigDict(json_schema_extra={
-        "example": {
-            "intent": "greeting",
-            "confidence_score": 0.95,
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "intent": "greeting",
+                "confidence_score": 0.95,
+            }
         }
-    })
-
-    @field_validator("user_id")
-    @classmethod
-    def user_id_positive(cls, v: int) -> int:
-        if v <= 0:
-            raise ValueError("user_id must be positive")
-        return v
-
-    @model_validator(mode="after")
-    def validate_consistency(self) -> "Conversation":
-        if self.total_turns > self.max_turns:
-            raise ValueError("total_turns cannot exceed max_turns")
-        if self.updated_at < self.created_at:
-            raise ValueError("updated_at must be after created_at")
-        if self.last_activity_at < self.created_at:
-            raise ValueError("last_activity_at must be after created_at")
-        return self
+    )
 
 
 class ConversationContext(BaseModel):
-    """Contextual information for the conversation."""
+    """Context information provided with a request or response."""
 
     conversation_id: UUID | None = None
     turn_number: int = Field(ge=1)
 
-    model_config = ConfigDict(json_schema_extra={
-        "example": {
-            "conversation_id": "550e8400-e29b-41d4-a716-446655440000",
-            "turn_number": 1,
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "conversation_id": "550e8400-e29b-41d4-a716-446655440000",
+                "turn_number": 1,
+            }
         }
-    })
-
-    @field_validator("conversation_id", "start_turn", "end_turn")
-    @classmethod
-    def positive_numbers(cls, v: int) -> int:
-        if v <= 0:
-            raise ValueError("must be positive")
-        return v
-
-    @model_validator(mode="after")
-    def validate_turns(self) -> "ConversationSummary":
-        if self.end_turn < self.start_turn:
-            raise ValueError("end_turn must be >= start_turn")
-        return self
+    )
 
 
 class ConversationRequest(BaseModel):
@@ -70,16 +46,19 @@ class ConversationRequest(BaseModel):
     language: str = Field(min_length=2, max_length=2)
     context: ConversationContext
 
-    model_config = ConfigDict(str_strip_whitespace=True, json_schema_extra={
-        "example": {
-            "message": "Bonjour",
-            "language": "fr",
-            "context": {
-                "conversation_id": "550e8400-e29b-41d4-a716-446655440000",
-                "turn_number": 1,
-            },
-        }
-    })
+    model_config = ConfigDict(
+        str_strip_whitespace=True,
+        json_schema_extra={
+            "example": {
+                "message": "Bonjour",
+                "language": "fr",
+                "context": {
+                    "conversation_id": "550e8400-e29b-41d4-a716-446655440000",
+                    "turn_number": 1,
+                },
+            }
+        },
+    )
 
     @field_validator("language")
     @classmethod
@@ -90,50 +69,35 @@ class ConversationRequest(BaseModel):
 
 
 class ConversationResponse(BaseModel):
-    """Assistant response returned by the conversation service."""
+    """Response returned by the conversation service."""
 
     response: str = Field(min_length=1)
     language: str = Field(min_length=2, max_length=2)
     context: ConversationContext
     metadata: ConversationMetadata | None = None
 
-    model_config = ConfigDict(str_strip_whitespace=True, json_schema_extra={
-        "example": {
-            "response": "Bonjour! Comment puis-je vous aider?",
-            "language": "fr",
-            "context": {
-                "conversation_id": "550e8400-e29b-41d4-a716-446655440000",
-                "turn_number": 1,
-            },
-            "metadata": {
-                "intent": "greeting",
-                "confidence_score": 0.95,
-            },
-        }
-    })
+    model_config = ConfigDict(
+        str_strip_whitespace=True,
+        json_schema_extra={
+            "example": {
+                "response": "Bonjour! Comment puis-je vous aider?",
+                "language": "fr",
+                "context": {
+                    "conversation_id": "550e8400-e29b-41d4-a716-446655440000",
+                    "turn_number": 1,
+                },
+                "metadata": {
+                    "intent": "greeting",
+                    "confidence_score": 0.95,
+                },
+            }
+        },
+    )
 
-    @field_validator("conversation_id", "turn_number", "search_results_count")
-    @classmethod
-    def non_negative(cls, v: int) -> int:
-        if v < 0:
-            raise ValueError("must be non-negative")
-        return v
-
-    @field_validator("processing_time_ms", "search_execution_time_ms")
-    @classmethod
-    def positive_floats(cls, v: Optional[float]) -> Optional[float]:
-        if v is not None and v < 0:
-            raise ValueError("must be non-negative")
-        return v
-
-    @model_validator(mode="after")
-    def validate_dates(self) -> "ConversationTurn":
-        if self.updated_at < self.created_at:
-            raise ValueError("updated_at must be after created_at")
-        return self
     @field_validator("language")
     @classmethod
     def validate_language(cls, v: str) -> str:
         if len(v) != 2 or not v.isalpha():
             raise ValueError("language must be a 2-letter ISO code")
         return v.lower()
+


### PR DESCRIPTION
## Summary
- add phase 2 conversation models with message/language validation
- enforce positive ids and turn ordering in conversation database models
- tidy model exports and agent model definitions

## Testing
- `pytest tests/conversation_service/models/test_conversation_models.py tests/conversation_service/models/test_cross_models.py`

------
https://chatgpt.com/codex/tasks/task_e_68a8b5e2e24c832085535cd92b2c8d92