### PR TITLE
feat: track synced accounts

### DIFF
--- a/enrichment_service/api/routes.py
+++ b/enrichment_service/api/routes.py
@@ -120,6 +120,7 @@ async def sync_user_transactions(
                 updated=0,
                 errors=0,
                 with_account_metadata=0,
+                accounts_synced=0,
                 processing_time=0.0,
                 status="success",
                 error_details=[]
@@ -162,7 +163,7 @@ async def sync_user_transactions(
             transaction_inputs.append(tx_input)
         
         logger.info(f"📊 Synchronisation de {len(transaction_inputs)} transactions pour l'utilisateur {user_id}")
-        
+
         # Synchroniser via le processeur Elasticsearch
         result = await processor.sync_user_transactions(
             user_id=user_id,
@@ -170,7 +171,16 @@ async def sync_user_transactions(
             accounts_map=accounts_map,
             force_refresh=force_refresh,
         )
-        
+        logger.info(
+            "📈 Résultat sync user %s: %s tx, %s indexées, %s mises à jour, %s erreurs, %s comptes",
+            user_id,
+            result.total_transactions,
+            result.indexed,
+            result.updated,
+            result.errors,
+            result.accounts_synced,
+        )
+
         return result
         
     except Exception as e:

--- a/enrichment_service/core/processor.py
+++ b/enrichment_service/core/processor.py
@@ -461,6 +461,7 @@ class ElasticsearchTransactionProcessor:
         )
 
         account_metadata_enriched = 0
+        accounts_synced = len({tx.account_id for tx in transactions})
 
         try:
             # Injecter les métadonnées de compte si fournies
@@ -513,6 +514,7 @@ class ElasticsearchTransactionProcessor:
                 updated=updated_count,
                 errors=error_count,
                 with_account_metadata=account_metadata_enriched,
+                accounts_synced=accounts_synced,
                 processing_time=processing_time,
                 status="success"
                 if error_count == 0
@@ -533,6 +535,7 @@ class ElasticsearchTransactionProcessor:
                 updated=0,
                 errors=len(transactions),
                 with_account_metadata=account_metadata_enriched,
+                accounts_synced=accounts_synced,
                 processing_time=processing_time,
                 status="failed",
                 error_details=[f"Sync failed: {str(e)}"],

--- a/enrichment_service/models.py
+++ b/enrichment_service/models.py
@@ -71,6 +71,7 @@ class UserSyncResult(BaseModel):
     updated: int
     errors: int
     with_account_metadata: int = 0
+    accounts_synced: int = 0
     processing_time: float
     status: str = "success"
     error_details: List[str] = []

--- a/tests/enrichment/test_sync_user_api.py
+++ b/tests/enrichment/test_sync_user_api.py
@@ -22,12 +22,13 @@ async def get_current_active_user():  # type: ignore
 
 deps_stub.get_current_active_user = get_current_active_user
 sys.modules["user_service.api.deps"] = deps_stub
+import importlib
+import enrichment_service.api.routes as routes
+importlib.reload(routes)
 
-from enrichment_service.api.routes import (
-    router,
-    get_db,
-    get_elasticsearch_processor,
-)
+router = routes.router
+get_db = routes.get_db
+get_elasticsearch_processor = routes.get_elasticsearch_processor
 from enrichment_service.core.account_enrichment_service import AccountEnrichmentService
 from enrichment_service.core.processor import ElasticsearchTransactionProcessor
 
@@ -117,6 +118,7 @@ def test_sync_user_produces_account_metadata(sample_es_account_response):
 
     response = client.post("/api/v1/enrichment/elasticsearch/sync-user/1")
     assert response.status_code == 200
+    assert response.json()["accounts_synced"] == 1
     assert es_client.documents, "No documents indexed"
 
     doc = es_client.documents[0]["document"]

--- a/tests/test_api_sync_user.py
+++ b/tests/test_api_sync_user.py
@@ -93,6 +93,7 @@ def test_sync_user_endpoint_invokes_processor():
             updated=0,
             errors=0,
             with_account_metadata=1,
+            accounts_synced=1,
             processing_time=0.0,
         )
     )
@@ -175,6 +176,7 @@ def test_sync_user_with_account_without_id_returns_200():
             updated=0,
             errors=0,
             with_account_metadata=1,
+            accounts_synced=1,
             processing_time=0.0,
         )
     )


### PR DESCRIPTION
## Summary
- record unique accounts synced in `UserSyncResult`
- expose `accounts_synced` via sync user API and logging
- add tests for new field

## Testing
- `pytest tests/test_api_sync_user.py tests/enrichment/test_sync_user_api.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab294ce6a08320af77cd81f5e57db5