### PR TITLE
Avoid mutable default in TransactionInput

### DIFF
--- a/enrichment_service/models.py
+++ b/enrichment_service/models.py
@@ -33,7 +33,6 @@ class TransactionInput(BaseModel):
     operation_type: Optional[str] = None
     deleted: bool = False
     future: bool = False
-    recent_transactions: List[float] = []
     recent_transactions: List[float] = Field(default_factory=list)
 
 


### PR DESCRIPTION
## Summary
- remove mutable list default for TransactionInput.recent_transactions to prevent shared state

## Testing
- `pytest tests/test_structured_transaction.py::test_structured_transaction_with_account_data -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab0bc2ec5483209527e84c7a17b9b0