### PR TITLE
refactor: simplify entity type enum

### DIFF
--- a/conversation_service/models/enums.py
+++ b/conversation_service/models/enums.py
@@ -188,15 +188,15 @@ class IntentType(str, Enum):
 class EntityType(str, Enum):
     """Catégories d'entités extraites d'un message."""
 
-    ACCOUNT = "ACCOUNT"
-    """Identifiant de compte bancaire.
+    AMOUNT = "AMOUNT"
+    """Valeur monétaire.
 
-    Exemple: "compte courant"."""
+    Exemple: "50 euros"."""
 
-    TRANSACTION = "TRANSACTION"
-    """Identifiant de transaction.
+    TEMPORAL = "TEMPORAL"
+    """Date ou période temporelle.
 
-    Exemple: "txn_123"."""
+    Exemple: "janvier 2024"."""
 
     MERCHANT = "MERCHANT"
     """Nom d'un marchand.
@@ -208,27 +208,22 @@ class EntityType(str, Enum):
 
     Exemple: "restaurants"."""
 
-    DATE = "DATE"
-    """Date explicite.
+    ACCOUNT = "ACCOUNT"
+    """Identifiant de compte bancaire.
 
-    Exemple: "2024-05-01"."""
-
-    PERIOD = "PERIOD"
-    """Période ou intervalle de dates.
-
-    Exemple: "janvier 2024"."""
-
-    AMOUNT = "AMOUNT"
-    """Valeur monétaire.
-
-    Exemple: "50 euros"."""
+    Exemple: "compte courant"."""
 
     OPERATION_TYPE = "OPERATION_TYPE"
     """Type d'opération financière.
 
     Exemple: "débit"."""
 
-    TEXT = "TEXT"
+    LOCATION = "LOCATION"
+    """Lieu géographique associé à la requête ou à la transaction.
+
+    Exemple: "Paris"."""
+
+    TEXT_QUERY = "TEXT_QUERY"
     """Texte libre de recherche.
 
     Exemple: "abonnement"."""

--- a/tests/conversation_service/models/test_enums_coverage.py
+++ b/tests/conversation_service/models/test_enums_coverage.py
@@ -41,14 +41,13 @@ def test_query_type_matches_categories():
 
 def test_entity_type_expected_values():
     expected = {
-        "ACCOUNT",
-        "TRANSACTION",
+        "AMOUNT",
+        "TEMPORAL",
         "MERCHANT",
         "CATEGORY",
-        "DATE",
-        "PERIOD",
-        "AMOUNT",
+        "ACCOUNT",
         "OPERATION_TYPE",
-        "TEXT",
+        "LOCATION",
+        "TEXT_QUERY",
     }
     assert expected == {e.value for e in EntityType}


### PR DESCRIPTION
## Summary
- condense `EntityType` enum to AMOUNT, TEMPORAL, MERCHANT, CATEGORY, ACCOUNT, OPERATION_TYPE, LOCATION and TEXT_QUERY
- adjust tests to match revised entity types

## Testing
- `python - <<'PY'
import json
from conversation_service.models.enums import EntityType
print(json.dumps({e.name: e for e in EntityType}))
PY`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a99cecc1d48320ad68ed67813412d7