### PR TITLE
feat: add page pagination to search requests

### DIFF
--- a/scripts/test_harena_nominal.py
+++ b/scripts/test_harena_nominal.py
@@ -273,8 +273,8 @@ class HarenaRealDataTestClient:
         search_payload = {
             "user_id": self.user_id,
             "query": "netflix",
-            "limit": 25,
-            "offset": 0,
+            "page": 1,
+            "page_size": 25,
             "filters": {
                 "amount": {
                     "gte": -25,

--- a/search_service/api/routes.py
+++ b/search_service/api/routes.py
@@ -68,7 +68,7 @@ async def search_transactions(
         # Log de la requête pour monitoring
         logger.info(
             f"Search request from user {request.user_id}: "
-            f"query='{request.query}', filters={len(request.filters)}, limit={request.limit}"
+            f"query='{request.query}', filters={len(request.filters)}, page={request.page}, page_size={request.page_size}"
         )
         
         # Recherche via moteur unifié

--- a/search_service/core/query_builder.py
+++ b/search_service/core/query_builder.py
@@ -46,7 +46,7 @@ class QueryBuilder:
             },
             "sort": self._build_sort_criteria(request),
             "_source": self._get_source_fields(),
-            "size": request.limit,
+            "size": request.page_size,
             "from": request.offset
         }
         

--- a/search_service/core/search_engine.py
+++ b/search_service/core/search_engine.py
@@ -77,7 +77,7 @@ class SearchEngine:
             query=request.query,
             filters=json.dumps(request.filters, sort_keys=True),
             offset=request.offset,
-            limit=request.limit,
+            page_size=request.page_size,
         )
 
     def _check_rate_limit(self, user_id: int) -> None:
@@ -244,13 +244,13 @@ class SearchEngine:
                     response = await self.elasticsearch_client.search(
                         index=self.index_name,
                         body=es_query,
-                        size=request.limit,
+                        size=request.page_size,
                         from_=request.offset,
                     )
                 else:
                     # Fallback: requête HTTP directe
                     search_url = f"/{self.index_name}/_search"
-                    es_query["size"] = request.limit
+                    es_query["size"] = request.page_size
                     es_query["from"] = request.offset
                     async with self.elasticsearch_client.session.post(
                         f"{self.elasticsearch_client.base_url}{search_url}",
@@ -400,8 +400,9 @@ class SearchEngine:
                 "user_id": request.user_id,
                 "query": request.query,
                 "filters": request.filters,
-                "limit": request.limit,
-                "offset": request.offset
+                "page": request.page,
+                "page_size": request.page_size,
+                "offset": request.offset,
             },
             "elasticsearch_query": es_query,
             "index_used": self.index_name

--- a/tests/test_aggregation_optimization.py
+++ b/tests/test_aggregation_optimization.py
@@ -16,7 +16,8 @@ def test_aggregation_only_returns_no_results_but_same_aggregations():
     base_payload = {
         "user_id": 1,
         "query": "",
-        "limit": 5,
+        "page": 1,
+        "page_size": 5,
         "aggregations": {"operation_type": {"terms": {"field": "operation_type"}}},
     }
     agg_only_payload = {**base_payload, "aggregation_only": True}


### PR DESCRIPTION
## Summary
- support page/page_size in SearchRequest with automatic offset
- update search engine, query builder, and routes for page-based pagination
- adjust tests and scripts to construct SearchRequest with new fields

## Testing
- `pre-commit run --files search_service/models/request.py search_service/core/query_builder.py search_service/core/search_engine.py search_service/api/routes.py tests/test_aggregation_optimization.py scripts/test_harena_nominal.py` (failed: .pre-commit-config.yaml is not a file)
- `pytest tests/test_aggregation_optimization.py`


------
https://chatgpt.com/codex/tasks/task_e_68aad5e52d9883209867f6cd55197884