### PR TITLE
Add account balance data quality check

### DIFF
--- a/enrichment_service/data_quality.py
+++ b/enrichment_service/data_quality.py
@@ -1,0 +1,58 @@
+import logging
+from typing import List, Dict
+
+
+class DataQualityValidator:
+    """Validates transaction and account consistency."""
+
+    def __init__(self, threshold: float = 1.0) -> None:
+        """Initialize the validator.
+
+        Args:
+            threshold: Maximum allowed difference between the account balance
+                and the aggregated transactions total before triggering an
+                alert.
+        """
+        self.threshold = threshold
+        self.logger = logging.getLogger("data_quality")
+
+    def validate_account_balance_consistency(
+        self, account_balance: float, recent_transactions: List[float]
+    ) -> Dict[str, float | bool]:
+        """Check that the balance matches the sum of recent transactions.
+
+        Args:
+            account_balance: Reported balance for the account.
+            recent_transactions: Monetary amounts for recent transactions.
+
+        Returns:
+            Dict containing ``balance_check_passed`` boolean and a
+            ``quality_score`` between 0 and 1.
+        """
+        if account_balance is None or recent_transactions is None:
+            return {"balance_check_passed": True, "quality_score": 1.0}
+
+        total = sum(recent_transactions)
+        difference = account_balance - total
+        passed = abs(difference) <= self.threshold
+
+        # Quality score is 1 when perfectly matched and degrades linearly with
+        # the relative difference, capped between 0 and 1.
+        if abs(account_balance) > 0:
+            relative_diff = min(abs(difference) / abs(account_balance), 1.0)
+            quality_score = 1.0 - relative_diff
+        else:
+            quality_score = 1.0 if passed else 0.0
+
+        if not passed:
+            self.logger.warning(
+                "Balance inconsistency detected: balance=%s, total=%s, diff=%s",
+                account_balance,
+                total,
+                difference,
+            )
+
+        return {
+            "balance_check_passed": passed,
+            "quality_score": round(quality_score, 3),
+        }

--- a/enrichment_service/models.py
+++ b/enrichment_service/models.py
@@ -27,6 +27,8 @@ class TransactionInput(BaseModel):
     operation_type: Optional[str] = None
     deleted: bool = False
     future: bool = False
+    account_balance: Optional[float] = None
+    recent_transactions: List[float] = []
 
 class BatchTransactionInput(BaseModel):
     """Modèle pour le traitement en lot de transactions."""
@@ -66,7 +68,7 @@ class UserSyncResult(BaseModel):
     status: str = "success"
     error_details: List[str] = []
 
-@dataclass 
+@dataclass
 class StructuredTransaction:
     """Transaction structurée pour l'indexation Elasticsearch."""
     # Identifiants
@@ -93,10 +95,12 @@ class StructuredTransaction:
     # Catégorisation
     category_id: Optional[int]
     operation_type: Optional[str]
-    
+
     # Métadonnées supplémentaires
     is_future: bool
     is_deleted: bool
+    balance_check_passed: Optional[bool] = None
+    quality_score: Optional[float] = None
     
     @classmethod
     def from_transaction_input(cls, tx: TransactionInput) -> 'StructuredTransaction':
@@ -127,7 +131,18 @@ class StructuredTransaction:
             searchable_parts.append(f"Catégorie: {tx.category_id}")
         
         searchable_text = " | ".join(searchable_parts)
-        
+        balance_check_passed = None
+        quality_score = None
+        if tx.account_balance is not None and tx.recent_transactions:
+            from .data_quality import DataQualityValidator
+
+            validator = DataQualityValidator()
+            result = validator.validate_account_balance_consistency(
+                tx.account_balance, tx.recent_transactions
+            )
+            balance_check_passed = result.get("balance_check_passed")
+            quality_score = result.get("quality_score")
+
         return cls(
             transaction_id=tx.bridge_transaction_id,
             user_id=tx.user_id,
@@ -145,46 +160,54 @@ class StructuredTransaction:
             category_id=tx.category_id,
             operation_type=tx.operation_type,
             is_future=tx.future,
-            is_deleted=tx.deleted
+            is_deleted=tx.deleted,
+            balance_check_passed=balance_check_passed,
+            quality_score=quality_score,
         )
     
     def to_elasticsearch_document(self) -> Dict[str, Any]:
         """Convertit en document Elasticsearch."""
-        return {
+        doc = {
             # Identifiants
             "transaction_id": self.transaction_id,
             "user_id": self.user_id,
             "account_id": self.account_id,
-            
+
             # Contenu recherchable
             "searchable_text": self.searchable_text,
             "primary_description": self.primary_description,
-            
+
             # Données financières
             "amount": self.amount,
             "amount_abs": self.amount_abs,
             "transaction_type": self.transaction_type,
             "currency_code": self.currency_code,
-            
+
             # Dates (optimisées pour les requêtes Elasticsearch)
             "date": self.date.isoformat(),
             "date_str": self.date_str,
             "month_year": self.month_year,
             "weekday": self.weekday,
             "timestamp": self.date.timestamp(),
-            
+
             # Catégorisation
             "category_id": self.category_id,
             "operation_type": self.operation_type,
-            
+
             # Flags
             "is_future": self.is_future,
             "is_deleted": self.is_deleted,
-            
+
             # Métadonnées d'indexation
             "indexed_at": datetime.now().isoformat(),
-            "version": "2.0-elasticsearch"
+            "version": "2.0-elasticsearch",
         }
+
+        if self.balance_check_passed is not None:
+            doc["balance_check_passed"] = self.balance_check_passed
+        if self.quality_score is not None:
+            doc["quality_score"] = self.quality_score
+        return doc
     
     def get_document_id(self) -> str:
         """Génère l'ID du document Elasticsearch."""

--- a/search_service/models/request.py
+++ b/search_service/models/request.py
@@ -65,6 +65,10 @@ class SearchRequest(BaseModel):
         """Alias historique pour ``page_size``."""
         return self.page_size
 
+    @limit.setter
+    def limit(self, value: int) -> None:
+        self.page_size = value
+
     @field_validator('query')
     @classmethod
     def validate_query(cls, v: str) -> str:

--- a/tests/test_data_quality_validator.py
+++ b/tests/test_data_quality_validator.py
@@ -1,0 +1,37 @@
+import logging
+from datetime import datetime
+
+from enrichment_service.data_quality import DataQualityValidator
+from enrichment_service.models import TransactionInput, StructuredTransaction
+
+
+def test_validate_account_balance_consistency_pass():
+    validator = DataQualityValidator(threshold=1.0)
+    result = validator.validate_account_balance_consistency(100.0, [50.0, 30.0, 20.0])
+    assert result["balance_check_passed"] is True
+    assert result["quality_score"] == 1.0
+
+
+def test_validate_account_balance_consistency_fail(caplog):
+    validator = DataQualityValidator(threshold=1.0)
+    with caplog.at_level(logging.WARNING):
+        result = validator.validate_account_balance_consistency(90.0, [50.0, 30.0, 20.0])
+        assert result["balance_check_passed"] is False
+        assert result["quality_score"] < 1.0
+        assert "Balance inconsistency detected" in caplog.text
+
+
+def test_structured_transaction_includes_quality_fields():
+    tx_input = TransactionInput(
+        bridge_transaction_id=1,
+        user_id=1,
+        account_id=1,
+        amount=50.0,
+        date=datetime(2024, 1, 1),
+        account_balance=100.0,
+        recent_transactions=[50.0, 30.0, 20.0],
+    )
+    structured = StructuredTransaction.from_transaction_input(tx_input)
+    doc = structured.to_elasticsearch_document()
+    assert doc["balance_check_passed"] is True
+    assert doc["quality_score"] == 1.0


### PR DESCRIPTION
## Summary
- add DataQualityValidator to compare account balances against recent transactions
- index balance check results in Elasticsearch documents
- cover balance mismatch scenarios with tests and search request limit alias fix

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaf9947e0883209fa0eebbdd4fa61b