### PR TITLE
Integrate account enrichment into transaction processing

### DIFF
--- a/enrichment_service/core/account_enrichment_service.py
+++ b/enrichment_service/core/account_enrichment_service.py
@@ -1,0 +1,67 @@
+import logging
+from typing import Optional, Dict
+
+from sqlalchemy.orm import Session
+
+from enrichment_service.models import TransactionInput
+from db_service.models.sync import SyncAccount, BridgeCategory
+
+logger = logging.getLogger(__name__)
+
+
+class AccountEnrichmentService:
+    """Service providing additional information about accounts and categories."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    async def enrich_with_account_data(self, transaction: TransactionInput) -> Dict[str, Optional[str]]:
+        """Return additional metadata for a transaction.
+
+        The returned dictionary can contain account name, category name and a
+        merchant name extracted from the description.
+        """
+        account_name = self.get_account_details(transaction.account_id)
+        category_name = self.resolve_category_name(transaction.category_id)
+        description = transaction.clean_description or transaction.provider_description or ""
+        merchant_name = self.extract_merchant_name(description)
+        return {
+            "account_name": account_name,
+            "category_name": category_name,
+            "merchant_name": merchant_name,
+        }
+
+    def get_account_details(self, account_id: int) -> Optional[str]:
+        """Fetch the account name for the given account id."""
+        if not self.db:
+            return None
+        account = (
+            self.db.query(SyncAccount)
+            .filter(SyncAccount.bridge_account_id == account_id)
+            .first()
+        )
+        if not account:
+            logger.debug(f"No account found for id {account_id}")
+            return None
+        return account.account_name
+
+    def resolve_category_name(self, category_id: Optional[int]) -> Optional[str]:
+        """Return the category name for the given category id."""
+        if not self.db or not category_id:
+            return None
+        category = (
+            self.db.query(BridgeCategory)
+            .filter(BridgeCategory.bridge_category_id == category_id)
+            .first()
+        )
+        if not category:
+            logger.debug(f"No category found for id {category_id}")
+            return None
+        return category.name
+
+    def extract_merchant_name(self, description: str) -> Optional[str]:
+        """Very naive merchant name extraction from the description."""
+        if not description:
+            return None
+        # Use the first word as a placeholder merchant extraction
+        return description.strip().split(" ")[0]

--- a/tests/test_account_enrichment.py
+++ b/tests/test_account_enrichment.py
@@ -1,0 +1,82 @@
+import pytest
+
+from enrichment_service.models import TransactionInput, BatchTransactionInput
+from enrichment_service.core.processor import ElasticsearchTransactionProcessor
+
+
+class DummyESClient:
+    index_name = "test-index"
+
+    async def document_exists(self, document_id):
+        return False
+
+    async def index_document(self, document_id, document):
+        return True
+
+    async def bulk_index_documents(self, documents, force_update=False):
+        return {
+            "indexed": len(documents),
+            "errors": 0,
+            "responses": [{"success": True} for _ in documents],
+        }
+
+
+class DummyAccountService:
+    async def enrich_with_account_data(self, transaction):
+        return {
+            "account_name": "Main Account",
+            "category_name": "Food",
+            "merchant_name": "Starbucks",
+        }
+
+
+@pytest.mark.asyncio
+async def test_process_transaction_enriches_account_info():
+    processor = ElasticsearchTransactionProcessor(DummyESClient(), DummyAccountService())
+    tx = TransactionInput(
+        bridge_transaction_id=1,
+        user_id=1,
+        account_id=123,
+        clean_description="Payment to Coffee",
+        amount=-10.5,
+        date="2024-01-01T00:00:00",
+        currency_code="EUR",
+    )
+    result = await processor.process_single_transaction(tx, False)
+    assert "Main Account" in result.searchable_text
+    assert "Food" in result.searchable_text
+    assert "Starbucks" in result.searchable_text
+
+
+@pytest.mark.asyncio
+async def test_process_batch_enriches_account_info():
+    processor = ElasticsearchTransactionProcessor(DummyESClient(), DummyAccountService())
+    batch = BatchTransactionInput(
+        user_id=1,
+        transactions=[
+            TransactionInput(
+                bridge_transaction_id=1,
+                user_id=1,
+                account_id=123,
+                clean_description="Payment to Coffee",
+                amount=-10.5,
+                date="2024-01-01T00:00:00",
+                currency_code="EUR",
+            ),
+            TransactionInput(
+                bridge_transaction_id=2,
+                user_id=1,
+                account_id=123,
+                clean_description="Groceries",
+                amount=-20.0,
+                date="2024-01-02T00:00:00",
+                currency_code="EUR",
+            ),
+        ],
+    )
+    result = await processor.process_transactions_batch(batch, False)
+    assert result.results
+    searchable = result.results[0].searchable_text
+    assert "Main Account" in searchable
+    assert "Food" in searchable
+    assert "Starbucks" in searchable


### PR DESCRIPTION
## Summary
- add `AccountEnrichmentService` to augment transactions with account, category and merchant info
- update transaction processor and API routes to use the enrichment service
- cover account enrichment via integration tests

## Testing
- `pytest tests/test_account_enrichment.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaf922c25483209724394b7cf5482b