### PR TITLE
fix user sync log count

### DIFF
--- a/enrichment_service/core/processor.py
+++ b/enrichment_service/core/processor.py
@@ -504,8 +504,6 @@ class ElasticsearchTransactionProcessor:
 
             # 4. Convertir le résultat batch en résultat de sync utilisateur
             processing_time = time.time() - start_time
-            indexed_count = sum(
-
             transactions_indexed = sum(
                 1 for result in batch_result.results if result.status == "success" and result.indexed
             )
@@ -517,7 +515,9 @@ class ElasticsearchTransactionProcessor:
             error_count = len(batch_result.errors)
             error_details = batch_result.errors.copy()
 
-            logger.info(f"{accounts_synced} accounts, {indexed_count} transactions indexed")
+            logger.info(
+                f"{accounts_synced} accounts, {transactions_indexed} transactions indexed"
+            )
 
             return UserSyncResult(
                 user_id=user_id,


### PR DESCRIPTION
## Summary
- fix log line in UserSyncResult to use transactions_indexed count

## Testing
- `pytest` *(fails: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68ab2c89ca4483209322a82bfdd1bbe9