### PR TITLE
Add prompts package to conversation service

### DIFF
--- a/conversation_service/prompts/__init__.py
+++ b/conversation_service/prompts/__init__.py
@@ -1,0 +1,13 @@
+"""Utilities and templates for conversation prompts.
+
+This package centralizes prompt-related constants and exposes the
+available template and utility submodules for convenience.
+"""
+
+from . import templates
+from . import utils
+
+# Default prefix used for building prompt identifiers.
+DEFAULT_PROMPT_PREFIX = "CONV_PROMPT"
+
+__all__ = ["templates", "utils", "DEFAULT_PROMPT_PREFIX"]

--- a/conversation_service/prompts/templates/__init__.py
+++ b/conversation_service/prompts/templates/__init__.py
@@ -1,0 +1,3 @@
+"""Prompt templates for the conversation service."""
+
+# Placeholder for future template definitions.

--- a/conversation_service/prompts/utils/__init__.py
+++ b/conversation_service/prompts/utils/__init__.py
@@ -1,0 +1,3 @@
+"""Utility helpers for working with conversation prompts."""
+
+# Placeholder for future utility functions.


### PR DESCRIPTION
## Summary
- add `prompts` package under `conversation_service`
- expose default prefix constant and submodules for prompt utilities and templates

## Testing
- `python - <<'PY'
import conversation_service.prompts as p
print('prefix:', p.DEFAULT_PROMPT_PREFIX)
PY`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68a94f967e0c832094d995162eef65f4