### PR TITLE
Add account metadata to search service

### DIFF
--- a/search_service/core/query_builder.py
+++ b/search_service/core/query_builder.py
@@ -13,7 +13,11 @@ class QueryBuilder:
             "searchable_text^2.0",      # Champ principal enrichi
             "primary_description^1.5",   # Description transaction
             "merchant_name^1.8",         # Nom marchand
-            "category_name^1.0"          # Catégorie
+            "category_name^1.0",         # Catégorie
+            "account_name^1.0",
+            "account_type^1.0",
+            "account_currency^1.0",
+            "account_balance"
         ]
     
     def build_query(self, request: SearchRequest) -> Dict[str, Any]:
@@ -105,7 +109,8 @@ class QueryBuilder:
         # Champs qui nécessitent .keyword pour les filtres exacts
         keyword_fields = {
             'category_name', 'merchant_name', 'operation_type',
-            'currency_code', 'transaction_type', 'weekday'
+            'currency_code', 'transaction_type', 'weekday',
+            'account_name', 'account_type', 'account_currency'
         }
         
         if field in keyword_fields:
@@ -130,6 +135,7 @@ class QueryBuilder:
         """Définit les champs à retourner dans les résultats"""
         return [
             "transaction_id", "user_id", "account_id",
+            "account_name", "account_type", "account_balance", "account_currency",
             "amount", "amount_abs", "currency_code", "transaction_type",
             "date", "month_year", "weekday",
             "primary_description", "merchant_name", "category_name", "operation_type"
@@ -254,7 +260,8 @@ class QueryBuilder:
         allowed_fields = {
             "amount", "amount_abs", "date", "transaction_id", "user_id", "account_id",
             "currency_code", "transaction_type", "operation_type", "category_name",
-            "merchant_name", "primary_description", "month_year", "weekday"
+            "merchant_name", "primary_description", "month_year", "weekday",
+            "account_name", "account_type", "account_balance", "account_currency"
         }
         
         validated = {}

--- a/search_service/core/search_engine.py
+++ b/search_service/core/search_engine.py
@@ -375,6 +375,10 @@ class SearchEngine:
                     
                     # Champs optionnels - gestion explicite des None
                     account_id=source.get('account_id'),  # Peut être None
+                    account_name=source.get('account_name'),
+                    account_type=source.get('account_type'),
+                    account_balance=source.get('account_balance'),
+                    account_currency=source.get('account_currency'),
                     month_year=source.get('month_year'),  # Peut être None
                     weekday=source.get('weekday'),        # Peut être None
                     merchant_name=source.get('merchant_name'),      # Peut être None ou ""

--- a/search_service/models/request.py
+++ b/search_service/models/request.py
@@ -85,7 +85,8 @@ class SearchRequest(BaseModel):
             'category_name', 'merchant_name', 'operation_type',
             'currency_code', 'transaction_type', 'month_year',
             'weekday', 'amount', 'amount_abs', 'date', 'account_id',
-            'primary_description', 'searchable_text'
+            'primary_description', 'searchable_text',
+            'account_name', 'account_type', 'account_balance', 'account_currency'
         }
         
         for field in v.keys():

--- a/search_service/models/response.py
+++ b/search_service/models/response.py
@@ -10,6 +10,10 @@ class SearchResult(BaseModel):
     transaction_id: str = Field(..., description="ID unique de la transaction")
     user_id: int = Field(..., description="ID utilisateur")
     account_id: Optional[int] = Field(None, description="ID du compte")
+    account_name: Optional[str] = Field(None, description="Nom du compte")
+    account_type: Optional[str] = Field(None, description="Type de compte")
+    account_balance: Optional[float] = Field(None, description="Solde du compte")
+    account_currency: Optional[str] = Field(None, description="Devise du compte")
     
     # Montants
     amount: float = Field(..., description="Montant avec signe")
@@ -38,6 +42,10 @@ class SearchResult(BaseModel):
                 "transaction_id": "user_34_tx_12345",
                 "user_id": 34,
                 "account_id": 101,
+                "account_name": "Compte courant",
+                "account_type": "checking",
+                "account_balance": 1000.0,
+                "account_currency": "EUR",
                 "amount": -45.67,
                 "amount_abs": 45.67,
                 "currency_code": "EUR",
@@ -88,6 +96,10 @@ class SearchResponse(BaseModel):
                         "transaction_id": "user_34_tx_12345",
                         "user_id": 34,
                         "account_id": 101,
+                        "account_name": "Compte courant",
+                        "account_type": "checking",
+                        "account_balance": 1000.0,
+                        "account_currency": "EUR",
                         "amount": -45.67,
                         "amount_abs": 45.67,
                         "currency_code": "EUR",

--- a/tests/test_aggregation_optimization.py
+++ b/tests/test_aggregation_optimization.py
@@ -11,6 +11,11 @@ def _make_hit(idx: int) -> dict:
         "_source": {
             "transaction_id": f"tx_{idx}",
             "user_id": 1,
+            "account_id": 10 + idx,
+            "account_name": f"Account {idx}",
+            "account_type": "checking",
+            "account_balance": 1000.0 + idx,
+            "account_currency": "EUR",
             "amount": float(idx),
             "amount_abs": float(idx),
             "currency_code": "EUR",
@@ -61,3 +66,8 @@ async def test_aggregation_only_returns_no_results_but_same_aggregations():
 
     assert agg_only["results"] == []
     assert full["aggregations"] == agg_only["aggregations"]
+    first = full["results"][0]
+    assert first["account_name"] == "Account 0"
+    assert first["account_type"] == "checking"
+    assert first["account_balance"] == 1000.0
+    assert first["account_currency"] == "EUR"

--- a/tests/test_aggregation_pagination.py
+++ b/tests/test_aggregation_pagination.py
@@ -11,6 +11,11 @@ def _make_hit(idx: int) -> dict:
         "_source": {
             "transaction_id": f"tx_{idx}",
             "user_id": 1,
+            "account_id": 20 + idx,
+            "account_name": f"Account {idx}",
+            "account_type": "checking",
+            "account_balance": 2000.0 + idx,
+            "account_currency": "EUR",
             "amount": float(idx),
             "amount_abs": float(idx),
             "currency_code": "EUR",
@@ -60,5 +65,10 @@ def test_pagination_with_aggregations_returns_all_hits():
         assert len(resp["results"]) == total_hits
         assert resp["response_metadata"]["total_pages"] > 1
         assert resp["response_metadata"]["returned_results"] == total_hits
+        first = resp["results"][0]
+        assert first["account_name"] == "Account 1"
+        assert first["account_type"] == "checking"
+        assert first["account_balance"] == 2001.0
+        assert first["account_currency"] == "EUR"
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- allow filtering by account_name, account_type, account_balance and account_currency
- include account metadata in search result schema and query builder
- test account metadata returned in search responses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaf968da688320941428b08d4cd327