### PR TITLE
feat: add aggregation-only flag to search request

### DIFF
--- a/search_service/models/request.py
+++ b/search_service/models/request.py
@@ -30,6 +30,11 @@ class SearchRequest(BaseModel):
         default=None, description="Requête d'agrégation optionnelle"
     )
 
+    aggregation_only: bool = Field(
+        default=False,
+        description="Si vrai, seuls les résultats d'agrégations sont renvoyés",
+    )
+
     @field_validator('query')
     @classmethod
     def validate_query(cls, v: str) -> str:
@@ -72,7 +77,11 @@ class SearchRequest(BaseModel):
                 },
                 "limit": 10,
                 "offset": 0,
-                "metadata": {"debug": True}
+                "metadata": {"debug": True},
+                "aggregations": {
+                    "by_category": {"terms": {"field": "category_name"}}
+                },
+                "aggregation_only": False
             }
         }
     )


### PR DESCRIPTION
## Summary
- add `aggregation_only` flag to `SearchRequest`
- document aggregation settings in example request

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'conversation_service')*

------
https://chatgpt.com/codex/tasks/task_e_68aac545ad388320953d114e7c390d23