### PR TITLE
feat: expose conversation metadata in conversation models package

### DIFF
--- a/conversation_service/models/__init__.py
+++ b/conversation_service/models/__init__.py
@@ -15,6 +15,7 @@ from .conversation_db_models import (
 )
 from .conversation_models import (
     ConversationContext,
+    ConversationMetadata,
     ConversationRequest,
     ConversationResponse,
 )
@@ -43,6 +44,7 @@ __all__ = [
     "DynamicFinancialEntity",
     "IntentResult",
     "ConversationContext",
+    "ConversationMetadata",
     "ConversationRequest",
     "ConversationResponse",
     "ConfidenceThreshold",


### PR DESCRIPTION
## Summary
- export `ConversationMetadata` from `conversation_service.models`

## Testing
- `pytest tests/test_conversation_models_phase2.py::test_conversation_response_valid -q` *(fails: NameError: ConversationMetadata not defined in tests; ensure tests import it)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a40f713c83209596c7b00ff3d5d9