### PR TITLE
Fix OpenAI call in template evaluation script

### DIFF
--- a/scripts/evaluate_templates.py
+++ b/scripts/evaluate_templates.py
@@ -45,12 +45,12 @@ def _openai_call(prompt: str, model: str, api_key: str | None = None) -> Mapping
             "OPENAI_API_KEY is missing: load it from .env or export it."
         )
     client = OpenAI(api_key=api_key) if api_key else OpenAI()
-    resp = client.responses.create(
+    resp = client.chat.completions.create(
         model=model,
-        input=prompt,
+        messages=[{"role": "user", "content": prompt}],
         response_format={"type": "json_object"},
     )
-    text = resp.output_text
+    text = resp.choices[0].message.content
     try:
         data = json.loads(text)
     except json.JSONDecodeError as exc:


### PR DESCRIPTION
## Summary
- update evaluate_templates to use `chat.completions.create` and parse content from choices

## Testing
- `pytest tests/test_evaluate_templates_script.py`
- `OPENAI_API_KEY=dummy python scripts/evaluate_templates.py tests/fixtures/intent_samples.json` *(fails: openai.APIConnectionError: Connection error.)*


------
https://chatgpt.com/codex/tasks/task_e_68a9996c7c808320ba8e02d4abaa34b5