### PR TITLE
fix: cleanup conversation schemas

### DIFF
--- a/conversation_service/schemas/conversation.py
+++ b/conversation_service/schemas/conversation.py
@@ -12,8 +12,8 @@ Example:
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, List, Optional, Dict
-from pydantic import BaseModel, Field, ConfigDict
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class ConversationTurnCreate(BaseModel):
@@ -21,30 +21,28 @@ class ConversationTurnCreate(BaseModel):
 
     user_message: str
     assistant_response: str
-    turn_metadata: Dict[str, object] = Field(default_factory=dict)
+    turn_metadata: Dict[str, Any] = Field(default_factory=dict)
     # Additional optional AI processing fields
     processing_time_ms: Optional[float] = None
     confidence_score: Optional[float] = None
     error_occurred: bool = False
     error_message: Optional[str] = None
     intent_result: Optional[Dict[str, Any]] = None
-    agent_chain: List[Any] = Field(default_factory=list)
+    agent_chain: List[Dict[str, Any]] = Field(default_factory=list)
     intent_classification: Dict[str, Any] = Field(default_factory=dict)
-    entities_extracted: List[Any] = Field(default_factory=list)
+    entities_extracted: List[Dict[str, Any]] = Field(default_factory=list)
     intent_confidence: float = 0
     total_tokens_used: int = 0
     financial_context: Dict[str, Any] = Field(default_factory=dict)
     user_preferences_ai: Dict[str, Any] = Field(default_factory=dict)
-    key_entities_history: List[Any] = Field(default_factory=list)
+    key_entities_history: List[Dict[str, Any]] = Field(default_factory=list)
     openai_usage_stats: Dict[str, Any] = Field(default_factory=dict)
-    openai_cost_usd: float = 0
+    openai_cost_usd: float = 0.0
     intent: Optional[Dict[str, Any]] = None
-    entities: Optional[Dict[str, Any]] = None
+    entities: Optional[List[Dict[str, Any]]] = Field(default_factory=list)
     prompt_tokens: Optional[int] = None
     completion_tokens: Optional[int] = None
     total_tokens: Optional[int] = None
-    openai_usage_stats: Dict[str, Any] = Field(default_factory=dict)
-    openai_cost_usd: float = 0.0
     search_query_used: Optional[str] = None
     search_results_count: int = 0
     search_execution_time_ms: Optional[float] = None
@@ -72,14 +70,24 @@ class ConversationCreate(BaseModel):
     title: Optional[str] = None
     language: str = "fr"
     domain: str = "financial"
-    conversation_metadata: Dict[str, object] = Field(default_factory=dict)
-    user_preferences: Dict[str, object] = Field(default_factory=dict)
-    session_metadata: Dict[str, object] = Field(default_factory=dict)
+    conversation_metadata: Dict[str, Any] = Field(default_factory=dict)
+    user_preferences: Dict[str, Any] = Field(default_factory=dict)
+    session_metadata: Dict[str, Any] = Field(default_factory=dict)
     # Additional optional metadata fields
-    financial_context: Dict[str, object] = Field(default_factory=dict)
-    user_preferences_ai: Dict[str, object] = Field(default_factory=dict)
-    key_entities_history: List[Dict[str, object]] = Field(default_factory=list)
-    key_entities_history: List[Any] = Field(default_factory=list)
+    financial_context: Dict[str, Any] = Field(default_factory=dict)
+    user_preferences_ai: Dict[str, Any] = Field(default_factory=dict)
+    intents: Optional[List[Dict[str, Any]]] = Field(default_factory=list)
+    entities: Optional[List[Dict[str, Any]]] = Field(default_factory=list)
+    prompt_tokens: Optional[int] = None
+    completion_tokens: Optional[int] = None
+    total_tokens: Optional[int] = None
+    intent_classification: Dict[str, Any] = Field(default_factory=dict)
+    entities_extracted: List[Dict[str, Any]] = Field(default_factory=list)
+    intent_confidence: Dict[str, Any] = Field(default_factory=dict)
+    total_tokens_used: Dict[str, Any] = Field(default_factory=dict)
+    openai_usage_stats: Dict[str, Any] = Field(default_factory=dict)
+    openai_cost_usd: Dict[str, Any] = Field(default_factory=dict)
+    key_entities_history: List[Dict[str, Any]] = Field(default_factory=list)
 
     model_config = ConfigDict(extra="allow")
 


### PR DESCRIPTION
## Summary
- remove duplicated metadata declarations
- align schema types with ORM models and expose AI metadata

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa14231a648320960f1378e0a1c3e6