### PR TITLE
Use English error message when OpenAI API key missing

### DIFF
--- a/scripts/evaluate_templates.py
+++ b/scripts/evaluate_templates.py
@@ -42,7 +42,7 @@ def _openai_call(prompt: str, model: str, api_key: str | None = None) -> Mapping
         raise RuntimeError("openai package not available")
     if not os.getenv("OPENAI_API_KEY"):
         raise RuntimeError(
-            "OPENAI_API_KEY manquante : chargez-la depuis .env ou exportez-la."
+            "OPENAI_API_KEY is missing: load it from .env or export it."
         )
     client = OpenAI()
     client = OpenAI(api_key=api_key) if api_key else OpenAI()


### PR DESCRIPTION
## Summary
- report missing OpenAI API key in English

## Testing
- `pytest tests/test_evaluate_templates_script.py::test_missing_api_key -q`


------
https://chatgpt.com/codex/tasks/task_e_68a98460296c8320974756c12b85a77a