### PR TITLE
standardize account currency field

### DIFF
--- a/enrichment_service/models.py
+++ b/enrichment_service/models.py
@@ -33,7 +33,6 @@ class TransactionInput(BaseModel):
     operation_type: Optional[str] = None
     deleted: bool = False
     future: bool = False
-    account_balance: Optional[float] = None
     recent_transactions: List[float] = []
 
 class BatchTransactionInput(BaseModel):
@@ -77,45 +76,37 @@ class UserSyncResult(BaseModel):
 @dataclass
 class StructuredTransaction:
     """Transaction structurée pour l'indexation Elasticsearch."""
+
     # Identifiants
     transaction_id: int
     user_id: int
     account_id: int
 
-    # Informations de compte
-    account_name: Optional[str] = None
-    account_type: Optional[str] = None
-    account_balance: Optional[float] = None
-    account_currency_code: Optional[str] = None
-    
     # Contenu principal
     searchable_text: str
     primary_description: str
-    
+
     # Données financières
     amount: float
     amount_abs: float
     transaction_type: str  # "debit" ou "credit"
     currency_code: str
-    
+
     # Dates
     date: datetime
     date_str: str
     month_year: str
     weekday: str
-    
+
     # Catégorisation
     category_id: Optional[int]
     operation_type: Optional[str]
 
-    # Métadonnées supplémentaires
+    # Flags
     is_future: bool
     is_deleted: bool
-    balance_check_passed: Optional[bool] = None
-    quality_score: Optional[float] = None
-    quality_score: float = 1.0
 
-    # Informations sur le compte
+    # Informations de compte
     account_name: Optional[str] = None
     account_type: Optional[str] = None
     account_balance: Optional[float] = None
@@ -125,36 +116,32 @@ class StructuredTransaction:
     # Information sur la catégorie
     category_name: Optional[str] = None
 
-    
+    # Métadonnées supplémentaires
+    balance_check_passed: Optional[bool] = None
+    quality_score: Optional[float] = None
+
     @classmethod
-    def from_transaction_input(cls, tx: TransactionInput) -> 'StructuredTransaction':
+    def from_transaction_input(cls, tx: TransactionInput) -> "StructuredTransaction":
         """Crée une StructuredTransaction à partir d'une TransactionInput."""
-        # Description principale
         primary_desc = tx.clean_description or tx.provider_description or "Transaction"
-        
-        # Type de transaction
         tx_type = "debit" if tx.amount < 0 else "credit"
-        
-        # Formatage des dates
-        date_str = tx.date.strftime('%Y-%m-%d')
-        month_year = tx.date.strftime('%Y-%m')
-        weekday = tx.date.strftime('%A')
-        
-        # Création du texte recherchable optimisé pour Elasticsearch
+
+        date_str = tx.date.strftime("%Y-%m-%d")
+        month_year = tx.date.strftime("%Y-%m")
+        weekday = tx.date.strftime("%A")
+
         searchable_parts = [
             f"Description: {primary_desc}",
             f"Montant: {abs(tx.amount):.2f} {tx.currency_code or 'EUR'}",
             f"Type: {tx_type}",
-            f"Date: {date_str}"
+            f"Date: {date_str}",
         ]
-        
         if tx.operation_type:
             searchable_parts.append(f"Opération: {tx.operation_type}")
-            
         if tx.category_id:
             searchable_parts.append(f"Catégorie: {tx.category_id}")
-        
         searchable_text = " | ".join(searchable_parts)
+
         balance_check_passed = None
         quality_score = None
         if tx.account_balance is not None and tx.recent_transactions:
@@ -171,10 +158,6 @@ class StructuredTransaction:
             transaction_id=tx.bridge_transaction_id,
             user_id=tx.user_id,
             account_id=tx.account_id,
-            account_name=None,
-            account_type=None,
-            account_balance=None,
-            account_currency_code=None,
             searchable_text=searchable_text,
             primary_description=primary_desc,
             amount=tx.amount,
@@ -189,67 +172,46 @@ class StructuredTransaction:
             operation_type=tx.operation_type,
             is_future=tx.future,
             is_deleted=tx.deleted,
-            balance_check_passed=balance_check_passed,
-            quality_score=quality_score,
             account_name=tx.account_name,
             account_type=tx.account_type,
             account_balance=tx.account_balance,
             account_currency=tx.account_currency,
             account_last_sync=tx.account_last_sync,
-            category_name=tx.category_name
+            category_name=tx.category_name,
+            balance_check_passed=balance_check_passed,
+            quality_score=quality_score,
         )
-    
+
     def to_elasticsearch_document(self) -> Dict[str, Any]:
         """Convertit en document Elasticsearch."""
         doc = {
-            # Identifiants
             "transaction_id": self.transaction_id,
             "user_id": self.user_id,
             "account_id": self.account_id,
-
             "account_name": self.account_name,
             "account_type": self.account_type,
             "account_balance": self.account_balance,
-            "account_currency_code": self.account_currency_code,
             "account_currency": self.account_currency,
             "account_last_sync": self.account_last_sync.isoformat() if self.account_last_sync else None,
-
-            # Contenu recherchable
             "searchable_text": self.searchable_text,
             "primary_description": self.primary_description,
-
-            # Données financières
             "amount": self.amount,
             "amount_abs": self.amount_abs,
             "transaction_type": self.transaction_type,
             "currency_code": self.currency_code,
-
-            "quality_score": self.quality_score,
-            
-
-            # Dates (optimisées pour les requêtes Elasticsearch)
             "date": self.date.isoformat(),
             "date_str": self.date_str,
             "month_year": self.month_year,
             "weekday": self.weekday,
             "timestamp": self.date.timestamp(),
-
-            # Catégorisation
             "category_id": self.category_id,
             "operation_type": self.operation_type,
-
             "category_name": self.category_name,
-            
-
-            # Flags
             "is_future": self.is_future,
             "is_deleted": self.is_deleted,
-
-            # Métadonnées d'indexation
             "indexed_at": datetime.now().isoformat(),
             "version": "2.0-elasticsearch",
         }
-
         if self.balance_check_passed is not None:
             doc["balance_check_passed"] = self.balance_check_passed
         if self.quality_score is not None:

--- a/enrichment_service/storage/elasticsearch_client.py
+++ b/enrichment_service/storage/elasticsearch_client.py
@@ -82,7 +82,9 @@ class ElasticsearchClient:
         body = {
             "aliases": {
                 self.index_name: {"is_write_index": True}
-        
+            }
+        }
+
         # Créer l'index avec mapping optimisé
         mapping = {
             "mappings": {
@@ -102,7 +104,7 @@ class ElasticsearchClient:
                     },
                     "account_type": {"type": "keyword"},
                     "account_balance": {"type": "float"},
-                    "account_currency_code": {"type": "keyword"},
+                    "account_currency": {"type": "keyword"},
 
                     # Contenu recherchable
                     "searchable_text": {
@@ -251,7 +253,7 @@ class ElasticsearchClient:
                 "account_name": getattr(structured_transaction, 'account_name', ''),
                 "account_type": getattr(structured_transaction, 'account_type', ''),
                 "account_balance": getattr(structured_transaction, 'account_balance', None),
-                "account_currency_code": getattr(structured_transaction, 'account_currency_code', ''),
+                "account_currency": getattr(structured_transaction, 'account_currency', ''),
 
                 # Contenu recherchable
                 "searchable_text": structured_transaction.searchable_text,
@@ -396,7 +398,7 @@ class ElasticsearchClient:
                 "account_name": getattr(tx, 'account_name', ''),
                 "account_type": getattr(tx, 'account_type', ''),
                 "account_balance": getattr(tx, 'account_balance', None),
-                "account_currency_code": getattr(tx, 'account_currency_code', ''),
+                "account_currency": getattr(tx, 'account_currency', ''),
                 "searchable_text": tx.searchable_text,
                 "primary_description": tx.primary_description,
                 "merchant_name": getattr(tx, 'merchant_name', ''),


### PR DESCRIPTION
## Summary
- remove legacy `account_currency_code` and standardize on `account_currency`
- update transaction models and Elasticsearch client to use the standardized field

## Testing
- `pytest` *(fails: IndentationError in enrichment_service/core/processor.py)*
- `pytest tests/test_structured_transaction.py tests/test_aggregation_pagination.py tests/test_aggregation_optimization.py` *(partial: 1 async test failed due to missing plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68ab088c79288320b8df1f04bb8470bd