### PR TITLE
Fix account mapping in enrichment service

### DIFF
--- a/enrichment_service/api/routes.py
+++ b/enrichment_service/api/routes.py
@@ -128,7 +128,8 @@ async def sync_user_transactions(
         account_ids = {tx.account_id for tx in raw_transactions}
         accounts = db.query(SyncAccount).filter(SyncAccount.id.in_(account_ids)).all()
         accounts_map = {
-            getattr(acc, "id", getattr(acc, "account_id")): acc for acc in accounts
+            (acc.id if hasattr(acc, "id") else acc.account_id): acc
+            for acc in accounts
         }
 
         # Convertir en TransactionInput avec métadonnées de compte


### PR DESCRIPTION
## Summary
- Safely map accounts by checking for `id` before `account_id` in enrichment API

## Testing
- `pytest tests/enrichment/test_sync_user_api.py::test_sync_user_produces_account_metadata -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab245340548320bc258183f0066172