### PR TITLE
Add health check to enrichment processor and API

### DIFF
--- a/enrichment_service/models.py
+++ b/enrichment_service/models.py
@@ -243,5 +243,6 @@ class ElasticsearchHealthStatus(BaseModel):
     status: str
     timestamp: str
     elasticsearch: Dict[str, Any]
+    database: Optional[Dict[str, Any]] = None
     capabilities: Dict[str, bool]
     performance_metrics: Optional[Dict[str, Any]] = None

--- a/tests/test_processor_health.py
+++ b/tests/test_processor_health.py
@@ -1,0 +1,34 @@
+import pytest
+
+from enrichment_service.core.processor import ElasticsearchTransactionProcessor
+
+
+class HealthyESClient:
+    async def ping(self):
+        return True
+
+
+class FailingESClient:
+    async def ping(self):
+        return False
+
+
+class DummyAccountService:
+    pass
+
+
+@pytest.mark.asyncio
+async def test_health_check_healthy():
+    processor = ElasticsearchTransactionProcessor(HealthyESClient(), DummyAccountService())
+    status = await processor.health_check()
+    assert status["status"] == "healthy"
+    assert status["elasticsearch"]["available"] is True
+    assert status.get("database", {}).get("available") is True
+
+
+@pytest.mark.asyncio
+async def test_health_check_failing_es():
+    processor = ElasticsearchTransactionProcessor(FailingESClient(), DummyAccountService())
+    status = await processor.health_check()
+    assert status["status"] != "healthy"
+    assert status["elasticsearch"]["available"] is False


### PR DESCRIPTION
## Summary
- implement health check for Elasticsearch processor with optional DB ping
- expose health check in API with 503 on failure and extended schema
- add tests for processor health check scenarios

## Testing
- `pytest tests/test_processor_health.py -q`
- `pytest -q` *(fails: TransactionInput defaults and enrichment tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ab16fd755883208e96229bacd723b7