### PR TITLE
Fix import path for template evaluation script

### DIFF
--- a/scripts/evaluate_templates.py
+++ b/scripts/evaluate_templates.py
@@ -15,6 +15,8 @@ import argparse
 import json
 from typing import Any, Dict, Mapping
 
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 from monitoring.evaluation import (
     Sample,
     aggregate_metrics,


### PR DESCRIPTION
## Summary
- ensure scripts/evaluate_templates.py can import monitoring package by adding repository root to `sys.path`

## Testing
- `python scripts/evaluate_templates.py tests/fixtures/intent_samples.json` *(fails: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9589b20188320b9dde47a67cbbb9c