### PR TITLE
Prefetch account metadata for transaction sync

### DIFF
--- a/enrichment_service/api/routes.py
+++ b/enrichment_service/api/routes.py
@@ -22,7 +22,7 @@ from datetime import datetime
 from db_service.session import get_db
 from user_service.api.deps import get_current_active_user
 from db_service.models.user import User
-from db_service.models.sync import RawTransaction
+from db_service.models.sync import RawTransaction, SyncAccount
 
 from enrichment_service.models import (
     TransactionInput,
@@ -208,13 +208,24 @@ async def sync_user_transactions(
                 error_details=[]
             )
         
-        # Convertir en TransactionInput
+        # Précharger les informations de compte pour toutes les transactions
+        account_ids = {tx.account_id for tx in raw_transactions}
+        accounts = db.query(SyncAccount).filter(SyncAccount.id.in_(account_ids)).all()
+        accounts_map = {acc.id: acc for acc in accounts}
+
+        # Convertir en TransactionInput avec métadonnées de compte
         transaction_inputs = []
         for raw_tx in raw_transactions:
+            account = accounts_map.get(raw_tx.account_id)
             tx_input = TransactionInput(
                 bridge_transaction_id=raw_tx.bridge_transaction_id,
                 user_id=raw_tx.user_id,
                 account_id=raw_tx.account_id,
+                account_name=account.account_name if account else None,
+                account_type=account.account_type if account else None,
+                account_balance=account.balance if account else None,
+                account_currency=account.currency_code if account else None,
+                account_last_sync=account.last_sync_timestamp if account else None,
                 clean_description=raw_tx.clean_description,
                 provider_description=raw_tx.provider_description,
                 amount=raw_tx.amount,
@@ -226,7 +237,7 @@ async def sync_user_transactions(
                 category_id=raw_tx.category_id,
                 operation_type=raw_tx.operation_type,
                 deleted=raw_tx.deleted,
-                future=raw_tx.future
+                future=raw_tx.future,
             )
             transaction_inputs.append(tx_input)
         
@@ -236,7 +247,8 @@ async def sync_user_transactions(
         result = await processor.sync_user_transactions(
             user_id=user_id,
             transactions=transaction_inputs,
-            force_refresh=force_refresh
+            accounts_map=accounts_map,
+            force_refresh=force_refresh,
         )
         
         return result

--- a/enrichment_service/core/processor.py
+++ b/enrichment_service/core/processor.py
@@ -446,57 +446,59 @@ class ElasticsearchTransactionProcessor:
                 results=results,
                 errors=[f"Batch processing failed: {str(e)}"],
             )
-async def sync_user_transactions(
-        self, 
-        user_id: int, 
+    async def sync_user_transactions(
+        self,
+        user_id: int,
         transactions: List[TransactionInput],
-        force_refresh: bool = False
+        accounts_map: Optional[Dict[int, Any]] = None,
+        force_refresh: bool = False,
     ) -> UserSyncResult:
-        """
-        Synchronise toutes les transactions d'un utilisateur dans Elasticsearch.
-        
-        Args:
-            user_id: ID de l'utilisateur
-            transactions: Liste complète des transactions de l'utilisateur
-            force_refresh: Force la suppression et recréation de tous les documents
-            
-        Returns:
-            UserSyncResult: Résultat de la synchronisation
-        """
+        """Synchronise toutes les transactions d'un utilisateur dans Elasticsearch."""
+
         start_time = time.time()
-        logger.info(f"🔄 Synchronisation user {user_id}: {len(transactions)} transactions (force_refresh={force_refresh})")
-        
+        logger.info(
+            f"🔄 Synchronisation user {user_id}: {len(transactions)} transactions (force_refresh={force_refresh})"
+        )
+
         try:
+            # Injecter les métadonnées de compte si fournies
+            if accounts_map:
+                for tx in transactions:
+                    acc = accounts_map.get(tx.account_id)
+                    if acc:
+                        tx.account_name = getattr(acc, "account_name", None)
+                        tx.account_type = getattr(acc, "account_type", None)
+                        tx.account_balance = getattr(acc, "balance", None)
+                        tx.account_currency = getattr(acc, "currency_code", None)
+                        tx.account_last_sync = getattr(acc, "last_sync_timestamp", None)
+
             # 1. Optionnel: Nettoyer les données existantes si force_refresh
             if force_refresh:
                 logger.info(f"🧹 Nettoyage des données existantes pour user {user_id}")
-                
                 deleted_count = await self.elasticsearch_client.delete_user_transactions(user_id)
                 logger.info(f"🗑️ {deleted_count} documents supprimés pour user {user_id}")
-            
+
             # 2. Créer un batch input et traiter
-            batch_input = BatchTransactionInput(
-                user_id=user_id,
-                transactions=transactions
-            )
-            
+            batch_input = BatchTransactionInput(user_id=user_id, transactions=transactions)
+
             batch_result = await self.process_transactions_batch(
-                batch_input, 
-                force_update=force_refresh
+                batch_input, force_update=force_refresh
             )
-            
+
             # 3. Convertir le résultat batch en résultat de sync utilisateur
             processing_time = time.time() - start_time
-            
-            # Compter les actions spécifiques
-            indexed_count = sum(1 for result in batch_result.results if result.status == "success" and result.indexed)
-            updated_count = sum(1 for result in batch_result.results 
-                              if result.status == "success" and result.metadata.get("action") == "updated")
+
+            indexed_count = sum(
+                1 for result in batch_result.results if result.status == "success" and result.indexed
+            )
+            updated_count = sum(
+                1
+                for result in batch_result.results
+                if result.status == "success" and result.metadata.get("action") == "updated"
+            )
             error_count = len(batch_result.errors)
-            
-            # Collecter les détails d'erreurs
             error_details = batch_result.errors.copy()
-            
+
             return UserSyncResult(
                 user_id=user_id,
                 total_transactions=len(transactions),
@@ -504,14 +506,18 @@ async def sync_user_transactions(
                 updated=updated_count,
                 errors=error_count,
                 processing_time=processing_time,
-                status="success" if error_count == 0 else "partial_success" if indexed_count > 0 else "failed",
-                error_details=error_details
+                status="success"
+                if error_count == 0
+                else "partial_success"
+                if indexed_count > 0
+                else "failed",
+                error_details=error_details,
             )
-            
+
         except Exception as e:
             processing_time = time.time() - start_time
             logger.error(f"💥 Erreur synchronisation user {user_id}: {e}")
-            
+
             return UserSyncResult(
                 user_id=user_id,
                 total_transactions=len(transactions),
@@ -520,6 +526,6 @@ async def sync_user_transactions(
                 errors=len(transactions),
                 processing_time=processing_time,
                 status="failed",
-                error_details=[f"Sync failed: {str(e)}"]
+                error_details=[f"Sync failed: {str(e)}"],
             )
     

--- a/enrichment_service/models.py
+++ b/enrichment_service/models.py
@@ -111,22 +111,15 @@ class StructuredTransaction:
     balance_check_passed: Optional[bool] = None
     quality_score: Optional[float] = None
 
-
     # Informations de compte
     account_name: Optional[str] = None
     account_type: Optional[str] = None
     account_balance: Optional[float] = None
-    account_currency_code: Optional[str] = None
     account_currency: Optional[str] = None
-    account_currency_code: Optional[str] = None
     account_last_sync: Optional[datetime] = None
 
     # Information sur la catégorie
     category_name: Optional[str] = None
-
-    # Métadonnées supplémentaires
-    balance_check_passed: Optional[bool] = None
-    quality_score: Optional[float] = None
 
     @classmethod
     def from_transaction_input(cls, tx: TransactionInput) -> "StructuredTransaction":

--- a/tests/enrichment/test_sync_user_api.py
+++ b/tests/enrichment/test_sync_user_api.py
@@ -1,0 +1,132 @@
+from datetime import datetime
+
+from fastapi import FastAPI
+from datetime import datetime
+import sys
+import types
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from db_service.base import Base
+from db_service.models.user import User
+from db_service.models.sync import SyncItem, SyncAccount, RawTransaction
+
+# Stub the user_service dependency to avoid heavy imports
+current_user = None
+deps_stub = types.ModuleType("user_service.api.deps")
+
+async def get_current_active_user():  # type: ignore
+    return current_user
+
+deps_stub.get_current_active_user = get_current_active_user
+sys.modules["user_service.api.deps"] = deps_stub
+
+from enrichment_service.api.routes import (
+    router,
+    get_db,
+    get_elasticsearch_processor,
+)
+from enrichment_service.core.account_enrichment_service import AccountEnrichmentService
+from enrichment_service.core.processor import ElasticsearchTransactionProcessor
+
+
+class DummyElasticsearchClient:
+    def __init__(self):
+        self.documents = []
+        self.default_batch_size = 500
+
+    async def delete_user_transactions(self, user_id: int) -> int:
+        self.documents = []
+        return 0
+
+    async def bulk_index_documents(self, docs, force_update: bool = False):
+        self.documents.extend(docs)
+        return {
+            "indexed": len(docs),
+            "errors": 0,
+            "responses": [{"success": True} for _ in docs],
+        }
+
+
+def create_app_and_db():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    db = Session()
+
+    user = User(id=1, email="test@example.com", password_hash="x")
+    item = SyncItem(id=1, user_id=1, bridge_item_id=1)
+    account = SyncAccount(
+        id=1,
+        item_id=1,
+        bridge_account_id=123,
+        account_name="Main Account",
+        account_type="checking",
+        balance=1000.0,
+        currency_code="EUR",
+        last_sync_timestamp=datetime(2024, 1, 2),
+    )
+    tx = RawTransaction(
+        id=1,
+        bridge_transaction_id=10,
+        account_id=1,
+        user_id=1,
+        clean_description="Coffee",
+        provider_description="Coffee shop",
+        amount=-3.5,
+        date=datetime(2024, 1, 3),
+        currency_code="EUR",
+    )
+    db.add_all([user, item, account, tx])
+    db.commit()
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1/enrichment")
+
+    def override_get_db():
+        try:
+            yield db
+        finally:
+            pass
+
+    es_client = DummyElasticsearchClient()
+    account_service = AccountEnrichmentService(db)
+    processor = ElasticsearchTransactionProcessor(es_client, account_service)
+
+    def override_processor():
+        return processor
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_elasticsearch_processor] = override_processor
+
+    global current_user
+    current_user = types.SimpleNamespace(id=1, is_superuser=True, is_active=True)
+
+    return app, es_client, db
+
+
+def test_sync_user_produces_account_metadata():
+    app, es_client, db = create_app_and_db()
+    client = TestClient(app)
+
+    response = client.post("/api/v1/enrichment/elasticsearch/sync-user/1")
+    assert response.status_code == 200
+    assert es_client.documents, "No documents indexed"
+
+    doc = es_client.documents[0]["document"]
+    assert doc["transaction_id"] == 10
+    assert doc["account_name"] == "Main Account"
+    assert doc["account_type"] == "checking"
+    assert doc["account_balance"] == 1000.0
+    assert doc["account_currency"] == "EUR"
+
+    db.close()
+


### PR DESCRIPTION
## Summary
- preload account metadata in /elasticsearch/sync-user and forward to processor
- enrich transactions with full account details for Elasticsearch indexing
- add integration test for user sync including account fields

## Testing
- `pytest tests/test_structured_transaction.py tests/test_account_enrichment.py tests/enrichment/test_sync_user_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab1712ef3483208fb8d32c76b42ff3