### PR TITLE
Fix missing parentheses in conversation model tests

### DIFF
--- a/tests/test_conversation_models_phase2.py
+++ b/tests/test_conversation_models_phase2.py
@@ -68,6 +68,8 @@ def test_confidence_score_range():
             intent=IntentType.GREETING,
             confidence_score=-0.1,
             extraction_mode="auto",
+        )
+    with pytest.raises(ValidationError):
         ConversationResponse(
             original_message="Hi",
             response="Hi",


### PR DESCRIPTION
## Summary
- ensure ConversationMetadata and ConversationResponse are called with parentheses in tests

## Testing
- `pytest tests/test_conversation_models_phase2.py` *(fails: SyntaxError in conversation_service/models/conversation_models.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a2bf4ffc8320957452edada9faa5