### PR TITLE
Sanitize database URL in column permission checker

### DIFF
--- a/scripts/check_column_permissions.py
+++ b/scripts/check_column_permissions.py
@@ -6,7 +6,10 @@ from config_service.config import settings
 
 
 def check_permissions() -> None:
-    engine = create_engine(settings.DATABASE_URL)
+    database_url = settings.DATABASE_URL or "sqlite://"
+    if database_url.startswith("postgres://"):
+        database_url = database_url.replace("postgres://", "postgresql://", 1)
+    engine = create_engine(database_url)
     query = text(
         """
         SELECT grantee, privilege_type, column_name


### PR DESCRIPTION
## Summary
- Handle deprecated postgres URL scheme in `check_column_permissions`
- Use normalized `database_url` when creating the SQLAlchemy engine

## Testing
- `REDIS_URL=redis://localhost:6379 python -m scripts.check_column_permissions` *(fails: sqlite3.OperationalError: no such table: information_schema.column_privileges)*
- `pytest -q` *(fails: ImportError: Error importing plugin "pytest_asyncio": No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_68a96467a384832084ef9963c6b95a5c