### PR TITLE
feat: add metrics and observability

### DIFF
--- a/docs/grafana_dashboard.json
+++ b/docs/grafana_dashboard.json
@@ -1,0 +1,34 @@
+{
+  "title": "Enrichment Service",
+  "schemaVersion": 38,
+  "version": 1,
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Enrichment Throughput",
+      "targets": [
+        {"expr": "rate(enrichment_processing_seconds_count[5m])"}
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Processor Error Rate",
+      "targets": [
+        {"expr": "rate(enrichment_errors_total[5m])"}
+      ]
+    },
+    {
+      "type": "gauge",
+      "title": "Data Quality Score",
+      "targets": [
+        {"expr": "account_enrichment_data_quality_score"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 1
+        }
+      }
+    }
+  ]
+}

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,30 @@
+# Observability
+
+This service exposes Prometheus metrics and structured JSON logs to monitor enrichment operations.
+
+## Metrics
+
+Metrics are exported at `/metrics` and include:
+
+- `enrichment_processing_seconds`: Histogram of single transaction processing time.
+- `enrichment_batch_processing_seconds`: Histogram for batch processing time.
+- `enrichment_cache_hits_total`: Counter of skipped transactions retrieved from cache.
+- `enrichment_errors_total`: Counter of processing errors.
+- `account_enrichment_seconds`: Histogram of end-to-end account enrichment time.
+- `account_enrichment_cache_hits_total`: Cache hit counter at service level.
+- `account_enrichment_errors_total`: Counter for account-level errors.
+- `account_enrichment_data_quality_score`: Gauge representing the ratio of successful transactions in a batch.
+
+## Logging
+
+Logging is configured with `python-json-logger` to emit JSON records. Each transaction is tagged with a `correlation_id` combining the user and transaction identifiers, enabling end‑to‑end tracing across services.
+
+## Dashboard
+
+A sample Grafana dashboard is provided in [`docs/grafana_dashboard.json`](grafana_dashboard.json). It visualises:
+
+1. Enrichment throughput
+2. Error rates
+3. Data‑quality score
+
+Import the dashboard into Grafana and configure Prometheus as the data source to start monitoring.

--- a/enrichment_service/account_enrichment_service.py
+++ b/enrichment_service/account_enrichment_service.py
@@ -1,0 +1,87 @@
+"""Service d'enrichissement de compte avec métriques et logging structuré."""
+import logging
+import time
+import uuid
+from typing import List
+
+from prometheus_client import Counter, Gauge, Histogram
+
+from enrichment_service.core.processor import ElasticsearchTransactionProcessor
+from enrichment_service.models import (
+    BatchEnrichmentResult,
+    BatchTransactionInput,
+    TransactionInput,
+)
+
+logger = logging.getLogger(__name__)
+
+# Métriques spécifiques au service d'enrichissement de compte
+ACCOUNT_ENRICH_TIME = Histogram(
+    "account_enrichment_seconds",
+    "Temps de traitement d'un compte"
+)
+ACCOUNT_CACHE_HITS = Counter(
+    "account_enrichment_cache_hits_total",
+    "Nombre de transactions traitées depuis le cache"
+)
+ACCOUNT_ERRORS = Counter(
+    "account_enrichment_errors_total",
+    "Nombre d'erreurs lors de l'enrichissement de compte"
+)
+DATA_QUALITY_SCORE = Gauge(
+    "account_enrichment_data_quality_score",
+    "Score de qualité des données pour un lot de transactions"
+)
+
+
+class AccountEnrichmentService:
+    """Service orchestrant l'enrichissement des transactions d'un compte."""
+
+    def __init__(self, processor: ElasticsearchTransactionProcessor):
+        self.processor = processor
+
+    async def enrich_account(
+        self,
+        user_id: int,
+        transactions: List[TransactionInput],
+        force_update: bool = False,
+    ) -> BatchEnrichmentResult:
+        """Enrichit toutes les transactions d'un compte utilisateur."""
+        correlation_id = str(uuid.uuid4())
+        log = logging.LoggerAdapter(
+            logger, {"correlation_id": correlation_id, "user_id": user_id}
+        )
+        start_time = time.perf_counter()
+
+        try:
+            batch_input = BatchTransactionInput(
+                user_id=user_id, transactions=transactions
+            )
+            result = await self.processor.process_transactions_batch(
+                batch_input, force_update=force_update
+            )
+
+            elapsed = time.perf_counter() - start_time
+            ACCOUNT_ENRICH_TIME.observe(elapsed)
+
+            cache_hits = len([r for r in result.results if r.status == "skipped"])
+            if cache_hits:
+                ACCOUNT_CACHE_HITS.inc(cache_hits)
+
+            quality = (
+                result.successful / result.total_transactions
+                if result.total_transactions
+                else 0
+            )
+            DATA_QUALITY_SCORE.set(quality)
+
+            log.info(
+                "Enrichissement de compte terminé",
+                extra={"cache_hits": cache_hits, "data_quality_score": quality},
+            )
+            return result
+        except Exception as e:
+            ACCOUNT_ERRORS.inc()
+            ACCOUNT_ENRICH_TIME.observe(time.perf_counter() - start_time)
+            log.error(f"Erreur enrichissement compte: {e}")
+            raise


### PR DESCRIPTION
## Summary
- instrument enrichment processor and account enrichment service with Prometheus metrics and correlation-id logging
- expose JSON logging and `/metrics` endpoint
- document observability and provide sample Grafana dashboard

## Testing
- `pytest` *(fails: AttributeError: property 'limit' of 'SearchRequest' object has no setter)*


------
https://chatgpt.com/codex/tasks/task_e_68aaf98cf4508320ad0c66c5fd579c8b