### PR TITLE
Respect user-defined offset in search request

### DIFF
--- a/search_service/models/request.py
+++ b/search_service/models/request.py
@@ -56,8 +56,9 @@ class SearchRequest(BaseModel):
 
     @model_validator(mode="after")
     def _compute_offset(self) -> "SearchRequest":
-        """Calcule automatiquement l'offset à partir de la page."""
-        self.offset = (self.page - 1) * self.page_size
+        """Calcule l'offset à partir de la page si non fourni."""
+        if "offset" not in self.model_fields_set:
+            self.offset = (self.page - 1) * self.page_size
         return self
 
     @property


### PR DESCRIPTION
## Summary
- avoid recalculating `offset` when provided by user

## Testing
- `pytest` *(fails: tests/test_api_sync_user.py::test_sync_user_endpoint_invokes_processor)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4c352b5c83208da1d124f00645f9