### PR TITLE
Simplify conversation schemas to match tables

### DIFF
--- a/conversation_service/schemas/conversation.py
+++ b/conversation_service/schemas/conversation.py
@@ -33,16 +33,8 @@ class ConversationTurnCreate(BaseModel):
     entities_extracted: List[Dict[str, Any]] = Field(default_factory=list)
     intent_confidence: float = 0
     total_tokens_used: int = 0
-    financial_context: Dict[str, Any] = Field(default_factory=dict)
-    user_preferences_ai: Dict[str, Any] = Field(default_factory=dict)
-    key_entities_history: List[Dict[str, Any]] = Field(default_factory=list)
     openai_usage_stats: Dict[str, Any] = Field(default_factory=dict)
     openai_cost_usd: float = 0.0
-    intent: Optional[Dict[str, Any]] = None
-    entities: Optional[List[Dict[str, Any]]] = Field(default_factory=list)
-    prompt_tokens: Optional[int] = None
-    completion_tokens: Optional[int] = None
-    total_tokens: Optional[int] = None
     search_query_used: Optional[str] = None
     search_results_count: int = 0
     search_execution_time_ms: Optional[float] = None
@@ -73,21 +65,6 @@ class ConversationCreate(BaseModel):
     conversation_metadata: Dict[str, Any] = Field(default_factory=dict)
     user_preferences: Dict[str, Any] = Field(default_factory=dict)
     session_metadata: Dict[str, Any] = Field(default_factory=dict)
-    # Additional optional metadata fields
-    financial_context: Dict[str, Any] = Field(default_factory=dict)
-    user_preferences_ai: Dict[str, Any] = Field(default_factory=dict)
-    intents: Optional[List[Dict[str, Any]]] = Field(default_factory=list)
-    entities: Optional[List[Dict[str, Any]]] = Field(default_factory=list)
-    prompt_tokens: Optional[int] = None
-    completion_tokens: Optional[int] = None
-    total_tokens: Optional[int] = None
-    intent_classification: Dict[str, Any] = Field(default_factory=dict)
-    entities_extracted: List[Dict[str, Any]] = Field(default_factory=list)
-    intent_confidence: Dict[str, Any] = Field(default_factory=dict)
-    total_tokens_used: Dict[str, Any] = Field(default_factory=dict)
-    openai_usage_stats: Dict[str, Any] = Field(default_factory=dict)
-    openai_cost_usd: Dict[str, Any] = Field(default_factory=dict)
-    key_entities_history: List[Dict[str, Any]] = Field(default_factory=list)
 
     model_config = ConfigDict(extra="allow")
 

--- a/tests/integration/test_conversation_creation.py
+++ b/tests/integration/test_conversation_creation.py
@@ -8,16 +8,14 @@ def test_conversation_create_with_metadata(db_session, user):
     conv = repo.create(
         ConversationCreate(
             user_id=user.id,
-            financial_context={"balance": 100},
-            user_preferences_ai={"tone": "formal"},
-            key_entities_history=[{"name": "Account", "type": "bank_account"}],
+            conversation_metadata={"topic": "budget"},
+            user_preferences={"tone": "formal"},
+            session_metadata={"ip": "127.0.0.1"},
         )
     )
 
     fetched = repo.get_conversation(conv.conversation_id, user_id=user.id)
 
-    assert fetched.financial_context == {"balance": 100}
-    assert fetched.user_preferences_ai == {"tone": "formal"}
-    assert fetched.key_entities_history == [
-        {"name": "Account", "type": "bank_account"}
-    ]
+    assert fetched.conversation_metadata == {"topic": "budget"}
+    assert fetched.user_preferences == {"tone": "formal"}
+    assert fetched.session_metadata == {"ip": "127.0.0.1"}


### PR DESCRIPTION
## Summary
- slim down ConversationCreate and ConversationTurnCreate to only expose fields stored in DB tables
- strip legacy attributes in ConversationRepository when persisting turns
- adjust integration test to use supported metadata fields

## Testing
- `pytest tests/integration -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa1727fb6483208d0f1b7700d09ece