### PR TITLE
Include aggregation data in search cache key

### DIFF
--- a/enrichment_service/api/routes.py
+++ b/enrichment_service/api/routes.py
@@ -176,7 +176,7 @@ async def sync_user_transactions(
 
         # ✅ LOG UNIQUE - Suppression des doublons
         logger.info(
-            f"📈 Sync user {user_id} completed: {result.transactions_indexed} transactions, {result.accounts_indexed} accounts indexed in {result.processing_time:.3f}s"
+            f"📈 Sync user {user_id} completed: {result.accounts_indexed} accounts, {result.transactions_indexed} transactions indexed in {result.processing_time:.3f}s"
         )
 
         return result

--- a/search_service/core/search_engine.py
+++ b/search_service/core/search_engine.py
@@ -77,6 +77,8 @@ class SearchEngine:
             "search",
             query=request.query,
             filters=json.dumps(request.filters, sort_keys=True),
+            aggregations=json.dumps(request.aggregations, sort_keys=True),
+            aggregation_only=request.aggregation_only,
             offset=request.offset,
             page_size=request.page_size,
         )

--- a/tests/test_cache_key.py
+++ b/tests/test_cache_key.py
@@ -1,0 +1,50 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from search_service.core.search_engine import SearchEngine
+from search_service.models.request import SearchRequest
+
+
+def test_cache_key_includes_aggregations_and_flag():
+    engine = SearchEngine()
+    base_req = SearchRequest(user_id=1, query="", filters={})
+    base_key = engine._generate_cache_key(base_req)
+
+    aggs_req = SearchRequest(
+        user_id=1,
+        query="",
+        filters={},
+        aggregations={"foo": {"terms": {"field": "bar"}}},
+    )
+    assert engine._generate_cache_key(aggs_req) != base_key
+
+    flag_req = SearchRequest(user_id=1, query="", filters={}, aggregation_only=True)
+    assert engine._generate_cache_key(flag_req) != base_key
+
+
+@pytest.mark.asyncio
+async def test_cache_get_set_use_generated_key():
+    engine = SearchEngine()
+    engine.elasticsearch_client = object()
+
+    req = SearchRequest(
+        user_id=1,
+        query="test",
+        filters={},
+        aggregations={"foo": {"terms": {"field": "bar"}}},
+    )
+
+    expected_key = engine._generate_cache_key(req)
+
+    engine.cache.get = AsyncMock(return_value=None)
+    engine.cache.set = AsyncMock()
+
+    es_resp = {"hits": {"hits": [], "total": {"value": 0}}, "aggregations": {}, "took": 1}
+    with patch.object(engine, "_execute_search", AsyncMock(return_value=es_resp)):
+        await engine.search(req)
+
+    engine.cache.get.assert_awaited_once()
+    engine.cache.set.assert_awaited_once()
+    assert engine.cache.get.await_args.args[1] == expected_key
+    assert engine.cache.set.await_args.args[1] == expected_key
+


### PR DESCRIPTION
## Summary
- include serialized aggregations and aggregation_only flag in search cache key
- adjust enrichment sync log message order
- add tests to ensure cache key accounts for aggregations and is used for cache operations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab5542dbcc8320ac19dc7940a254ea