### PR TITLE
Refactor agent models and restore validation

### DIFF
--- a/conversation_service/models/__init__.py
+++ b/conversation_service/models/__init__.py
@@ -1,12 +1,6 @@
-"""Expose Pydantic models for external use."""
-
-from .agent_models import (
 """Expose agent models for external use."""
-"""Public exports for conversation service models."""
 
 from .agent_models import (
-    AgentStep,
-    AgentTrace,
     AgentConfig,
     AgentResponse,
     AgentStep,
@@ -14,62 +8,13 @@ from .agent_models import (
     DynamicFinancialEntity,
     IntentResult,
 )
-from .conversation_models import (
-    ConversationRequest,
-    ConversationResponse,
-    ConversationMetadata,
-    ConversationContext,
-)
-from .conversation_db_models import (
-    Conversation,
-    ConversationSummary,
-    ConversationTurn,
-)
-from .conversation_models import (
-    ConversationContext,
-    ConversationMetadata,
-    ConversationRequest,
-    ConversationResponse,
-)
-from .enums import ConfidenceThreshold, EntityType, IntentType, QueryType
 
 __all__ = [
-from .enums import (
-    IntentType,
-    EntityType,
-    QueryType,
-    ConfidenceThreshold,
-)
-
-__all__ = [
-
-    "AgentStep",
-    "AgentTrace",
     "AgentConfig",
     "AgentResponse",
     "AgentStep",
     "AgentTrace",
     "DynamicFinancialEntity",
     "IntentResult",
-    "Conversation",
-    "ConversationSummary",
-    "ConversationTurn",
-    "ConversationContext",
-    "ConversationMetadata",
-    "ConversationRequest",
-    "ConversationResponse",
-    "ConfidenceThreshold",
-
-    "ConversationRequest",
-    "ConversationResponse",
-    "ConversationMetadata",
-    "ConversationContext",
-    "Conversation",
-    "ConversationSummary",
-    "ConversationTurn",
-    "IntentType",
-    "EntityType",
-    "IntentType",
-    "QueryType",
 ]
 


### PR DESCRIPTION
## Summary
- Clean up agent model module and consolidate imports
- Rebuild agent step/trace with explicit validation and examples
- Re-export agent models from a simplified package init

## Testing
- `pytest tests/conversation_service/models/test_agent_models.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8bc70c95483209be2658a122906f2