### PR TITLE
Fix ConversationMetadata import in tests

### DIFF
--- a/tests/test_conversation_models_phase2.py
+++ b/tests/test_conversation_models_phase2.py
@@ -6,6 +6,7 @@ from conversation_service.models import (
     ConversationRequest,
     ConversationResponse,
     ConversationContext,
+    ConversationMetadata,
     IntentType,
     DynamicFinancialEntity,
     EntityType,
@@ -105,11 +106,9 @@ def test_conversation_response_valid():
     )
     entity = DynamicFinancialEntity(
         entity_type=EntityType.ACCOUNT,
-        value="123",
+        raw_value="123",
         confidence_score=0.9,
     )
-    ctx = ConversationContext(turn_number=2)
-    meta = ConversationMetadata(intent=IntentType.GREETING, confidence_score=0.8)
     resp = ConversationResponse(
         original_message="Hi",
         response="Hello!",
@@ -122,7 +121,7 @@ def test_conversation_response_valid():
         user_preferences={"tone": "friendly"},
     )
     assert resp.intent == IntentType.GREETING
-    assert resp.entities[0].value == "123"
+    assert resp.entities[0].raw_value == "123"
     assert resp.confidence_score == 0.8
     assert resp.suggested_actions == ["check_balance"]
     assert resp.user_preferences["tone"] == "friendly"


### PR DESCRIPTION
## Summary
- include ConversationMetadata in test imports
- adjust DynamicFinancialEntity usage in conversation response test

## Testing
- `pytest tests/test_conversation_models_phase2.py::test_confidence_score_range tests/test_conversation_models_phase2.py::test_conversation_response_valid tests/test_conversation_models_phase2.py::test_metadata_invalid_intent tests/test_conversation_models_phase2.py::test_metadata_negative_cache_stats -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9a56c8d048320b590817f4b76448d