### PR TITLE
feat: handle numeric account balance queries

### DIFF
--- a/tests/test_account_balance_search.py
+++ b/tests/test_account_balance_search.py
@@ -1,0 +1,15 @@
+from search_service.core.query_builder import QueryBuilder
+from search_service.models.request import SearchRequest
+
+
+def test_search_fields_do_not_include_account_balance():
+    qb = QueryBuilder()
+    assert "account_balance" not in qb.search_fields
+
+
+def test_numeric_query_builds_account_balance_filter():
+    qb = QueryBuilder()
+    req = SearchRequest(user_id=1, query="123.45")
+    query = qb.build_query(req)
+    must_filters = query["query"]["bool"]["must"]
+    assert {"range": {"account_balance": {"gte": 123.45, "lte": 123.45}}} in must_filters


### PR DESCRIPTION
## Summary
- avoid searching account balances in text queries
- support numeric-only queries as account balance range filters
- cover account balance handling with new tests

## Testing
- `pytest -q`
- `pytest tests/test_account_balance_search.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab553aea7483208e6a442e57cd199a