### PR TITLE
Fix account mapping for enrichment sync API

### DIFF
--- a/enrichment_service/api/routes.py
+++ b/enrichment_service/api/routes.py
@@ -127,14 +127,12 @@ async def sync_user_transactions(
         # Précharger les informations de compte pour toutes les transactions
         account_ids = {tx.account_id for tx in raw_transactions}
         accounts = db.query(SyncAccount).filter(SyncAccount.id.in_(account_ids)).all()
-        accounts_map = {
-            getattr(acc, "id", getattr(acc, "account_id")): acc for acc in accounts
-        }
+        accounts_map = {acc.id: acc for acc in accounts}
 
         # Convertir en TransactionInput avec métadonnées de compte
         transaction_inputs = []
         for raw_tx in raw_transactions:
-            account_key = getattr(raw_tx, "account_id", getattr(raw_tx, "id", None))
+            account_key = raw_tx.account_id
             account = accounts_map.get(account_key)
             tx_input = TransactionInput(
                 bridge_transaction_id=raw_tx.bridge_transaction_id,

--- a/tests/enrichment/test_sync_user_api.py
+++ b/tests/enrichment/test_sync_user_api.py
@@ -123,10 +123,12 @@ def test_sync_user_produces_account_metadata():
 
     doc = es_client.documents[0]["document"]
     assert doc["transaction_id"] == 10
+    assert doc["account_id"] == 1
     assert doc["account_name"] == "Main Account"
     assert doc["account_type"] == "checking"
     assert doc["account_balance"] == 1000.0
     assert doc["account_currency"] == "EUR"
+    assert doc["account_last_sync"] == datetime(2024, 1, 2).isoformat()
 
     db.close()
 


### PR DESCRIPTION
## Summary
- map enrichment accounts by primary key `id`
- ensure sync user test validates account metadata

## Testing
- `pytest tests/enrichment/test_sync_user_api.py::test_sync_user_produces_account_metadata -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab1f00c0588320bf47b8c7e09676c5