### PR TITLE
Add indexed alias for UserSyncResult

### DIFF
--- a/enrichment_service/api/routes.py
+++ b/enrichment_service/api/routes.py
@@ -173,12 +173,12 @@ async def sync_user_transactions(
             force_refresh=force_refresh,
         )
 
-        logger.info(f"{result.accounts_synced} accounts, {result.indexed} transactions indexed")
+        logger.info(f"{result.accounts_synced} accounts, {result.transactions_indexed} transactions indexed")
         logger.info(
             "📈 Résultat sync user %s: %s tx, %s indexées, %s mises à jour, %s erreurs, %s comptes",
             user_id,
             result.total_transactions,
-            result.indexed,
+            result.transactions_indexed,
             result.updated,
             result.errors,
             result.accounts_synced,

--- a/enrichment_service/models.py
+++ b/enrichment_service/models.py
@@ -77,6 +77,10 @@ class UserSyncResult(BaseModel):
     status: str = "success"
     error_details: List[str] = []
 
+    @property
+    def indexed(self) -> int:
+        return self.transactions_indexed
+
 @dataclass
 class StructuredTransaction:
     """Transaction structurée pour l'indexation Elasticsearch."""

--- a/tests/test_api_sync_user.py
+++ b/tests/test_api_sync_user.py
@@ -112,8 +112,14 @@ def test_sync_user_endpoint_invokes_processor(caplog):
     assert len(kwargs["transactions"]) == 1
     assert kwargs["accounts_map"][123].account_name == "Main"
     assert len(kwargs["accounts"]) == 1
-    assert response.json()["with_account_metadata"] == 1
-    assert response.json()["accounts_synced"] == 1
+    payload = response.json()
+    assert payload["with_account_metadata"] == 1
+    assert payload["accounts_synced"] == 1
+    assert payload["transactions_indexed"] == 1
+    # Property alias should mirror transactions_indexed
+    result_obj = processor_mock.sync_user_transactions.return_value
+    assert result_obj.transactions_indexed == 1
+    assert result_obj.indexed == 1
     assert "1 accounts, 1 transactions indexed" in caplog.text
 
 


### PR DESCRIPTION
## Summary
- provide `indexed` property alias for `UserSyncResult`
- switch internal sync routes to use `transactions_indexed`
- test alias behavior and transactions indexed field

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab2df6f28c83209696fc194ff2e488