### PR TITLE
feat: load env variables and CLI API key for template evaluation

### DIFF
--- a/scripts/evaluate_templates.py
+++ b/scripts/evaluate_templates.py
@@ -25,15 +25,21 @@ from monitoring.evaluation import (
 )
 
 try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
+try:
     from openai import OpenAI
 except Exception:  # pragma: no cover - openai optional for tests
     OpenAI = None  # type: ignore
 
 
-def _openai_call(prompt: str, model: str) -> Mapping[str, Any]:
+def _openai_call(prompt: str, model: str, api_key: str | None = None) -> Mapping[str, Any]:
     if OpenAI is None:
         raise RuntimeError("openai package not available")
-    client = OpenAI()
+    client = OpenAI(api_key=api_key) if api_key else OpenAI()
     resp = client.responses.create(model=model, input=prompt)
     text = resp.output_text
     data = json.loads(text)
@@ -48,6 +54,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Evaluate template variants")
     parser.add_argument("fixture", help="JSON fixture with templates and samples")
     parser.add_argument("--model", default="gpt-4o-mini", help="Model to use")
+    parser.add_argument("--api-key", help="OpenAI API key", default=None)
     args = parser.parse_args()
 
     with open(args.fixture, "r", encoding="utf-8") as fh:
@@ -59,7 +66,10 @@ def main() -> None:
     results_by_variant: Dict[str, Any] = {}
     for name, template in templates.items():
         results_by_variant[name] = evaluate_variant(
-            samples, template, lambda p: _openai_call(p, args.model), model=args.model
+            samples,
+            template,
+            lambda p: _openai_call(p, args.model, args.api_key),
+            model=args.model,
         )
 
     summary = aggregate_metrics(results_by_variant)


### PR DESCRIPTION
## Summary
- load dotenv if available before importing OpenAI
- allow passing `--api-key` to `evaluate_templates.py` and use it for OpenAI client

## Testing
- `python -m scripts.evaluate_templates tests/fixtures/intent_samples.json --api-key dummy` *(fails: httpx.ProxyError: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a980e77f6c83209a84b95d7bd93dcf