### PR TITLE
refactor: use field validators for agent step

### DIFF
--- a/conversation_service/models/agent_models.py
+++ b/conversation_service/models/agent_models.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any, List
+from typing import List
 
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field, field_validator
 
 
 class AgentStep(BaseModel):
@@ -13,47 +13,23 @@ class AgentStep(BaseModel):
     agent: str = Field(..., min_length=1, description="Name of the agent")
     status: str = Field(..., min_length=1, description="Resulting status of the step")
 
-    def __init__(self, **data: Any) -> None:  # noqa: D401
-        errors = []
-        if not data.get("agent"):
-            errors.append({"loc": ("agent",), "msg": "must not be empty", "type": "value_error"})
-        if not data.get("status"):
-            errors.append({"loc": ("status",), "msg": "must not be empty", "type": "value_error"})
-        if errors:
-            raise ValidationError(errors, type(self))
-        super().__init__(**data)
+    @field_validator("agent", "status")
+    @classmethod
+    def _not_empty(cls, value: str) -> str:
+        if not value:
+            raise ValueError("must not be empty")
+        return value
 
 
 class AgentTrace(BaseModel):
     """Trace of agent steps with total execution time."""
 
-    steps: List[AgentStep] = Field(..., description="Steps executed by the agent")
+    steps: List[AgentStep] = Field(
+        ..., min_length=1, description="Steps executed by the agent"
+    )
     total_time_ms: float = Field(
         ..., ge=0, description="Total execution time of all steps in milliseconds"
     )
-
-    def __init__(self, **data: Any) -> None:  # noqa: D401
-        errors = []
-        steps_raw = data.get("steps") or []
-        converted_steps: List[AgentStep] = []
-        for s in steps_raw:
-            try:
-                converted_steps.append(s if isinstance(s, AgentStep) else AgentStep(**s))
-            except ValidationError as e:  # pragma: no cover - forwarded errors
-                errors.extend(getattr(e, "errors", [e]))
-        if not converted_steps:
-            errors.append({"loc": ("steps",), "msg": "steps cannot be empty", "type": "value_error"})
-        data["steps"] = converted_steps
-        total = data.get("total_time_ms")
-        if total is not None and total < 0:
-            errors.append({
-                "loc": ("total_time_ms",),
-                "msg": "total_time_ms must be non-negative",
-                "type": "value_error",
-            })
-        if errors:
-            raise ValidationError(errors, type(self))
-        super().__init__(**data)
 
 
 class AgentConfig(BaseModel):
@@ -95,17 +71,4 @@ class AgentResponse(BaseModel):
     confidence_score: float = Field(
         ..., ge=0.0, le=1.0, description="Overall confidence score for the response"
     )
-
-    def __init__(self, **data: Any) -> None:  # noqa: D401
-        errors = []
-        score = data.get("confidence_score")
-        if score is not None and not 0.0 <= score <= 1.0:
-            errors.append({
-                "loc": ("confidence_score",),
-                "msg": "confidence_score must be between 0.0 and 1.0",
-                "type": "value_error",
-            })
-        if errors:
-            raise ValidationError(errors, type(self))
-        super().__init__(**data)
 


### PR DESCRIPTION
## Summary
- replace manual validation in `AgentStep` with a `field_validator`
- rely on pydantic field constraints for `AgentTrace` and `AgentResponse`

## Testing
- `pytest tests/conversation_service/models/test_agent_models.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8c67dddd0832092ccdcb7cb6b6e31