### PR TITLE
refactor: use shared DB models for enrichment Postgres client

### DIFF
--- a/enrichment_service/storage/postgres_client.py
+++ b/enrichment_service/storage/postgres_client.py
@@ -1,0 +1,24 @@
+"""PostgreSQL client for the enrichment service using shared DB models."""
+from typing import Generator
+
+from db_service.base import Base
+from db_service.models.sync import (
+    SyncAccount as SyncAccountModel,
+    BridgeCategory as BridgeCategoryModel,
+    RawTransaction as RawTransactionModel,
+)  # noqa: F401
+from db_service.session import SessionLocal, engine
+
+
+def init_db() -> None:
+    """Create database tables based on shared Base metadata."""
+    Base.metadata.create_all(bind=engine)
+
+
+def get_db() -> Generator:
+    """Yield a database session and ensure it is closed afterwards."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
- add Postgres client for enrichment service using `db_service` models and Base

## Testing
- `pytest -q` *(fails: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68aafde46214832096502f293ee34fb0