### PR TITLE
Handle clusters without ILM support

### DIFF
--- a/tests/test_index_management.py
+++ b/tests/test_index_management.py
@@ -7,8 +7,9 @@ from enrichment_service.storage.index_management import (
 
 
 class MockResponse:
-    def __init__(self, status=200):
+    def __init__(self, status=200, text=""):
         self.status = status
+        self._text = text
 
     async def __aenter__(self):
         return self
@@ -17,7 +18,7 @@ class MockResponse:
         pass
 
     async def text(self):
-        return ""
+        return self._text
 
 
 class MockSession:
@@ -42,3 +43,27 @@ async def test_ensure_template_and_policy_calls_es():
         "http://es:9200/_index_template/harena_transactions_template",
         INDEX_TEMPLATE,
     )
+
+
+class FailingILMSession(MockSession):
+    def put(self, url, json):
+        self.calls.append((url, json))
+        if "_ilm" in url:
+            return MockResponse(status=400, text="ILM unsupported")
+        return MockResponse()
+
+
+@pytest.mark.asyncio
+async def test_ensure_template_and_policy_bypasses_ilm_on_error():
+    session = FailingILMSession()
+    await ensure_template_and_policy(session, "http://es:9200")
+
+    # ILM policy call attempted first
+    assert session.calls[0][0] == (
+        "http://es:9200/_ilm/policy/harena_transactions_policy"
+    )
+
+    # Template call should not contain ILM settings
+    settings = session.calls[1][1]["template"]["settings"]
+    assert "index.lifecycle.name" not in settings
+    assert "index.lifecycle.rollover_alias" not in settings


### PR DESCRIPTION
## Summary
- Allow the enrichment service to continue when the Elasticsearch cluster lacks ILM support by falling back to an index template without lifecycle settings.
- Add tests covering the ILM bypass logic.

## Testing
- `pytest tests/test_index_management.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab107e4ab083209ca60e0e5ade7eed