### PR TITLE
feat: add structured agents with pydantic prompts

### DIFF
--- a/conversation_service/agents/__init__.py
+++ b/conversation_service/agents/__init__.py
@@ -1,0 +1,13 @@
+"""Conversational agents built on top of OpenAI."""
+
+from .intent_classifier import IntentClassifier
+from .entity_extractor import EntityExtractor
+from .query_generator import QueryGenerator
+from .response_generator import ResponseGenerator
+
+__all__ = [
+    "IntentClassifier",
+    "EntityExtractor",
+    "QueryGenerator",
+    "ResponseGenerator",
+]

--- a/conversation_service/agents/base.py
+++ b/conversation_service/agents/base.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Common utilities for OpenAI-based agents with Pydantic validation."""
+
+import json
+from typing import Any, Dict, List, Type
+
+from pydantic import BaseModel
+
+from conversation_service.models.agent_models import AgentConfig
+
+
+class BaseAgent:
+    """Base class for agents relying on the OpenAI client."""
+
+    def __init__(self, client: Any, config: AgentConfig) -> None:
+        self.client = client
+        self.config = config
+
+    async def _run(
+        self, messages: List[Dict[str, str]], response_model: Type[BaseModel]
+    ) -> BaseModel:
+        """Execute a prompt and parse the response as ``response_model``."""
+        response = await self.client.chat_completion(
+            model=self.config.model,
+            messages=[
+                {"role": "system", "content": self.config.system_prompt},
+                *messages,
+            ],
+            temperature=self.config.temperature,
+            max_tokens=self.config.max_tokens,
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": response_model.__name__,
+                    "schema": response_model.model_json_schema(),
+                },
+            },
+            agent_name=self.config.name,
+        )
+        content = response.choices[0].message.content
+        try:
+            data = json.loads(content)
+            return response_model.model_validate(data)
+        except Exception as exc:
+            raise ValueError(
+                f"Invalid response from agent {self.config.name}: {content}"
+            ) from exc

--- a/conversation_service/agents/entity_extractor.py
+++ b/conversation_service/agents/entity_extractor.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+"""Entity extraction agent."""
+
+from typing import Any, List
+
+from pydantic import BaseModel, Field
+
+from conversation_service.models.agent_models import AgentConfig, DynamicFinancialEntity
+from .base import BaseAgent
+
+
+class EntityExtractionResult(BaseModel):
+    entities: List[DynamicFinancialEntity] = Field(default_factory=list)
+
+
+DEFAULT_CONFIG = AgentConfig(
+    name="entity-extractor",
+    system_prompt="Extract financial entities and return JSON.",
+    model="gpt-4o-mini",
+)
+
+
+class EntityExtractor(BaseAgent):
+    """Agent extracting entities from user text."""
+
+    def __init__(self, client: Any, config: AgentConfig | None = None) -> None:
+        super().__init__(client, config or DEFAULT_CONFIG)
+
+    async def extract(self, text: str) -> List[DynamicFinancialEntity]:
+        messages = [{"role": "user", "content": text}]
+        result = await self._run(messages, EntityExtractionResult)
+        return result.entities

--- a/conversation_service/agents/intent_classifier.py
+++ b/conversation_service/agents/intent_classifier.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+"""Intent classification agent."""
+
+from typing import Any
+
+from conversation_service.models.agent_models import AgentConfig, IntentResult
+from .base import BaseAgent
+
+
+DEFAULT_CONFIG = AgentConfig(
+    name="intent-classifier",
+    system_prompt="Classify the user's intent and return JSON.",
+    model="gpt-4o-mini",
+)
+
+
+class IntentClassifier(BaseAgent):
+    """Agent responsible for intent classification."""
+
+    def __init__(self, client: Any, config: AgentConfig | None = None) -> None:
+        super().__init__(client, config or DEFAULT_CONFIG)
+
+    async def classify(self, text: str) -> IntentResult:
+        messages = [{"role": "user", "content": text}]
+        return await self._run(messages, IntentResult)

--- a/conversation_service/agents/query_generator.py
+++ b/conversation_service/agents/query_generator.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Query generation agent."""
+
+import json
+from typing import Any, List
+
+from pydantic import BaseModel
+
+from conversation_service.models.agent_models import (
+    AgentConfig,
+    IntentResult,
+    DynamicFinancialEntity,
+)
+from .base import BaseAgent
+
+
+class QueryModel(BaseModel):
+    query: str
+
+
+DEFAULT_CONFIG = AgentConfig(
+    name="query-generator",
+    system_prompt="Generate a search query based on intent and entities.",
+    model="gpt-4o-mini",
+)
+
+
+class QueryGenerator(BaseAgent):
+    """Agent converting intents and entities into a query string."""
+
+    def __init__(self, client: Any, config: AgentConfig | None = None) -> None:
+        super().__init__(client, config or DEFAULT_CONFIG)
+
+    async def generate(
+        self, intent: IntentResult, entities: List[DynamicFinancialEntity]
+    ) -> str:
+        payload = {
+            "intent": intent.model_dump(),
+            "entities": [e.model_dump() for e in entities],
+        }
+        messages = [{"role": "user", "content": json.dumps(payload)}]
+        result = await self._run(messages, QueryModel)
+        return result.query

--- a/conversation_service/agents/response_generator.py
+++ b/conversation_service/agents/response_generator.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+"""Final response generation agent."""
+
+import json
+from typing import Any, List
+
+from conversation_service.models.agent_models import (
+    AgentConfig,
+    AgentResponse,
+    IntentResult,
+    DynamicFinancialEntity,
+)
+from .base import BaseAgent
+
+
+DEFAULT_CONFIG = AgentConfig(
+    name="response-generator",
+    system_prompt="Craft a helpful response based on intent, entities and query.",
+    model="gpt-4o-mini",
+)
+
+
+class ResponseGenerator(BaseAgent):
+    """Agent composing the final answer for the user."""
+
+    def __init__(self, client: Any, config: AgentConfig | None = None) -> None:
+        super().__init__(client, config or DEFAULT_CONFIG)
+
+    async def respond(
+        self,
+        intent: IntentResult,
+        entities: List[DynamicFinancialEntity],
+        query: str,
+    ) -> AgentResponse:
+        payload = {
+            "intent": intent.model_dump(),
+            "entities": [e.model_dump() for e in entities],
+            "query": query,
+        }
+        messages = [{"role": "user", "content": json.dumps(payload)}]
+        return await self._run(messages, AgentResponse)

--- a/tests/conversation_service/test_agents_pipeline.py
+++ b/tests/conversation_service/test_agents_pipeline.py
@@ -1,0 +1,136 @@
+pytest_plugins = ("pytest_asyncio",)
+
+import json
+from types import SimpleNamespace
+from typing import Dict
+
+import pytest
+
+from conversation_service.agents import (
+    EntityExtractor,
+    IntentClassifier,
+    QueryGenerator,
+    ResponseGenerator,
+)
+from conversation_service.models.agent_models import DynamicFinancialEntity
+from conversation_service.models.enums import EntityType, IntentType
+
+
+# ---------------------------------------------------------------------------
+# Fake OpenAI client
+# ---------------------------------------------------------------------------
+
+INTENT_EXAMPLES: Dict[str, IntentType] = {
+    "show all transactions": IntentType.TRANSACTION_SEARCH,
+    "transactions on may 5": IntentType.SEARCH_BY_DATE,
+    "transactions over 50 euros": IntentType.SEARCH_BY_AMOUNT,
+    "transactions at amazon": IntentType.SEARCH_BY_MERCHANT,
+    "transactions for groceries": IntentType.SEARCH_BY_CATEGORY,
+    "over 100 euros in march": IntentType.SEARCH_BY_AMOUNT_AND_DATE,
+    "only debit operations": IntentType.SEARCH_BY_OPERATION_TYPE,
+    "search 'subscription'": IntentType.SEARCH_BY_TEXT,
+    "count my transactions": IntentType.COUNT_TRANSACTIONS,
+    "amazon spending analysis": IntentType.MERCHANT_INQUIRY,
+    "add debit filter": IntentType.FILTER_REQUEST,
+    "analyze my spending": IntentType.SPENDING_ANALYSIS,
+    "spending by category": IntentType.SPENDING_ANALYSIS_BY_CATEGORY,
+    "spending in april": IntentType.SPENDING_ANALYSIS_BY_PERIOD,
+    "compare january and february": IntentType.SPENDING_COMPARISON,
+    "spending trend": IntentType.TREND_ANALYSIS,
+    "category breakdown": IntentType.CATEGORY_ANALYSIS,
+    "restaurants vs groceries": IntentType.COMPARISON_QUERY,
+    "what is my balance": IntentType.BALANCE_INQUIRY,
+    "balance of savings account": IntentType.ACCOUNT_BALANCE_SPECIFIC,
+    "balance evolution": IntentType.BALANCE_EVOLUTION,
+}
+
+
+class FakeOpenAIClient:
+    async def chat_completion(self, *, model, messages, agent_name, **kwargs):  # type: ignore[override]
+        user_content = messages[-1]["content"]
+        if agent_name == "intent-classifier":
+            if user_content == "bad json":
+                content = "not json"
+            else:
+                intent = next(
+                    (v for k, v in INTENT_EXAMPLES.items() if k in user_content),
+                    IntentType.UNKNOWN,
+                )
+                content = json.dumps({"intent_type": intent, "confidence_score": 0.9})
+        elif agent_name == "entity-extractor":
+            entities = []
+            if "amazon" in user_content.lower():
+                entities.append(
+                    {
+                        "entity_type": EntityType.MERCHANT,
+                        "value": "Amazon",
+                        "confidence_score": 0.8,
+                    }
+                )
+            content = json.dumps({"entities": entities})
+        elif agent_name == "query-generator":
+            payload = json.loads(user_content)
+            query = f"{payload['intent']['intent_type']} with {len(payload['entities'])} entities"
+            content = json.dumps({"query": query})
+        elif agent_name == "response-generator":
+            payload = json.loads(user_content)
+            content = json.dumps(
+                {
+                    "response": f"Result for {payload['query']}",
+                    "intent": payload["intent"],
+                    "entities": payload["entities"],
+                    "confidence_score": 0.99,
+                }
+            )
+        else:
+            content = "{}"
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_intent_classifier_handles_many_intents():
+    client = FakeOpenAIClient()
+    classifier = IntentClassifier(client)
+    for text, expected in INTENT_EXAMPLES.items():
+        result = await classifier.classify(text)
+        assert result.intent_type == expected
+        assert 0.0 <= result.confidence_score <= 1.0
+
+
+@pytest.mark.asyncio
+async def test_invalid_json_raises():
+    client = FakeOpenAIClient()
+    classifier = IntentClassifier(client)
+    with pytest.raises(ValueError):
+        await classifier.classify("bad json")
+
+
+class Pipeline:
+    def __init__(self, client):
+        self.intent = IntentClassifier(client)
+        self.entities = EntityExtractor(client)
+        self.query = QueryGenerator(client)
+        self.response = ResponseGenerator(client)
+
+    async def run(self, text: str):
+        intent = await self.intent.classify(text)
+        entities = await self.entities.extract(text)
+        query = await self.query.generate(intent, entities)
+        return await self.response.respond(intent, entities, query)
+
+
+@pytest.mark.asyncio
+async def test_agent_pipeline_end_to_end():
+    client = FakeOpenAIClient()
+    pipeline = Pipeline(client)
+    result = await pipeline.run("show all transactions at amazon")
+    assert result.intent.intent_type == IntentType.TRANSACTION_SEARCH
+    assert result.entities and result.entities[0].value == "Amazon"
+    assert result.response.startswith("Result for")


### PR DESCRIPTION
## Summary
- add BaseAgent to enforce Pydantic JSON schema outputs via OpenAI
- implement IntentClassifier, EntityExtractor, QueryGenerator and ResponseGenerator
- cover 21 intent cases and pipeline flow with async tests

## Testing
- `pytest tests/conversation_service/test_agents_pipeline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a95004c7408320b319f7f9ba115724