### PR TITLE
Refactor conversation service model exports

### DIFF
--- a/conversation_service/models/__init__.py
+++ b/conversation_service/models/__init__.py
@@ -1,16 +1,10 @@
-"""Expose Pydantic models for external use."""
-
-from .agent_models import (
-"""Expose agent models for external use."""
-"""Public exports for conversation service models."""
+"""Expose conversation service models for external use."""
 
 from .agent_models import (
     AgentStep,
     AgentTrace,
     AgentConfig,
     AgentResponse,
-    AgentStep,
-    AgentTrace,
     DynamicFinancialEntity,
     IntentResult,
 )
@@ -25,15 +19,6 @@ from .conversation_db_models import (
     ConversationSummary,
     ConversationTurn,
 )
-from .conversation_models import (
-    ConversationContext,
-    ConversationMetadata,
-    ConversationRequest,
-    ConversationResponse,
-)
-from .enums import ConfidenceThreshold, EntityType, IntentType, QueryType
-
-__all__ = [
 from .enums import (
     IntentType,
     EntityType,
@@ -42,24 +27,12 @@ from .enums import (
 )
 
 __all__ = [
-
     "AgentStep",
     "AgentTrace",
     "AgentConfig",
     "AgentResponse",
-    "AgentStep",
-    "AgentTrace",
     "DynamicFinancialEntity",
     "IntentResult",
-    "Conversation",
-    "ConversationSummary",
-    "ConversationTurn",
-    "ConversationContext",
-    "ConversationMetadata",
-    "ConversationRequest",
-    "ConversationResponse",
-    "ConfidenceThreshold",
-
     "ConversationRequest",
     "ConversationResponse",
     "ConversationMetadata",
@@ -69,7 +42,6 @@ __all__ = [
     "ConversationTurn",
     "IntentType",
     "EntityType",
-    "IntentType",
     "QueryType",
+    "ConfidenceThreshold",
 ]
-

--- a/conversation_service/models/conversation_db_models.py
+++ b/conversation_service/models/conversation_db_models.py
@@ -1,4 +1,3 @@
-
 """Pydantic models representing conversation data persisted in the database."""
 
 from __future__ import annotations
@@ -10,12 +9,12 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 
 class Conversation(BaseModel):
-    """Représente une conversation utilisateur."""
+    """Represents a persisted conversation."""
 
     id: int
     conversation_id: str
     user_id: int
-    title: Optional[str] = None
+    title: str | None = None
     status: str
     language: str
     domain: str
@@ -28,25 +27,27 @@ class Conversation(BaseModel):
     created_at: datetime
     updated_at: datetime
 
-    model_config = ConfigDict(json_schema_extra={
-        "example": {
-            "id": 1,
-            "conversation_id": "conv_123",
-            "user_id": 42,
-            "title": "Budget 2024",
-            "status": "active",
-            "language": "fr",
-            "domain": "finance",
-            "total_turns": 2,
-            "max_turns": 50,
-            "last_activity_at": "2024-06-01T12:00:00Z",
-            "conversation_metadata": {"topic": "budget"},
-            "user_preferences": {"tone": "friendly"},
-            "session_metadata": {"browser": "firefox"},
-            "created_at": "2024-06-01T12:00:00Z",
-            "updated_at": "2024-06-01T12:05:00Z",
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "id": 1,
+                "conversation_id": "conv_123",
+                "user_id": 42,
+                "title": "Budget 2024",
+                "status": "active",
+                "language": "fr",
+                "domain": "finance",
+                "total_turns": 2,
+                "max_turns": 50,
+                "last_activity_at": "2024-06-01T12:00:00Z",
+                "conversation_metadata": {"topic": "budget"},
+                "user_preferences": {"tone": "friendly"},
+                "session_metadata": {"browser": "firefox"},
+                "created_at": "2024-06-01T12:00:00Z",
+                "updated_at": "2024-06-01T12:05:00Z",
+            }
         }
-    })
+    )
 
     @field_validator("user_id")
     @classmethod
@@ -66,20 +67,8 @@ class Conversation(BaseModel):
         return self
 
 
-
-    @model_validator(mode="after")
-    def validate_consistency(self) -> "Conversation":
-        if self.total_turns > self.max_turns:
-            raise ValueError("total_turns cannot exceed max_turns")
-        if self.updated_at < self.created_at:
-            raise ValueError("updated_at must be after created_at")
-        if self.last_activity_at < self.created_at:
-            raise ValueError("last_activity_at must be after created_at")
-        return self
-
-
 class ConversationSummary(BaseModel):
-    """Résumé partiel d'une conversation."""
+    """Partial summary of a conversation."""
 
     id: int
     conversation_id: int
@@ -92,20 +81,22 @@ class ConversationSummary(BaseModel):
     created_at: datetime
     updated_at: datetime
 
-    model_config = ConfigDict(json_schema_extra={
-        "example": {
-            "id": 1,
-            "conversation_id": 1,
-            "start_turn": 1,
-            "end_turn": 4,
-            "summary_text": "Résumé des échanges...",
-            "key_topics": ["budget", "économie"],
-            "important_entities": [{"name": "Paris", "type": "city"}],
-            "summary_method": "llm",
-            "created_at": "2024-06-01T12:00:00Z",
-            "updated_at": "2024-06-01T12:05:00Z",
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "id": 1,
+                "conversation_id": 1,
+                "start_turn": 1,
+                "end_turn": 4,
+                "summary_text": "Résumé des échanges...",
+                "key_topics": ["budget", "économie"],
+                "important_entities": [{"name": "Paris", "type": "city"}],
+                "summary_method": "llm",
+                "created_at": "2024-06-01T12:00:00Z",
+                "updated_at": "2024-06-01T12:05:00Z",
+            }
         }
-    })
+    )
 
     @field_validator("conversation_id", "start_turn", "end_turn")
     @classmethod
@@ -123,16 +114,8 @@ class ConversationSummary(BaseModel):
         return self
 
 
-
-    @model_validator(mode="after")
-    def validate_turns(self) -> "ConversationSummary":
-        if self.end_turn < self.start_turn:
-            raise ValueError("end_turn must be >= start_turn")
-        return self
-
-
 class ConversationTurn(BaseModel):
-    """Tour de conversation entre l'utilisateur et l'assistant."""
+    """Single turn exchanged in a conversation."""
 
     id: int
     turn_id: str
@@ -153,38 +136,31 @@ class ConversationTurn(BaseModel):
     created_at: datetime
     updated_at: datetime
 
-    model_config = ConfigDict(json_schema_extra={
-        "example": {
-            "id": 10,
-            "turn_id": "turn_0010",
-            "conversation_id": 1,
-            "turn_number": 3,
-            "user_message": "Quel est mon solde ?",
-            "assistant_response": "Votre solde est de 50€.",
-            "processing_time_ms": 120.5,
-            "confidence_score": 0.98,
-            "error_occurred": False,
-            "error_message": None,
-            "intent_result": {"name": "check_balance"},
-            "agent_chain": [{"agent": "retrieval", "status": "ok"}],
-            "search_query_used": "balance account",
-            "search_results_count": 3,
-            "search_execution_time_ms": 50.2,
-            "turn_metadata": {"debug": True},
-            "created_at": "2024-06-01T12:00:00Z",
-            "updated_at": "2024-06-01T12:00:01Z",
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "id": 10,
+                "turn_id": "turn_0010",
+                "conversation_id": 1,
+                "turn_number": 3,
+                "user_message": "Quel est mon solde ?",
+                "assistant_response": "Votre solde est de 50€.",
+                "processing_time_ms": 120.5,
+                "confidence_score": 0.98,
+                "error_occurred": False,
+                "error_message": None,
+                "intent_result": {"name": "check_balance"},
+                "agent_chain": [{"agent": "retrieval", "status": "ok"}],
+                "search_query_used": "balance account",
+                "search_results_count": 3,
+                "search_execution_time_ms": 50.2,
+                "turn_metadata": {"debug": True},
+                "created_at": "2024-06-01T12:00:00Z",
+                "updated_at": "2024-06-01T12:00:01Z",
+            }
         }
-    })
+    )
 
-    @field_validator("conversation_id")
-    @classmethod
-    def conversation_id_positive(cls, v: int) -> int:
-        if v <= 0:
-            raise ValueError("conversation_id must be positive")
-        return v
-
-    @model_validator(mode="after")
-    def validate_times(self) -> "ConversationTurn":
     @field_validator("conversation_id", "turn_number", "search_results_count")
     @classmethod
     def non_negative(cls, v: int) -> int:
@@ -192,7 +168,9 @@ class ConversationTurn(BaseModel):
             raise ValueError("must be non-negative")
         return v
 
-    @field_validator("processing_time_ms", "search_execution_time_ms", "confidence_score")
+    @field_validator(
+        "processing_time_ms", "search_execution_time_ms", "confidence_score"
+    )
     @classmethod
     def positive_floats(cls, v: Optional[float]) -> Optional[float]:
         if v is not None and v < 0:
@@ -201,7 +179,6 @@ class ConversationTurn(BaseModel):
 
     @model_validator(mode="after")
     def validate_dates(self) -> "ConversationTurn":
-
         if self.updated_at < self.created_at:
             raise ValueError("updated_at must be after created_at")
         return self

--- a/conversation_service/models/conversation_models.py
+++ b/conversation_service/models/conversation_models.py
@@ -1,5 +1,3 @@
-"""Pydantic models for the conversation service API (phase 2)."""
-
 """Pydantic models for conversation requests and responses."""
 
 from __future__ import annotations
@@ -17,15 +15,9 @@ class ConversationMetadata(BaseModel):
 
     model_config = ConfigDict(
         json_schema_extra={
-            "example": {
-                "intent": "greeting",
-                "confidence_score": 0.95,
-            }
+            "example": {"intent": "greeting", "confidence_score": 0.95}
         }
     )
-    model_config = ConfigDict(json_schema_extra={
-        "example": {"intent": "greeting", "confidence_score": 0.95}
-    })
 
 
 class ConversationContext(BaseModel):
@@ -42,8 +34,6 @@ class ConversationContext(BaseModel):
             }
         }
     )
-    })
-
 
 
 class ConversationRequest(BaseModel):
@@ -101,25 +91,9 @@ class ConversationResponse(BaseModel):
         },
     )
 
-    model_config = ConfigDict(str_strip_whitespace=True, json_schema_extra={
-        "example": {
-            "response": "Bonjour! Comment puis-je vous aider?",
-            "language": "fr",
-            "context": {
-                "conversation_id": "550e8400-e29b-41d4-a716-446655440000",
-                "turn_number": 1,
-            },
-            "metadata": {
-                "intent": "greeting",
-                "confidence_score": 0.95,
-            },
-        }
-    })
-
     @field_validator("language")
     @classmethod
     def validate_language(cls, v: str) -> str:
         if len(v) != 2 or not v.isalpha():
             raise ValueError("language must be a 2-letter ISO code")
         return v.lower()
-


### PR DESCRIPTION
## Summary
- clean up `conversation_service.models` package exports
- rebuild agent and conversation data models with validation
- ensure conversation models import correctly

## Testing
- `pytest tests/conversation_service/models/test_*`

------
https://chatgpt.com/codex/tasks/task_e_68a8bc6eeb488320899f1f05cb186e80