### PR TITLE
Clean conversation models and fix validations

### DIFF
--- a/conversation_service/models/__init__.py
+++ b/conversation_service/models/__init__.py
@@ -1,12 +1,6 @@
 """Expose Pydantic models for external use."""
 
 from .agent_models import (
-"""Expose agent models for external use."""
-"""Public exports for conversation service models."""
-
-from .agent_models import (
-    AgentStep,
-    AgentTrace,
     AgentConfig,
     AgentResponse,
     AgentStep,
@@ -14,17 +8,7 @@ from .agent_models import (
     DynamicFinancialEntity,
     IntentResult,
 )
-from .conversation_models import (
-    ConversationRequest,
-    ConversationResponse,
-    ConversationMetadata,
-    ConversationContext,
-)
-from .conversation_db_models import (
-    Conversation,
-    ConversationSummary,
-    ConversationTurn,
-)
+from .conversation_db_models import Conversation, ConversationSummary, ConversationTurn
 from .conversation_models import (
     ConversationContext,
     ConversationMetadata,
@@ -34,17 +18,6 @@ from .conversation_models import (
 from .enums import ConfidenceThreshold, EntityType, IntentType, QueryType
 
 __all__ = [
-from .enums import (
-    IntentType,
-    EntityType,
-    QueryType,
-    ConfidenceThreshold,
-)
-
-__all__ = [
-
-    "AgentStep",
-    "AgentTrace",
     "AgentConfig",
     "AgentResponse",
     "AgentStep",
@@ -59,15 +32,6 @@ __all__ = [
     "ConversationRequest",
     "ConversationResponse",
     "ConfidenceThreshold",
-
-    "ConversationRequest",
-    "ConversationResponse",
-    "ConversationMetadata",
-    "ConversationContext",
-    "Conversation",
-    "ConversationSummary",
-    "ConversationTurn",
-    "IntentType",
     "EntityType",
     "IntentType",
     "QueryType",

--- a/conversation_service/models/agent_models.py
+++ b/conversation_service/models/agent_models.py
@@ -1,15 +1,6 @@
 """Pydantic models describing agent configurations and traces."""
 
 from __future__ import annotations
-"""Pydantic models describing agent traces, configuration, and responses."""
-
-"""Pydantic models related to agent configuration and execution."""
-
-  from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
-
-from __future__ import annotations
-
-from __future__ import annotations
 
 from typing import Any, List
 
@@ -19,12 +10,10 @@ from pydantic import (
     Field,
     ValidationError,
     field_validator,
+    model_validator,
 )
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-
-# Agent trace models
 class AgentStep(BaseModel):
     """Single step executed by an agent."""
 
@@ -61,17 +50,16 @@ class AgentTrace(BaseModel):
             errors.append({"loc": ("steps",), "msg": "steps cannot be empty", "type": "value_error"})
         data["steps"] = converted_steps
         if data.get("total_time_ms") is not None and data["total_time_ms"] < 0:
-            errors.append({
-                "loc": ("total_time_ms",),
-                "msg": "total_time_ms must be non-negative",
-                "type": "value_error",
-            })
+            errors.append(
+                {
+                    "loc": ("total_time_ms",),
+                    "msg": "total_time_ms must be non-negative",
+                    "type": "value_error",
+                }
+            )
         if errors:
             raise ValidationError(errors, type(self))
         super().__init__(**data)
-
-
-# Advanced agent models
 
     @field_validator("total_time_ms")
     @classmethod
@@ -207,7 +195,7 @@ class AgentResponse(BaseModel):
                         "confidence_score": 0.87,
                     }
                 ],
-                "confidence_score": 0.92,
+                "confidence_score": 0.9,
             }
         }
     )

--- a/conversation_service/models/conversation_db_models.py
+++ b/conversation_service/models/conversation_db_models.py
@@ -1,4 +1,3 @@
-
 """Pydantic models representing conversation data persisted in the database."""
 
 from __future__ import annotations
@@ -6,7 +5,14 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 
 
 class Conversation(BaseModel):
@@ -28,25 +34,62 @@ class Conversation(BaseModel):
     created_at: datetime
     updated_at: datetime
 
-    model_config = ConfigDict(json_schema_extra={
-        "example": {
-            "id": 1,
-            "conversation_id": "conv_123",
-            "user_id": 42,
-            "title": "Budget 2024",
-            "status": "active",
-            "language": "fr",
-            "domain": "finance",
-            "total_turns": 2,
-            "max_turns": 50,
-            "last_activity_at": "2024-06-01T12:00:00Z",
-            "conversation_metadata": {"topic": "budget"},
-            "user_preferences": {"tone": "friendly"},
-            "session_metadata": {"browser": "firefox"},
-            "created_at": "2024-06-01T12:00:00Z",
-            "updated_at": "2024-06-01T12:05:00Z",
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "id": 1,
+                "conversation_id": "conv_123",
+                "user_id": 42,
+                "title": "Budget 2024",
+                "status": "active",
+                "language": "fr",
+                "domain": "finance",
+                "total_turns": 2,
+                "max_turns": 50,
+                "last_activity_at": "2024-06-01T12:00:00Z",
+                "conversation_metadata": {"topic": "budget"},
+                "user_preferences": {"tone": "friendly"},
+                "session_metadata": {"browser": "firefox"},
+                "created_at": "2024-06-01T12:00:00Z",
+                "updated_at": "2024-06-01T12:05:00Z",
+            }
         }
-    })
+    )
+
+    def __init__(self, **data: Any) -> None:
+        errors = []
+        if data.get("user_id") is not None and data["user_id"] <= 0:
+            errors.append({"loc": ("user_id",), "msg": "user_id must be positive", "type": "value_error"})
+        total_turns = data.get("total_turns")
+        max_turns = data.get("max_turns")
+        if (
+            total_turns is not None
+            and max_turns is not None
+            and total_turns > max_turns
+        ):
+            errors.append({
+                "loc": ("total_turns",),
+                "msg": "total_turns cannot exceed max_turns",
+                "type": "value_error",
+            })
+        created_at = data.get("created_at")
+        updated_at = data.get("updated_at")
+        last_activity_at = data.get("last_activity_at")
+        if created_at and updated_at and updated_at < created_at:
+            errors.append({
+                "loc": ("updated_at",),
+                "msg": "updated_at must be after created_at",
+                "type": "value_error",
+            })
+        if created_at and last_activity_at and last_activity_at < created_at:
+            errors.append({
+                "loc": ("last_activity_at",),
+                "msg": "last_activity_at must be after created_at",
+                "type": "value_error",
+            })
+        if errors:
+            raise ValidationError(errors, type(self))
+        super().__init__(**data)
 
     @field_validator("user_id")
     @classmethod
@@ -54,18 +97,6 @@ class Conversation(BaseModel):
         if v <= 0:
             raise ValueError("user_id must be positive")
         return v
-
-    @model_validator(mode="after")
-    def validate_consistency(self) -> "Conversation":
-        if self.total_turns > self.max_turns:
-            raise ValueError("total_turns cannot exceed max_turns")
-        if self.updated_at < self.created_at:
-            raise ValueError("updated_at must be after created_at")
-        if self.last_activity_at < self.created_at:
-            raise ValueError("last_activity_at must be after created_at")
-        return self
-
-
 
     @model_validator(mode="after")
     def validate_consistency(self) -> "Conversation":
@@ -92,20 +123,47 @@ class ConversationSummary(BaseModel):
     created_at: datetime
     updated_at: datetime
 
-    model_config = ConfigDict(json_schema_extra={
-        "example": {
-            "id": 1,
-            "conversation_id": 1,
-            "start_turn": 1,
-            "end_turn": 4,
-            "summary_text": "Résumé des échanges...",
-            "key_topics": ["budget", "économie"],
-            "important_entities": [{"name": "Paris", "type": "city"}],
-            "summary_method": "llm",
-            "created_at": "2024-06-01T12:00:00Z",
-            "updated_at": "2024-06-01T12:05:00Z",
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "id": 1,
+                "conversation_id": 1,
+                "start_turn": 1,
+                "end_turn": 4,
+                "summary_text": "Résumé des échanges...",
+                "key_topics": ["budget", "économie"],
+                "important_entities": [{"name": "Paris", "type": "city"}],
+                "summary_method": "llm",
+                "created_at": "2024-06-01T12:00:00Z",
+                "updated_at": "2024-06-01T12:05:00Z",
+            }
         }
-    })
+    )
+
+    def __init__(self, **data: Any) -> None:
+        errors = []
+        for field in ("conversation_id", "start_turn", "end_turn"):
+            if data.get(field) is not None and data[field] <= 0:
+                errors.append({"loc": (field,), "msg": "must be positive", "type": "value_error"})
+        start = data.get("start_turn")
+        end = data.get("end_turn")
+        if start is not None and end is not None and end < start:
+            errors.append({
+                "loc": ("end_turn",),
+                "msg": "end_turn must be >= start_turn",
+                "type": "value_error",
+            })
+        created_at = data.get("created_at")
+        updated_at = data.get("updated_at")
+        if created_at and updated_at and updated_at < created_at:
+            errors.append({
+                "loc": ("updated_at",),
+                "msg": "updated_at must be after created_at",
+                "type": "value_error",
+            })
+        if errors:
+            raise ValidationError(errors, type(self))
+        super().__init__(**data)
 
     @field_validator("conversation_id", "start_turn", "end_turn")
     @classmethod
@@ -120,14 +178,6 @@ class ConversationSummary(BaseModel):
             raise ValueError("end_turn must be >= start_turn")
         if self.updated_at < self.created_at:
             raise ValueError("updated_at must be after created_at")
-        return self
-
-
-
-    @model_validator(mode="after")
-    def validate_turns(self) -> "ConversationSummary":
-        if self.end_turn < self.start_turn:
-            raise ValueError("end_turn must be >= start_turn")
         return self
 
 
@@ -153,38 +203,51 @@ class ConversationTurn(BaseModel):
     created_at: datetime
     updated_at: datetime
 
-    model_config = ConfigDict(json_schema_extra={
-        "example": {
-            "id": 10,
-            "turn_id": "turn_0010",
-            "conversation_id": 1,
-            "turn_number": 3,
-            "user_message": "Quel est mon solde ?",
-            "assistant_response": "Votre solde est de 50€.",
-            "processing_time_ms": 120.5,
-            "confidence_score": 0.98,
-            "error_occurred": False,
-            "error_message": None,
-            "intent_result": {"name": "check_balance"},
-            "agent_chain": [{"agent": "retrieval", "status": "ok"}],
-            "search_query_used": "balance account",
-            "search_results_count": 3,
-            "search_execution_time_ms": 50.2,
-            "turn_metadata": {"debug": True},
-            "created_at": "2024-06-01T12:00:00Z",
-            "updated_at": "2024-06-01T12:00:01Z",
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "id": 10,
+                "turn_id": "turn_0010",
+                "conversation_id": 1,
+                "turn_number": 3,
+                "user_message": "Quel est mon solde ?",
+                "assistant_response": "Votre solde est de 50€.",
+                "processing_time_ms": 120.5,
+                "confidence_score": 0.98,
+                "error_occurred": False,
+                "error_message": None,
+                "intent_result": {"name": "check_balance"},
+                "agent_chain": [{"agent": "retrieval", "status": "ok"}],
+                "search_query_used": "balance account",
+                "search_results_count": 3,
+                "search_execution_time_ms": 50.2,
+                "turn_metadata": {"debug": True},
+                "created_at": "2024-06-01T12:00:00Z",
+                "updated_at": "2024-06-01T12:00:01Z",
+            }
         }
-    })
+    )
 
-    @field_validator("conversation_id")
-    @classmethod
-    def conversation_id_positive(cls, v: int) -> int:
-        if v <= 0:
-            raise ValueError("conversation_id must be positive")
-        return v
+    def __init__(self, **data: Any) -> None:
+        errors = []
+        for field in ("conversation_id", "turn_number", "search_results_count"):
+            if data.get(field) is not None and data[field] < 0:
+                errors.append({"loc": (field,), "msg": "must be non-negative", "type": "value_error"})
+        for field in ("processing_time_ms", "search_execution_time_ms", "confidence_score"):
+            if data.get(field) is not None and data[field] < 0:
+                errors.append({"loc": (field,), "msg": "must be non-negative", "type": "value_error"})
+        created_at = data.get("created_at")
+        updated_at = data.get("updated_at")
+        if created_at and updated_at and updated_at < created_at:
+            errors.append({
+                "loc": ("updated_at",),
+                "msg": "updated_at must be after created_at",
+                "type": "value_error",
+            })
+        if errors:
+            raise ValidationError(errors, type(self))
+        super().__init__(**data)
 
-    @model_validator(mode="after")
-    def validate_times(self) -> "ConversationTurn":
     @field_validator("conversation_id", "turn_number", "search_results_count")
     @classmethod
     def non_negative(cls, v: int) -> int:
@@ -201,7 +264,7 @@ class ConversationTurn(BaseModel):
 
     @model_validator(mode="after")
     def validate_dates(self) -> "ConversationTurn":
-
         if self.updated_at < self.created_at:
             raise ValueError("updated_at must be after created_at")
         return self
+

--- a/conversation_service/models/conversation_models.py
+++ b/conversation_service/models/conversation_models.py
@@ -1,5 +1,3 @@
-"""Pydantic models for the conversation service API (phase 2)."""
-
 """Pydantic models for conversation requests and responses."""
 
 from __future__ import annotations
@@ -23,9 +21,6 @@ class ConversationMetadata(BaseModel):
             }
         }
     )
-    model_config = ConfigDict(json_schema_extra={
-        "example": {"intent": "greeting", "confidence_score": 0.95}
-    })
 
 
 class ConversationContext(BaseModel):
@@ -42,8 +37,6 @@ class ConversationContext(BaseModel):
             }
         }
     )
-    })
-
 
 
 class ConversationRequest(BaseModel):
@@ -100,21 +93,6 @@ class ConversationResponse(BaseModel):
             }
         },
     )
-
-    model_config = ConfigDict(str_strip_whitespace=True, json_schema_extra={
-        "example": {
-            "response": "Bonjour! Comment puis-je vous aider?",
-            "language": "fr",
-            "context": {
-                "conversation_id": "550e8400-e29b-41d4-a716-446655440000",
-                "turn_number": 1,
-            },
-            "metadata": {
-                "intent": "greeting",
-                "confidence_score": 0.95,
-            },
-        }
-    })
 
     @field_validator("language")
     @classmethod


### PR DESCRIPTION
## Summary
- Streamline conversation request and response models and tighten language validation.
- Rebuild conversation database models with explicit validation logic.
- Simplify model package exports.

## Testing
- `pytest tests/conversation_service/models/test_conversation_models.py tests/conversation_service/models/test_cross_models.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8bc74915c8320a420d510bc585d15