### PR TITLE
feat: add account metadata to structured transaction

### DIFF
--- a/enrichment_service/models.py
+++ b/enrichment_service/models.py
@@ -15,6 +15,11 @@ class TransactionInput(BaseModel):
     bridge_transaction_id: int
     user_id: int
     account_id: int
+    account_name: Optional[str] = None
+    account_type: Optional[str] = None
+    account_balance: Optional[float] = None
+    account_currency: Optional[str] = None
+    account_last_sync: Optional[datetime] = None
     clean_description: Optional[str] = None
     provider_description: Optional[str] = None
     amount: float
@@ -24,6 +29,7 @@ class TransactionInput(BaseModel):
     value_date: Optional[datetime] = None
     currency_code: Optional[str] = None
     category_id: Optional[int] = None
+    category_name: Optional[str] = None
     operation_type: Optional[str] = None
     deleted: bool = False
     future: bool = False
@@ -97,6 +103,16 @@ class StructuredTransaction:
     # Métadonnées supplémentaires
     is_future: bool
     is_deleted: bool
+
+    # Informations sur le compte
+    account_name: Optional[str] = None
+    account_type: Optional[str] = None
+    account_balance: Optional[float] = None
+    account_currency: Optional[str] = None
+    account_last_sync: Optional[datetime] = None
+
+    # Information sur la catégorie
+    category_name: Optional[str] = None
     
     @classmethod
     def from_transaction_input(cls, tx: TransactionInput) -> 'StructuredTransaction':
@@ -145,7 +161,13 @@ class StructuredTransaction:
             category_id=tx.category_id,
             operation_type=tx.operation_type,
             is_future=tx.future,
-            is_deleted=tx.deleted
+            is_deleted=tx.deleted,
+            account_name=tx.account_name,
+            account_type=tx.account_type,
+            account_balance=tx.account_balance,
+            account_currency=tx.account_currency,
+            account_last_sync=tx.account_last_sync,
+            category_name=tx.category_name
         )
     
     def to_elasticsearch_document(self) -> Dict[str, Any]:
@@ -155,6 +177,11 @@ class StructuredTransaction:
             "transaction_id": self.transaction_id,
             "user_id": self.user_id,
             "account_id": self.account_id,
+            "account_name": self.account_name,
+            "account_type": self.account_type,
+            "account_balance": self.account_balance,
+            "account_currency": self.account_currency,
+            "account_last_sync": self.account_last_sync.isoformat() if self.account_last_sync else None,
             
             # Contenu recherchable
             "searchable_text": self.searchable_text,
@@ -176,6 +203,7 @@ class StructuredTransaction:
             # Catégorisation
             "category_id": self.category_id,
             "operation_type": self.operation_type,
+            "category_name": self.category_name,
             
             # Flags
             "is_future": self.is_future,

--- a/tests/test_structured_transaction.py
+++ b/tests/test_structured_transaction.py
@@ -1,0 +1,38 @@
+from datetime import datetime
+from enrichment_service.models import TransactionInput, StructuredTransaction
+
+
+def test_structured_transaction_with_account_data():
+    tx_input = TransactionInput(
+        bridge_transaction_id=1,
+        user_id=1,
+        account_id=123,
+        clean_description="Coffee",
+        amount=-4.5,
+        date=datetime(2024, 1, 1),
+        currency_code="EUR",
+        category_id=10,
+        category_name="Food",
+        account_name="Main Account",
+        account_type="checking",
+        account_balance=1000.0,
+        account_currency="EUR",
+        account_last_sync=datetime(2024, 1, 2),
+    )
+
+    structured = StructuredTransaction.from_transaction_input(tx_input)
+
+    assert structured.account_name == "Main Account"
+    assert structured.account_type == "checking"
+    assert structured.account_balance == 1000.0
+    assert structured.account_currency == "EUR"
+    assert structured.account_last_sync == datetime(2024, 1, 2)
+    assert structured.category_name == "Food"
+
+    doc = structured.to_elasticsearch_document()
+    assert doc["account_name"] == "Main Account"
+    assert doc["account_type"] == "checking"
+    assert doc["account_balance"] == 1000.0
+    assert doc["account_currency"] == "EUR"
+    assert doc["account_last_sync"] == datetime(2024, 1, 2).isoformat()
+    assert doc["category_name"] == "Food"


### PR DESCRIPTION
## Summary
- allow TransactionInput to carry optional account and category metadata
- expose account and category info in StructuredTransaction and Elasticsearch documents
- test structured transactions including account details

## Testing
- `pytest` *(fails: async tests require plugin and SearchRequest.limit has no setter)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf916087883209ce07955e737c0d9