### PR TITLE
feat: extend conversation models with enums

### DIFF
--- a/conversation_service/models/agent_models.py
+++ b/conversation_service/models/agent_models.py
@@ -6,6 +6,8 @@ from typing import List
 
 from pydantic import BaseModel, Field, field_validator
 
+from .enums import EntityType, IntentType
+
 
 class AgentStep(BaseModel):
     """Single step executed by an agent."""
@@ -35,6 +37,10 @@ class AgentTrace(BaseModel):
 class AgentConfig(BaseModel):
     """Configuration for a conversational agent."""
 
+    name: str = Field(..., min_length=1, description="Name of the agent")
+    system_prompt: str = Field(
+        ..., min_length=1, description="System prompt guiding the agent"
+    )
     model: str = Field(..., description="Name of the model")
     temperature: float = Field(0.7, ge=0.0, le=1.0)
     max_tokens: int = Field(512, ge=1, lt=4000)
@@ -44,7 +50,7 @@ class AgentConfig(BaseModel):
 class IntentResult(BaseModel):
     """Result of the intent classification."""
 
-    intent_type: str = Field(..., description="Detected intent")
+    intent_type: IntentType = Field(..., description="Detected intent")
     confidence_score: float = Field(
         ..., ge=0.0, le=1.0, description="Confidence score for the intent"
     )
@@ -53,7 +59,7 @@ class IntentResult(BaseModel):
 class DynamicFinancialEntity(BaseModel):
     """Financial entity extracted from a message."""
 
-    entity_type: str = Field(..., description="Type of the entity")
+    entity_type: EntityType = Field(..., description="Type of the entity")
     value: str = Field(..., description="Value associated with the entity")
     confidence_score: float = Field(
         ..., ge=0.0, le=1.0, description="Confidence score for the entity"

--- a/conversation_service/models/conversation_models.py
+++ b/conversation_service/models/conversation_models.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 from uuid import UUID
+from typing import Any, Dict, List
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from .enums import IntentType
 
 
 class ConversationMetadata(BaseModel):
     """Optional metadata associated with a conversation."""
 
-    intent: str | None = None
+    intent: IntentType | None = None
     confidence_score: float | None = Field(default=None, ge=0.0, le=1.0)
 
     model_config = ConfigDict(
@@ -42,6 +45,7 @@ class ConversationRequest(BaseModel):
     message: str = Field(min_length=1)
     language: str = Field(min_length=2, max_length=2)
     context: ConversationContext
+    user_preferences: Dict[str, Any] = Field(default_factory=dict)
 
     model_config = ConfigDict(
         str_strip_whitespace=True,
@@ -53,6 +57,7 @@ class ConversationRequest(BaseModel):
                     "conversation_id": "550e8400-e29b-41d4-a716-446655440000",
                     "turn_number": 1,
                 },
+                "user_preferences": {"tone": "friendly"},
             }
         },
     )
@@ -72,6 +77,8 @@ class ConversationResponse(BaseModel):
     language: str = Field(min_length=2, max_length=2)
     context: ConversationContext
     metadata: ConversationMetadata | None = None
+    suggested_actions: List[str] = Field(default_factory=list)
+    user_preferences: Dict[str, Any] = Field(default_factory=dict)
 
     model_config = ConfigDict(
         str_strip_whitespace=True,
@@ -87,6 +94,8 @@ class ConversationResponse(BaseModel):
                     "intent": "greeting",
                     "confidence_score": 0.95,
                 },
+                "suggested_actions": ["check_balance"],
+                "user_preferences": {"tone": "friendly"},
             }
         },
     )

--- a/tests/conversation_service/models/test_agent_models.py
+++ b/tests/conversation_service/models/test_agent_models.py
@@ -3,7 +3,15 @@ import json
 import pytest
 from pydantic import ValidationError
 
-from conversation_service.models import AgentStep, AgentTrace
+from conversation_service.models import (
+    AgentConfig,
+    AgentStep,
+    AgentTrace,
+    DynamicFinancialEntity,
+    IntentResult,
+    EntityType,
+    IntentType,
+)
 
 
 def test_agent_models_validation_and_json():
@@ -23,3 +31,31 @@ def test_agent_models_validation_and_json():
 
     with pytest.raises(ValidationError):
         AgentTrace(steps=[], total_time_ms=1.0)
+
+
+def test_agent_config_and_enums():
+    config = AgentConfig(
+        name="classifier",
+        system_prompt="You are a bot.",
+        model="gpt-4",
+        temperature=0.5,
+        max_tokens=100,
+        timeout=10,
+    )
+    assert config.name == "classifier"
+
+    intent = IntentResult(intent_type=IntentType.GREETING, confidence_score=0.9)
+    assert intent.intent_type is IntentType.GREETING
+
+    with pytest.raises(ValidationError):
+        IntentResult(intent_type="INVALID", confidence_score=0.5)
+
+    entity = DynamicFinancialEntity(
+        entity_type=EntityType.ACCOUNT,
+        value="123",
+        confidence_score=0.8,
+    )
+    assert entity.entity_type is EntityType.ACCOUNT
+
+    with pytest.raises(ValidationError):
+        DynamicFinancialEntity(entity_type="BAD", value="1", confidence_score=0.1)

--- a/tests/test_conversation_models_phase2.py
+++ b/tests/test_conversation_models_phase2.py
@@ -7,13 +7,20 @@ from conversation_service.models import (
     ConversationResponse,
     ConversationMetadata,
     ConversationContext,
+    IntentType,
 )
 
 
 def test_conversation_request_valid():
     ctx = ConversationContext(conversation_id=uuid4(), turn_number=1)
-    req = ConversationRequest(message="Hello", language="en", context=ctx)
+    req = ConversationRequest(
+        message="Hello",
+        language="en",
+        context=ctx,
+        user_preferences={"tone": "formal"},
+    )
     assert req.context.turn_number == 1
+    assert req.user_preferences["tone"] == "formal"
 
 
 def test_user_message_not_empty():
@@ -37,9 +44,9 @@ def test_conversation_id_uuid():
 
 def test_confidence_score_range():
     with pytest.raises(ValidationError):
-        ConversationMetadata(intent="greeting", confidence_score=1.5)
+        ConversationMetadata(intent=IntentType.GREETING, confidence_score=1.5)
     with pytest.raises(ValidationError):
-        ConversationMetadata(intent="greeting", confidence_score=-0.1)
+        ConversationMetadata(intent=IntentType.GREETING, confidence_score=-0.1)
 
 
 def test_turn_number_positive():
@@ -49,8 +56,20 @@ def test_turn_number_positive():
 
 def test_conversation_response_valid():
     ctx = ConversationContext(conversation_id=uuid4(), turn_number=2)
-    meta = ConversationMetadata(intent="greeting", confidence_score=0.8)
+    meta = ConversationMetadata(intent=IntentType.GREETING, confidence_score=0.8)
     resp = ConversationResponse(
-        response="Hello!", language="en", context=ctx, metadata=meta
+        response="Hello!",
+        language="en",
+        context=ctx,
+        metadata=meta,
+        suggested_actions=["check_balance"],
+        user_preferences={"tone": "friendly"},
     )
     assert resp.metadata.confidence_score == 0.8
+    assert resp.suggested_actions == ["check_balance"]
+    assert resp.user_preferences["tone"] == "friendly"
+
+
+def test_metadata_invalid_intent():
+    with pytest.raises(ValidationError):
+        ConversationMetadata(intent="NOT_AN_INTENT", confidence_score=0.5)


### PR DESCRIPTION
## Summary
- add name and system_prompt to AgentConfig
- use IntentType and EntityType enums in agent and conversation models
- include user_preferences and suggested_actions fields in conversation models
- update tests for new fields and enums

## Testing
- `pytest tests/conversation_service/models/test_agent_models.py tests/test_conversation_models_phase2.py`

------
https://chatgpt.com/codex/tasks/task_e_68a8c8bdea6c8320bfe63f147d7cd741