### PR TITLE
Handle empty Elasticsearch hits early in _process_results

### DIFF
--- a/search_service/core/search_engine.py
+++ b/search_service/core/search_engine.py
@@ -288,8 +288,11 @@ class SearchEngine:
         VERSION CORRIGÉE - Robuste aux données manquantes/nulles
         """
         results = []
-        
+
         hits = es_response.get('hits', {}).get('hits', [])
+        if not hits:
+            logger.debug("No hits returned from Elasticsearch")
+            return []
         logger.debug(f"Processing {len(hits)} hits from Elasticsearch")
         
         for i, hit in enumerate(hits):


### PR DESCRIPTION
## Summary
- avoid extra processing when Elasticsearch returns no hits

## Testing
- `pytest` (fails: FileNotFoundError: [Errno 2] No such file or directory: '/workspace/harena/...', plus multiple errors during collection)

------
https://chatgpt.com/codex/tasks/task_e_68aac55368b483209be32b6a35ada3f5