### PR TITLE
Rename DataQualityValidator threshold parameter with compatibility alias

### DIFF
--- a/enrichment_service/core/data_quality_validator.py
+++ b/enrichment_service/core/data_quality_validator.py
@@ -5,8 +5,10 @@ from enrichment_service.models import TransactionInput
 class DataQualityValidator:
     """Basic validator to detect transaction anomalies."""
 
-    def __init__(self, amount_threshold: float = 1_000_000):
-        self.amount_threshold = amount_threshold
+    def __init__(self, threshold: float = 1_000_000, **kwargs):
+        if "amount_threshold" in kwargs:
+            threshold = kwargs["amount_threshold"]
+        self.threshold = threshold
 
     def validate_transaction_consistency(self, tx: TransactionInput) -> bool:
         """Check mandatory fields of a transaction."""
@@ -22,7 +24,7 @@ class DataQualityValidator:
 
     def detect_amount_anomalies(self, tx: TransactionInput) -> bool:
         """Return True if amount is outside accepted range."""
-        return abs(tx.amount) > self.amount_threshold or tx.amount == 0
+        return abs(tx.amount) > self.threshold or tx.amount == 0
 
     def validate_account_balance_consistency(
         self, tx: TransactionInput, account_balance: Optional[float] = None

--- a/tests/test_data_quality_validator.py
+++ b/tests/test_data_quality_validator.py
@@ -36,7 +36,9 @@ def test_structured_transaction_includes_quality_fields():
     assert doc["balance_check_passed"] is True
     assert doc["quality_score"] == 1.0
 from datetime import datetime
-from enrichment_service.core.data_quality_validator import DataQualityValidator
+from enrichment_service.core.data_quality_validator import (
+    DataQualityValidator as CoreDataQualityValidator,
+)
 from enrichment_service.models import TransactionInput
 
 
@@ -54,7 +56,7 @@ def make_tx(**kwargs):
 
 
 def test_detect_amount_anomaly():
-    validator = DataQualityValidator(amount_threshold=1000)
+    validator = CoreDataQualityValidator(amount_threshold=1000)
     tx = make_tx(amount=5000)
     assert validator.detect_amount_anomalies(tx)
     is_valid, score, flags = validator.evaluate(tx)
@@ -64,7 +66,7 @@ def test_detect_amount_anomaly():
 
 
 def test_missing_currency_code_inconsistency():
-    validator = DataQualityValidator()
+    validator = CoreDataQualityValidator()
     tx = make_tx(currency_code=None)
     assert not validator.validate_transaction_consistency(tx)
     is_valid, score, flags = validator.evaluate(tx)
@@ -73,7 +75,7 @@ def test_missing_currency_code_inconsistency():
 
 
 def test_account_balance_inconsistency():
-    validator = DataQualityValidator()
+    validator = CoreDataQualityValidator()
     tx = make_tx(amount=-150)
     assert not validator.validate_account_balance_consistency(tx, account_balance=100)
     is_valid, score, flags = validator.evaluate(tx, account_balance=100)


### PR DESCRIPTION
## Summary
- rename `amount_threshold` constructor parameter to `threshold`
- allow legacy `amount_threshold` via kwargs for backward compatibility
- adjust tests to alias core `DataQualityValidator` to avoid import clashes

## Testing
- `pytest tests/test_data_quality_validator.py::test_validate_account_balance_consistency_pass tests/test_data_quality_validator.py::test_validate_account_balance_consistency_fail -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab0bc115b083208959ac66a4cc3fe3