### PR TITLE
Use transactions_indexed in enrichment sync responses

### DIFF
--- a/enrichment_service/api/routes.py
+++ b/enrichment_service/api/routes.py
@@ -116,7 +116,8 @@ async def sync_user_transactions(
             return UserSyncResult(
                 user_id=user_id,
                 total_transactions=0,
-                indexed=0,
+                transactions_indexed=0,
+                accounts_indexed=0,
                 updated=0,
                 errors=0,
                 with_account_metadata=0,
@@ -173,12 +174,14 @@ async def sync_user_transactions(
             force_refresh=force_refresh,
         )
 
-        logger.info(f"{result.accounts_synced} accounts, {result.indexed} transactions indexed")
+        logger.info(
+            f"{result.accounts_synced} accounts, {result.transactions_indexed} transactions indexed"
+        )
         logger.info(
             "📈 Résultat sync user %s: %s tx, %s indexées, %s mises à jour, %s erreurs, %s comptes",
             user_id,
             result.total_transactions,
-            result.indexed,
+            result.transactions_indexed,
             result.updated,
             result.errors,
             result.accounts_synced,

--- a/tests/test_api_sync_user.py
+++ b/tests/test_api_sync_user.py
@@ -114,6 +114,7 @@ def test_sync_user_endpoint_invokes_processor(caplog):
     assert len(kwargs["accounts"]) == 1
     assert response.json()["with_account_metadata"] == 1
     assert response.json()["accounts_synced"] == 1
+    assert response.json()["transactions_indexed"] == 1
     assert "1 accounts, 1 transactions indexed" in caplog.text
 
 
@@ -193,3 +194,4 @@ def test_sync_user_with_account_without_id_returns_200():
 
     response = client.post("/api/v1/enrichment/elasticsearch/sync-user/1")
     assert response.status_code == 200
+    assert response.json()["transactions_indexed"] == 1


### PR DESCRIPTION
## Summary
- Replace `result.indexed` with `result.transactions_indexed` in the sync user route
- Log and return transaction counts via `transactions_indexed`
- Update tests to assert `transactions_indexed` in responses

## Testing
- `pytest tests/enrichment/test_sync_user_api.py::test_sync_user_produces_account_metadata tests/test_api_sync_user.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab2df5600c8320acdbc5622b446e20