### PR TITLE
Fix TransactionInput defaults and test coverage

### DIFF
--- a/enrichment_service/models.py
+++ b/enrichment_service/models.py
@@ -7,7 +7,7 @@ et l'indexation des transactions financières dans Elasticsearch.
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict, Any, List, Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 # Modèles Pydantic pour l'API
 class TransactionInput(BaseModel):
@@ -33,8 +33,7 @@ class TransactionInput(BaseModel):
     operation_type: Optional[str] = None
     deleted: bool = False
     future: bool = False
-    account_balance: Optional[float] = None
-    recent_transactions: List[float] = []
+    recent_transactions: List[float] = Field(default_factory=list)
 
 class BatchTransactionInput(BaseModel):
     """Modèle pour le traitement en lot de transactions."""
@@ -82,12 +81,6 @@ class StructuredTransaction:
     user_id: int
     account_id: int
 
-    # Informations de compte
-    account_name: Optional[str] = None
-    account_type: Optional[str] = None
-    account_balance: Optional[float] = None
-    account_currency_code: Optional[str] = None
-    
     # Contenu principal
     searchable_text: str
     primary_description: str
@@ -113,13 +106,13 @@ class StructuredTransaction:
     is_deleted: bool
     balance_check_passed: Optional[bool] = None
     quality_score: Optional[float] = None
-    quality_score: float = 1.0
 
     # Informations sur le compte
     account_name: Optional[str] = None
     account_type: Optional[str] = None
     account_balance: Optional[float] = None
     account_currency: Optional[str] = None
+    account_currency_code: Optional[str] = None
     account_last_sync: Optional[datetime] = None
 
     # Information sur la catégorie
@@ -171,10 +164,6 @@ class StructuredTransaction:
             transaction_id=tx.bridge_transaction_id,
             user_id=tx.user_id,
             account_id=tx.account_id,
-            account_name=None,
-            account_type=None,
-            account_balance=None,
-            account_currency_code=None,
             searchable_text=searchable_text,
             primary_description=primary_desc,
             amount=tx.amount,

--- a/tests/test_account_enrichment.py
+++ b/tests/test_account_enrichment.py
@@ -30,6 +30,20 @@ class DummyAccountService:
         }
 
 
+def test_transaction_input_defaults():
+    tx = TransactionInput(
+        bridge_transaction_id=1,
+        user_id=1,
+        account_id=123,
+        amount=0.0,
+        date="2024-01-01T00:00:00",
+    )
+    assert tx.account_balance is None
+    assert tx.deleted is False
+    assert tx.future is False
+    assert tx.recent_transactions == []
+
+
 @pytest.mark.asyncio
 async def test_process_transaction_enriches_account_info():
     processor = ElasticsearchTransactionProcessor(DummyESClient(), DummyAccountService())


### PR DESCRIPTION
## Summary
- remove duplicate `account_balance` field from `TransactionInput`
- use `Field(default_factory=list)` for `recent_transactions`
- add unit test for `TransactionInput` default values
- trim broken tail of processor to fix import errors in tests

## Testing
- `pytest tests/test_account_enrichment.py::test_transaction_input_defaults -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab0889122c83208a868fc2ebab3c4a