### PR TITLE
Use model_dump in conversation service tests

### DIFF
--- a/tests/conversation_service/models/test_agent_models.py
+++ b/tests/conversation_service/models/test_agent_models.py
@@ -9,7 +9,7 @@ from conversation_service.models import AgentStep, AgentTrace
 def test_agent_models_validation_and_json():
     step = AgentStep(agent="retriever", status="ok")
     trace = AgentTrace(steps=[step], total_time_ms=12.5)
-    data = {"steps": [s.dict() for s in trace.steps], "total_time_ms": trace.total_time_ms}
+    data = {"steps": [s.model_dump() for s in trace.steps], "total_time_ms": trace.total_time_ms}
     json_data = json.dumps(data)
     loaded = AgentTrace(**json.loads(json_data))
     assert loaded.steps[0].model_dump() == step.model_dump()

--- a/tests/conversation_service/models/test_conversation_models.py
+++ b/tests/conversation_service/models/test_conversation_models.py
@@ -40,7 +40,7 @@ def test_conversation_validation_and_json(timestamps):
 
     data = {
         k: (v.isoformat() if isinstance(v, datetime) else v)
-        for k, v in conv.dict().items()
+        for k, v in conv.model_dump().items()
     }
     json_data = json.dumps(data)
     loaded = Conversation(**json.loads(json_data))
@@ -127,7 +127,7 @@ def test_summary_validation_and_json(timestamps):
 
     data = {
         k: (v.isoformat() if isinstance(v, datetime) else v)
-        for k, v in summary.dict().items()
+        for k, v in summary.model_dump().items()
     }
     json_data = json.dumps(data)
     loaded = ConversationSummary(**json.loads(json_data))
@@ -179,7 +179,7 @@ def test_turn_validation_and_json(timestamps):
 
     data = {
         k: (v.isoformat() if isinstance(v, datetime) else v)
-        for k, v in turn.dict().items()
+        for k, v in turn.model_dump().items()
     }
     json_data = json.dumps(data)
     loaded = ConversationTurn(**json.loads(json_data))


### PR DESCRIPTION
## Summary
- replace deprecated `.dict()` with `.model_dump()` in conversation model tests
- serialize agent trace steps using `.model_dump()`

## Testing
- `pytest tests/conversation_service/models/test_*`


------
https://chatgpt.com/codex/tasks/task_e_68a8c685541483208d05dd425511f256