### PR TITLE
feat: extend agent config with caching and examples

### DIFF
--- a/tests/conversation_service/models/test_agent_models.py
+++ b/tests/conversation_service/models/test_agent_models.py
@@ -37,12 +37,35 @@ def test_agent_config_and_enums():
     config = AgentConfig(
         name="classifier",
         system_prompt="You are a bot.",
-        model="gpt-4",
+        model="gpt-4o-mini",
         temperature=0.5,
         max_tokens=100,
         timeout=10,
+        few_shot_examples=[["hi", "hello there"]],
+        cache_ttl=10,
+        cache_strategy="memory",
     )
     assert config.name == "classifier"
+    assert config.few_shot_examples[0] == ["hi", "hello there"]
+    assert config.cache_strategy == "memory"
+
+    with pytest.raises(ValidationError):
+        AgentConfig(name="bad", system_prompt="x", model="bad-model")
+
+    with pytest.raises(ValidationError):
+        AgentConfig(
+            name="bad", system_prompt="x", model="gpt-4o-mini", few_shot_examples=[["only one"]]
+        )
+
+    with pytest.raises(ValidationError):
+        AgentConfig(
+            name="bad", system_prompt="x", model="gpt-4o-mini", cache_ttl=0
+        )
+
+    with pytest.raises(ValidationError):
+        AgentConfig(
+            name="bad", system_prompt="x", model="gpt-4o-mini", cache_strategy="disk"
+        )
 
     intent = IntentResult(intent_type=IntentType.GREETING, confidence_score=0.9)
     assert intent.intent_type is IntentType.GREETING


### PR DESCRIPTION
## Summary
- restrict AgentConfig model to specific OpenAI models
- support few-shot examples and caching options on AgentConfig
- cover configuration validation edge cases in tests

## Testing
- `pytest tests/conversation_service/models/test_agent_models.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*


------
https://chatgpt.com/codex/tasks/task_e_68a99d0935bc8320b7d47a3175a33412