### PR TITLE
refactor: streamline transaction account fields

### DIFF
--- a/enrichment_service/models.py
+++ b/enrichment_service/models.py
@@ -82,40 +82,35 @@ class StructuredTransaction:
     user_id: int
     account_id: int
 
-    # Informations de compte
-    account_name: Optional[str] = None
-    account_type: Optional[str] = None
-    account_balance: Optional[float] = None
-    account_currency_code: Optional[str] = None
-    
     # Contenu principal
     searchable_text: str
     primary_description: str
-    
+
     # Données financières
     amount: float
     amount_abs: float
     transaction_type: str  # "debit" ou "credit"
     currency_code: str
-    
+
     # Dates
     date: datetime
     date_str: str
     month_year: str
     weekday: str
-    
+
     # Catégorisation
     category_id: Optional[int]
     operation_type: Optional[str]
 
-    # Métadonnées supplémentaires
+    # Flags
     is_future: bool
     is_deleted: bool
+
+    # Résultats qualité et métadonnées
     balance_check_passed: Optional[bool] = None
     quality_score: Optional[float] = None
-    quality_score: float = 1.0
 
-    # Informations sur le compte
+    # Informations de compte
     account_name: Optional[str] = None
     account_type: Optional[str] = None
     account_balance: Optional[float] = None
@@ -171,10 +166,6 @@ class StructuredTransaction:
             transaction_id=tx.bridge_transaction_id,
             user_id=tx.user_id,
             account_id=tx.account_id,
-            account_name=None,
-            account_type=None,
-            account_balance=None,
-            account_currency_code=None,
             searchable_text=searchable_text,
             primary_description=primary_desc,
             amount=tx.amount,
@@ -196,7 +187,7 @@ class StructuredTransaction:
             account_balance=tx.account_balance,
             account_currency=tx.account_currency,
             account_last_sync=tx.account_last_sync,
-            category_name=tx.category_name
+            category_name=tx.category_name,
         )
     
     def to_elasticsearch_document(self) -> Dict[str, Any]:
@@ -210,7 +201,6 @@ class StructuredTransaction:
             "account_name": self.account_name,
             "account_type": self.account_type,
             "account_balance": self.account_balance,
-            "account_currency_code": self.account_currency_code,
             "account_currency": self.account_currency,
             "account_last_sync": self.account_last_sync.isoformat() if self.account_last_sync else None,
 
@@ -224,9 +214,6 @@ class StructuredTransaction:
             "transaction_type": self.transaction_type,
             "currency_code": self.currency_code,
 
-            "quality_score": self.quality_score,
-            
-
             # Dates (optimisées pour les requêtes Elasticsearch)
             "date": self.date.isoformat(),
             "date_str": self.date_str,
@@ -239,7 +226,6 @@ class StructuredTransaction:
             "operation_type": self.operation_type,
 
             "category_name": self.category_name,
-            
 
             # Flags
             "is_future": self.is_future,

--- a/enrichment_service/storage/elasticsearch_client.py
+++ b/enrichment_service/storage/elasticsearch_client.py
@@ -102,7 +102,7 @@ class ElasticsearchClient:
                     },
                     "account_type": {"type": "keyword"},
                     "account_balance": {"type": "float"},
-                    "account_currency_code": {"type": "keyword"},
+                    "account_currency": {"type": "keyword"},
 
                     # Contenu recherchable
                     "searchable_text": {
@@ -251,7 +251,7 @@ class ElasticsearchClient:
                 "account_name": getattr(structured_transaction, 'account_name', ''),
                 "account_type": getattr(structured_transaction, 'account_type', ''),
                 "account_balance": getattr(structured_transaction, 'account_balance', None),
-                "account_currency_code": getattr(structured_transaction, 'account_currency_code', ''),
+                "account_currency": getattr(structured_transaction, 'account_currency', ''),
 
                 # Contenu recherchable
                 "searchable_text": structured_transaction.searchable_text,
@@ -396,7 +396,7 @@ class ElasticsearchClient:
                 "account_name": getattr(tx, 'account_name', ''),
                 "account_type": getattr(tx, 'account_type', ''),
                 "account_balance": getattr(tx, 'account_balance', None),
-                "account_currency_code": getattr(tx, 'account_currency_code', ''),
+                "account_currency": getattr(tx, 'account_currency', ''),
                 "searchable_text": tx.searchable_text,
                 "primary_description": tx.primary_description,
                 "merchant_name": getattr(tx, 'merchant_name', ''),


### PR DESCRIPTION
## Summary
- de-duplicate account-related fields in StructuredTransaction and drop stray quality score
- align field names with `account_currency` and include `account_last_sync`
- update Elasticsearch mapping and writes for new account field

## Testing
- `pytest tests/test_structured_transaction.py tests/test_aggregation_optimization.py tests/test_aggregation_pagination.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab0887084c8320a7a2f9982ae10721