### PR TITLE
refactor: clean up conversation response example

### DIFF
--- a/conversation_service/models/conversation_models.py
+++ b/conversation_service/models/conversation_models.py
@@ -74,7 +74,6 @@ class ConversationContext(BaseModel):
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
-                "conversation_id": "550e8400-e29b-41d4-a716-446655440000",
                 "turn_number": 1,
                 "recent_intents": ["greeting"],
                 "previous_entities": [],
@@ -83,7 +82,6 @@ class ConversationContext(BaseModel):
                 "auto_summary": None,
             }
         }
-        json_schema_extra={"example": {"turn_number": 1}}
     )
 
     @field_validator("auto_summary")
@@ -168,7 +166,7 @@ class ConversationResponse(BaseModel):
                 "context": {
                     "conversation_id": "550e8400-e29b-41d4-a716-446655440000",
                     "turn_number": 1,
-                "context": {"turn_number": 1},
+                },
                 "metadata": {
                     "intent": "greeting",
                     "confidence_score": 0.95,


### PR DESCRIPTION
## Summary
- simplify ConversationContext example
- flatten metadata, suggested_actions, and user_preferences in ConversationResponse example

## Testing
- `pytest` *(fails: SyntaxError in tests/test_conversation_models_phase2.py: '(' was never closed)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a2b9160883208e9ec201f378443a