### PR TITLE
feat: move cache utilities to enrichment service

### DIFF
--- a/enrichment_service/__init__.py
+++ b/enrichment_service/__init__.py
@@ -2,4 +2,9 @@
 
 __version__ = "2.0.0-elasticsearch"
 
-__all__ = ["__version__"]
+# Re-export frequently used utilities so they can be imported directly from
+# ``enrichment_service``.  This mirrors the old API where caches lived in a
+# top-level ``account_enrichment_service`` package.
+from .cache import AccountLRUCache, MerchantCategoryCache
+
+__all__ = ["__version__", "AccountLRUCache", "MerchantCategoryCache"]

--- a/enrichment_service/cache.py
+++ b/enrichment_service/cache.py
@@ -1,0 +1,49 @@
+from collections import OrderedDict
+from typing import Any, Dict, Optional
+
+class AccountLRUCache:
+    """Simple LRU cache for account information.
+
+    This implementation keeps the API intentionally tiny: ``get`` returns
+    a previously cached value or ``None`` and ``set`` stores a value while
+    enforcing a maximum size.  The behaviour is sufficient for the unit
+    tests which only require basic caching semantics.
+    """
+
+    def __init__(self, maxsize: int = 128) -> None:
+        self.maxsize = maxsize
+        self._store: "OrderedDict[int, Any]" = OrderedDict()
+
+    def get(self, key: int) -> Optional[Any]:
+        try:
+            value = self._store.pop(key)
+        except KeyError:
+            return None
+        self._store[key] = value  # move to end (most recent)
+        return value
+
+    def set(self, key: int, value: Any) -> None:
+        if key in self._store:
+            self._store.pop(key)
+        elif len(self._store) >= self.maxsize:
+            self._store.popitem(last=False)
+        self._store[key] = value
+
+    def clear(self) -> None:
+        self._store.clear()
+
+
+class MerchantCategoryCache:
+    """Very small in-memory cache mapping merchant names to categories."""
+
+    def __init__(self) -> None:
+        self._store: Dict[str, Any] = {}
+
+    def get(self, merchant: str) -> Optional[Any]:
+        return self._store.get(merchant)
+
+    def set(self, merchant: str, category: Any) -> None:
+        self._store[merchant] = category
+
+    def clear(self) -> None:
+        self._store.clear()


### PR DESCRIPTION
## Summary
- add `AccountLRUCache` and `MerchantCategoryCache` under `enrichment_service`
- expose cache classes from package root

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy'; SyntaxError: keyword argument repeated: account_name)*

------
https://chatgpt.com/codex/tasks/task_e_68ab055cc7108320ad4368b609dffbdb