### PR TITLE
Add intent evaluation and template AB testing utilities

### DIFF
--- a/monitoring/evaluation.py
+++ b/monitoring/evaluation.py
@@ -1,0 +1,131 @@
+"""Utilities to evaluate intent detection and extraction.
+
+This module provides helpers to run prompts through a model function and
+collect metrics such as latency, token usage and success rate.  It is
+used by scripts/evaluate_templates.py and unit tests.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import time
+from typing import Any, Callable, Dict, List, Mapping, Sequence
+
+import tiktoken
+
+# Prices in dollars per token (approx for gpt-4o-mini)
+PROMPT_TOKEN_PRICE = 0.00000015  # $0.15 per 1M tokens
+COMPLETION_TOKEN_PRICE = 0.00000060  # $0.60 per 1M tokens
+
+
+@dataclass
+class Sample:
+    """Single evaluation example."""
+
+    prompt: str
+    expected_intent: str
+    expected_entities: Mapping[str, Any]
+
+
+def _count_tokens(text: str, model: str) -> int:
+    """Return token count for *text* using *model* encoding."""
+
+    try:
+        enc = tiktoken.encoding_for_model(model)
+    except Exception:
+        try:
+            enc = tiktoken.get_encoding("cl100k_base")
+        except Exception:
+            return len(text.split())
+    return len(enc.encode(text))
+
+
+def evaluate_variant(
+    samples: Sequence[Sample],
+    template: str,
+    call_model: Callable[[str], Mapping[str, Any]],
+    *,
+    model: str = "gpt-4o-mini",
+) -> List[Dict[str, Any]]:
+    """Evaluate *template* on *samples* using *call_model*.
+
+    ``call_model`` must accept a prompt string and return a mapping with at
+    least the keys ``intent``, ``entities`` and ``raw_response``.
+    """
+
+    results: List[Dict[str, Any]] = []
+    for sample in samples:
+        full_prompt = template.format(prompt=sample.prompt)
+        start = time.perf_counter()
+        output = call_model(full_prompt)
+        latency = time.perf_counter() - start
+
+        prompt_tokens = _count_tokens(full_prompt, model)
+        completion_tokens = _count_tokens(output.get("raw_response", ""), model)
+
+        success = (
+            output.get("intent") == sample.expected_intent
+            and output.get("entities") == sample.expected_entities
+        )
+        cost = (
+            prompt_tokens * PROMPT_TOKEN_PRICE
+            + completion_tokens * COMPLETION_TOKEN_PRICE
+        )
+
+        results.append(
+            {
+                "prompt": sample.prompt,
+                "intent": sample.expected_intent,
+                "prompt_length": len(full_prompt),
+                "latency": latency,
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "cost": cost,
+                "success": success,
+            }
+        )
+    return results
+
+
+def aggregate_metrics(
+    results_by_variant: Mapping[str, Sequence[Mapping[str, Any]]],
+) -> Dict[str, Any]:
+    """Aggregate metrics for each variant."""
+
+    summary: Dict[str, Any] = {}
+    for variant, results in results_by_variant.items():
+        total = len(results)
+        successes = sum(1 for r in results if r["success"])
+        avg_latency = sum(r["latency"] for r in results) / total if total else 0
+        avg_prompt_len = (
+            sum(r["prompt_length"] for r in results) / total if total else 0
+        )
+        avg_cost = sum(r["cost"] for r in results) / total if total else 0
+
+        # Accuracy per intent
+        intent_totals: Dict[str, int] = {}
+        intent_success: Dict[str, int] = {}
+        for r in results:
+            intent = r["intent"]
+            intent_totals[intent] = intent_totals.get(intent, 0) + 1
+            if r["success"]:
+                intent_success[intent] = intent_success.get(intent, 0) + 1
+        accuracy_by_intent = {
+            intent: intent_success.get(intent, 0) / total
+            for intent, total in intent_totals.items()
+        }
+
+        summary[variant] = {
+            "success_rate": successes / total if total else 0,
+            "avg_latency": avg_latency,
+            "avg_prompt_len": avg_prompt_len,
+            "avg_cost": avg_cost,
+            "accuracy_by_intent": accuracy_by_intent,
+        }
+    return summary
+
+
+def best_variant(summary: Mapping[str, Mapping[str, Any]]) -> str:
+    """Return the variant name with highest success rate."""
+
+    return max(summary.items(), key=lambda kv: kv[1]["success_rate"])[0]

--- a/scripts/evaluate_templates.py
+++ b/scripts/evaluate_templates.py
@@ -1,0 +1,78 @@
+"""Evaluate prompt templates against intent fixtures.
+
+This script loads a fixture file describing template variants and
+examples with expected intents and entities.  For each template variant it
+runs the examples through an LLM (OpenAI by default) and reports metrics
+such as accuracy by intent, average latency and token cost.
+
+Example:
+    python scripts/evaluate_templates.py tests/fixtures/intent_samples.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any, Dict, Mapping
+
+from monitoring.evaluation import (
+    Sample,
+    aggregate_metrics,
+    best_variant,
+    evaluate_variant,
+)
+
+try:
+    from openai import OpenAI
+except Exception:  # pragma: no cover - openai optional for tests
+    OpenAI = None  # type: ignore
+
+
+def _openai_call(prompt: str, model: str) -> Mapping[str, Any]:
+    if OpenAI is None:
+        raise RuntimeError("openai package not available")
+    client = OpenAI()
+    resp = client.responses.create(model=model, input=prompt)
+    text = resp.output_text
+    data = json.loads(text)
+    return {
+        "intent": data.get("intent"),
+        "entities": data.get("entities", {}),
+        "raw_response": text,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Evaluate template variants")
+    parser.add_argument("fixture", help="JSON fixture with templates and samples")
+    parser.add_argument("--model", default="gpt-4o-mini", help="Model to use")
+    args = parser.parse_args()
+
+    with open(args.fixture, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+
+    templates: Dict[str, str] = data["template_variants"]
+    samples = [Sample(**s) for s in data["samples"]]
+
+    results_by_variant: Dict[str, Any] = {}
+    for name, template in templates.items():
+        results_by_variant[name] = evaluate_variant(
+            samples, template, lambda p: _openai_call(p, args.model), model=args.model
+        )
+
+    summary = aggregate_metrics(results_by_variant)
+    for name, metrics in summary.items():
+        print(
+            f"Variant {name}: success={metrics['success_rate']:.2%}, "
+            f"latency={metrics['avg_latency']*1000:.1f}ms, "
+            f"cost=${metrics['avg_cost']:.6f}"
+        )
+        for intent, acc in metrics["accuracy_by_intent"].items():
+            print(f"  - {intent}: {acc:.2%}")
+
+    winner = best_variant(summary)
+    print(f"\nBest variant: {winner}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/tests/fixtures/intent_samples.json
+++ b/tests/fixtures/intent_samples.json
@@ -1,0 +1,18 @@
+{
+  "template_variants": {
+    "A": "Classify the user's intent and extract entities as JSON.\nMessage: {prompt}",
+    "B": "You detect financial intents. Reply with JSON using keys 'intent' and 'entities'.\nUser: {prompt}"
+  },
+  "samples": [
+    {
+      "prompt": "bonjour",
+      "expected_intent": "GREETING",
+      "expected_entities": {}
+    },
+    {
+      "prompt": "Combien j'ai dépensé chez Carrefour ?",
+      "expected_intent": "SPENDING_ANALYSIS",
+      "expected_entities": {"merchant": "Carrefour"}
+    }
+  ]
+}

--- a/tests/test_evaluation_metrics.py
+++ b/tests/test_evaluation_metrics.py
@@ -1,0 +1,31 @@
+from monitoring.evaluation import (
+    Sample,
+    aggregate_metrics,
+    best_variant,
+    evaluate_variant,
+)
+
+
+def dummy_model(prompt: str):
+    if "bonjour" in prompt:
+        return {"intent": "GREETING", "entities": {}, "raw_response": "{}"}
+    return {
+        "intent": "SPENDING_ANALYSIS",
+        "entities": {"merchant": "Carrefour"},
+        "raw_response": "{}",
+    }
+
+
+def test_aggregate_metrics():
+    samples = [
+        Sample(prompt="bonjour", expected_intent="GREETING", expected_entities={}),
+        Sample(
+            prompt="Combien j'ai dépensé chez Carrefour ?",
+            expected_intent="SPENDING_ANALYSIS",
+            expected_entities={"merchant": "Carrefour"},
+        ),
+    ]
+    results = evaluate_variant(samples, "{prompt}", dummy_model)
+    summary = aggregate_metrics({"A": results})
+    assert summary["A"]["success_rate"] == 1.0
+    assert best_variant(summary) == "A"


### PR DESCRIPTION
## Summary
- add evaluation helpers to compute intent accuracy, latency and token cost
- create script for running automatic A/B tests on prompt templates
- provide sample fixtures and unit tests for evaluation utilities

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'redis')*
- `pytest tests/test_evaluation_metrics.py`

------
https://chatgpt.com/codex/tasks/task_e_68a94ffdfae88320aaf41a2d0cbff528