### PR TITLE
Remove deprecated Elasticsearch transaction endpoints

### DIFF
--- a/enrichment_service/main.py
+++ b/enrichment_service/main.py
@@ -97,8 +97,6 @@ async def lifespan(app: FastAPI):
     # 5. Affichage des endpoints disponibles
     logger.info("🌐 ENDPOINTS DISPONIBLES:")
     logger.info("   Elasticsearch Processing:")
-    logger.info("     POST /api/v1/enrichment/elasticsearch/process-transaction")
-    logger.info("     POST /api/v1/enrichment/elasticsearch/process-batch")
     logger.info("     POST /api/v1/enrichment/elasticsearch/sync-user/{user_id}")
     logger.info("     DELETE /api/v1/enrichment/elasticsearch/user-data/{user_id}")
     logger.info("   Monitoring & Diagnostics:")


### PR DESCRIPTION
## Summary
- drop unused `/elasticsearch/process-transaction` and `/elasticsearch/process-batch` routes
- prune corresponding endpoint logging

## Testing
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68ab170c4a7c8320963fe940489b5611