### PR TITLE
feat: support additional filter types

### DIFF
--- a/tests/test_additional_filters.py
+++ b/tests/test_additional_filters.py
@@ -1,0 +1,21 @@
+import pytest
+from search_service.core.query_builder import QueryBuilder
+
+
+def test_additional_filters_exists_wildcard_prefix():
+    qb = QueryBuilder()
+    filters = {
+        "merchant_name": {"wildcard": "Ama*"},
+        "category_name": {"exists": True},
+        "account_name": {"prefix": "Main"},
+    }
+    result = qb._build_additional_filters(filters)
+    assert {"wildcard": {"merchant_name.keyword": {"value": "Ama*"}}} in result
+    assert {"exists": {"field": "category_name"}} in result
+    assert {"prefix": {"account_name.keyword": "Main"}} in result
+
+
+def test_unknown_filter_raises_error():
+    qb = QueryBuilder()
+    with pytest.raises(ValueError):
+        qb._build_additional_filters({"merchant_name": {"foo": "bar"}})


### PR DESCRIPTION
## Summary
- extend query builder to handle `exists`, `wildcard`, `prefix`, `regexp`, `term`, and `terms` filters with validation
- raise clear error on unsupported filter types
- test additional filter behaviour and error handling

## Testing
- `pytest tests/test_additional_filters.py -q`
- `pytest -q` *(fails: assert '1 accounts, 1 transactions indexed' in caplog.text)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4c5179388320866768c03e3d1c63