### PR TITLE
test: ensure single account in sync user endpoint

### DIFF
--- a/tests/test_api_sync_user.py
+++ b/tests/test_api_sync_user.py
@@ -34,6 +34,7 @@ def test_sync_user_endpoint_invokes_processor():
 
     account = SimpleNamespace(
         id=123,
+        account_id=123,
         account_name="Main",
         account_type="checking",
         balance=1000.0,
@@ -59,16 +60,6 @@ def test_sync_user_endpoint_invokes_processor():
         future=False,
     )
 
-    account = SimpleNamespace(
-        id=123,
-        account_id=123,
-        account_name="test",
-        account_type="checking",
-        balance=0.0,
-        currency_code="EUR",
-        last_sync_timestamp=datetime(2024, 1, 1),
-    )
-
     class DummyQuery:
         def __init__(self, results):
             self._results = results
@@ -80,15 +71,6 @@ def test_sync_user_endpoint_invokes_processor():
             return self._results
 
     class DummyDB:
-        def __init__(self, transactions, accounts):
-            self.transactions = transactions
-            self.accounts = accounts
-
-        def query(self, model):
-            if model is RawTransaction:
-                return DummyQuery(self.transactions)
-            if model is SyncAccount:
-                return DummyQuery(self.accounts)
         def __init__(self, tx_results, account_results):
             self.tx_results = tx_results
             self.account_results = account_results
@@ -98,7 +80,6 @@ def test_sync_user_endpoint_invokes_processor():
                 return DummyQuery(self.tx_results)
             if model is SyncAccount:
                 return DummyQuery(self.account_results)
-
             return DummyQuery([])
 
     dummy_db = DummyDB([raw_tx], [account])


### PR DESCRIPTION
## Summary
- simplify test by using single account object with expected name
- streamline DummyDB to return that account instance

## Testing
- `pytest tests/test_api_sync_user.py::test_sync_user_endpoint_invokes_processor -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab1f0c14348320b6fffde5361dbc27