### PR TITLE
feat: support aggregation-only queries

### DIFF
--- a/search_service/core/query_builder.py
+++ b/search_service/core/query_builder.py
@@ -183,7 +183,14 @@ class QueryBuilder:
         # Ajouter les agrégations à la requête finale
         if aggregations:
             base_query["aggs"] = aggregations
-            logger.info(f"Added {len(aggregations)} aggregations to query: {list(aggregations.keys())}")
+            logger.info(
+                f"Added {len(aggregations)} aggregations to query: {list(aggregations.keys())}"
+            )
+            if getattr(request, "aggregation_only", False):
+                base_query["size"] = 0
+                logger.info(
+                    "Aggregation-only request detected: returning only aggregations"
+                )
         else:
             logger.warning("No valid aggregations generated from input")
 


### PR DESCRIPTION
## Summary
- add aggregation-only mode for Elasticsearch queries

## Testing
- `pytest` (fails: FileNotFoundError: No such file or directory; 20 errors)


------
https://chatgpt.com/codex/tasks/task_e_68aac54f2410832099e42ef35ab168c7