### PR TITLE
fix: clean __all__ definitions

### DIFF
--- a/conversation_service/clients/__init__.py
+++ b/conversation_service/clients/__init__.py
@@ -2,8 +2,6 @@
 
 from .cache_client import CacheClient
 from .search_client import SearchClient
-
-__all__ = ["CacheClient", "SearchClient"]
 from .openai_client import OpenAIClient, LRUCache
 
-__all__ = ["OpenAIClient", "LRUCache"]
+__all__ = ["CacheClient", "SearchClient", "OpenAIClient", "LRUCache"]

--- a/conversation_service/models/__init__.py
+++ b/conversation_service/models/__init__.py
@@ -1,8 +1,8 @@
-"""Expose Pydantic models for external use."""
-"""Expose agent models for external use."""
 """Expose conversation service models for external use."""
 
 from .agent_models import (
+    AgentStep,
+    AgentTrace,
     AgentConfig,
     AgentResponse,
     DynamicFinancialEntity,
@@ -16,28 +16,6 @@ from .conversation_models import (
     ConversationResponse,
 )
 from .enums import ConfidenceThreshold, EntityType, IntentType, QueryType
-
-__all__ = [
-
-__all__ = [
-
-from .conversation_models import (
-    ConversationRequest,
-    ConversationResponse,
-    ConversationMetadata,
-    ConversationContext,
-)
-from .conversation_db_models import (
-    Conversation,
-    ConversationSummary,
-    ConversationTurn,
-)
-from .enums import (
-    IntentType,
-    EntityType,
-    QueryType,
-    ConfidenceThreshold,
-)
 
 __all__ = [
     "AgentStep",
@@ -54,15 +32,7 @@ __all__ = [
     "ConversationRequest",
     "ConversationResponse",
     "ConfidenceThreshold",
-    "ConversationRequest",
-    "ConversationResponse",
-    "ConversationMetadata",
-    "ConversationContext",
-    "Conversation",
-    "ConversationSummary",
-    "ConversationTurn",
     "IntentType",
     "EntityType",
     "QueryType",
-    "ConfidenceThreshold",
 ]

--- a/conversation_service/utils/__init__.py
+++ b/conversation_service/utils/__init__.py
@@ -1,4 +1,4 @@
-"""Utility helpers for conversation service."""
+"""Utility helpers for the conversation service."""
 
 from .logging import (
     clear_correlation_id,

--- a/enrichment_service/__init__.py
+++ b/enrichment_service/__init__.py
@@ -1,45 +1,5 @@
-"""
-Service d'enrichissement et d'indexation pour Harena - Elasticsearch uniquement.
-
-Ce service est responsable de la structuration des données financières
-et de leur indexation dans Elasticsearch pour des recherches lexicales optimisées.
-"""
+"""Enrichment and indexing service for Harena (Elasticsearch only)."""
 
 __version__ = "2.0.0-elasticsearch"
+
 __all__ = ["__version__"]
-
-# ============================================================
-# enrichment_service/api/__init__.py
-
-"""
-Module API pour le service d'enrichissement Elasticsearch.
-
-Contient les routes et endpoints REST pour l'enrichissement et l'indexation
-des transactions dans Elasticsearch.
-"""
-
-__all__ = []
-
-# ============================================================
-# enrichment_service/core/__init__.py
-
-"""
-Module core contenant la logique métier de l'enrichissement.
-
-Inclut le traitement des transactions et la structuration des données
-pour l'indexation Elasticsearch.
-"""
-
-__all__ = []
-
-# ============================================================
-# enrichment_service/storage/__init__.py
-
-"""
-Module de stockage pour Elasticsearch.
-
-Fournit l'interface pour interagir avec Elasticsearch
-pour l'indexation et la gestion des documents.
-"""
-
-__all__ = []

--- a/search_service/models/__init__.py
+++ b/search_service/models/__init__.py
@@ -1,4 +1,4 @@
-"""Expose les modèles publics du Search Service."""
+"""Expose public models for the search service."""
 
 from .request import SearchRequest
 from .response import SearchResponse, SearchResult
@@ -9,7 +9,6 @@ from .llm_models import (
     LLMExtractedInsights,
 )
 
-__all__ = ["SearchRequest", "SearchResponse", "SearchResult"]
 __all__ = [
     "SearchRequest",
     "SearchResponse",


### PR DESCRIPTION
## Summary
- tidy `__all__` declarations across services
- streamline client and model exports for clarity

## Testing
- `pytest` *(fails: SyntaxError in `conversation_service/models/agent_models.py` and missing modules `redis`, `alembic`)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c37591f4832093074fd5fed8c936