### PR TITLE
Handle accounts without ID in enrichment routes

### DIFF
--- a/enrichment_service/api/routes.py
+++ b/enrichment_service/api/routes.py
@@ -127,13 +127,14 @@ async def sync_user_transactions(
         # Précharger les informations de compte pour toutes les transactions
         account_ids = {tx.account_id for tx in raw_transactions}
         accounts = db.query(SyncAccount).filter(SyncAccount.id.in_(account_ids)).all()
-        accounts_map = {acc.id: acc for acc in accounts}
+        accounts_map = {
+            getattr(acc, "id", getattr(acc, "account_id")): acc for acc in accounts
+        }
 
         # Convertir en TransactionInput avec métadonnées de compte
         transaction_inputs = []
         for raw_tx in raw_transactions:
-            account_key = raw_tx.account_id
-            account = accounts_map.get(account_key)
+            account = accounts_map.get(raw_tx.account_id)
             tx_input = TransactionInput(
                 bridge_transaction_id=raw_tx.bridge_transaction_id,
                 user_id=raw_tx.user_id,


### PR DESCRIPTION
## Summary
- map accounts using `id` or fallback `account_id`
- use `raw_tx.account_id` when retrieving account metadata

## Testing
- `pytest tests/test_api_sync_user.py::test_sync_user_with_account_without_id_returns_200 -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab22126c98832081f42bafcb38d148