### PR TITLE
Add integration test for conversation metadata fields

### DIFF
--- a/tests/integration/test_conversation_creation.py
+++ b/tests/integration/test_conversation_creation.py
@@ -1,0 +1,23 @@
+from conversation_service.repositories import ConversationRepository
+from conversation_service.schemas import ConversationCreate
+from tests.test_phase_0.conftest import db_session, user  # noqa: F401
+
+
+def test_conversation_create_with_metadata(db_session, user):
+    repo = ConversationRepository(db_session)
+    conv = repo.create(
+        ConversationCreate(
+            user_id=user.id,
+            financial_context={"balance": 100},
+            user_preferences_ai={"tone": "formal"},
+            key_entities_history=[{"name": "Account", "type": "bank_account"}],
+        )
+    )
+
+    fetched = repo.get_conversation(conv.conversation_id, user_id=user.id)
+
+    assert fetched.financial_context == {"balance": 100}
+    assert fetched.user_preferences_ai == {"tone": "formal"}
+    assert fetched.key_entities_history == [
+        {"name": "Account", "type": "bank_account"}
+    ]


### PR DESCRIPTION
## Summary
- add integration test ensuring ConversationRepository persists financial_context, user_preferences_ai, and key_entities_history

## Testing
- `pytest tests/integration/test_conversation_creation.py -q` *(fails: AssertionError: assert {} == {'balance': 100})*

------
https://chatgpt.com/codex/tasks/task_e_68aa0639b40c83208aac1aae8bff102e