### PR TITLE
Use Pydantic v2 APIs for cache manager

### DIFF
--- a/conversation_service/core/cache_manager.py
+++ b/conversation_service/core/cache_manager.py
@@ -77,7 +77,10 @@ class CacheManager:
         if model is not None:
             validated = validate_model(model, value)
             l1_value = validated
-            l2_value = validated.dict()
+            try:
+                l2_value = validated.model_dump()
+            except AttributeError:  # pragma: no cover - support for Pydantic v1
+                l2_value = validated.dict()
         else:
             l1_value = l2_value = value
 

--- a/conversation_service/core/validators.py
+++ b/conversation_service/core/validators.py
@@ -13,15 +13,12 @@ def validate_model(model: Type[T], data: Any) -> T:
     """Validate ``data`` against ``model``.
 
     If ``data`` is already an instance of ``model`` it is returned as-is.
-    Otherwise ``model.parse_obj`` is used to construct and validate an instance.
+    Otherwise ``model.model_validate`` is used to construct and validate an instance.
     """
 
     if isinstance(data, model):
         return data
     try:
-        return model.parse_obj(data)  # Pydantic v1
-    except AttributeError:  # pragma: no cover - support for Pydantic v2
-        try:
-            return model.model_validate(data)  # type: ignore[attr-defined]
-        except AttributeError:
-            return model(**data)
+        return model.model_validate(data)  # type: ignore[attr-defined]
+    except AttributeError:  # pragma: no cover - support for Pydantic v1
+        return model(**data)


### PR DESCRIPTION
## Summary
- favor `model_validate` for model checks and drop `parse_obj`
- serialize models with `model_dump`

## Testing
- `pytest tests/test_cache_manager_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8c8a8d7688320b5658af9414bceba