### PR TITLE
Raise HTTP 502 on unsuccessful search

### DIFF
--- a/search_service/api/routes.py
+++ b/search_service/api/routes.py
@@ -74,6 +74,10 @@ async def search_transactions(
         # Recherche via moteur unifié
         results = await engine.search(request)
 
+        # Vérification du succès de la recherche
+        if not results["success"]:
+            raise HTTPException(status_code=502, detail=results["error_message"])
+
         # Log des résultats
         metadata = results.get("response_metadata", {})
         logger.info(


### PR DESCRIPTION
## Summary
- validate `SearchEngine` results in `/search` endpoint and raise `HTTPException` with 502 when `success` is false

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68ab554fa3c88320896c2f44f57155e1