### PR TITLE
Expose Elasticsearch _score in search results

### DIFF
--- a/search_service/core/search_engine.py
+++ b/search_service/core/search_engine.py
@@ -220,7 +220,7 @@ class SearchEngine:
             has_more_results = (request.offset + returned_results) < total_results
 
             response = {
-                "results": [r.model_dump() for r in results],
+                "results": [r.model_dump(by_alias=True) for r in results],
                 "aggregations": aggregations,
                 "success": True,
                 "error_message": None,

--- a/search_service/models/response.py
+++ b/search_service/models/response.py
@@ -31,12 +31,15 @@ class SearchResult(BaseModel):
     merchant_name: Optional[str] = Field(None, description="Nom du marchand")
     category_name: Optional[str] = Field(None, description="Catégorie")
     operation_type: Optional[str] = Field(None, description="Type d'opération")
-    
+
     # Métadonnées de recherche
-    score: Optional[float] = Field(None, description="Score de pertinence")
+    score: Optional[float] = Field(
+        None, description="Score de pertinence", alias="_score"
+    )
     highlights: Optional[Dict[str, List[str]]] = Field(None, description="Surlignade des termes")
 
     model_config = ConfigDict(
+        populate_by_name=True,
         json_schema_extra={
             "example": {
                 "transaction_id": "user_34_tx_12345",
@@ -57,7 +60,7 @@ class SearchResult(BaseModel):
                 "merchant_name": "Le Bistrot",
                 "category_name": "Restaurant",
                 "operation_type": "card_payment",
-                "score": 1.0,
+                "_score": 1.0,
                 "highlights": {"primary_description": ["bistrot"]}
             }
         }
@@ -111,7 +114,7 @@ class SearchResponse(BaseModel):
                         "merchant_name": "Le Bistrot",
                         "category_name": "Restaurant",
                         "operation_type": "card_payment",
-                        "score": 1.0,
+                        "_score": 1.0,
                         "highlights": {"primary_description": ["bistrot"]}
                     }
                 ],

--- a/tests/test_aggregation_optimization.py
+++ b/tests/test_aggregation_optimization.py
@@ -71,3 +71,5 @@ async def test_aggregation_only_returns_no_results_but_same_aggregations():
     assert first["account_type"] == "checking"
     assert first["account_balance"] == 1000.0
     assert first["account_currency"] == "EUR"
+    assert first["_score"] == 1.0
+    assert "score" not in first


### PR DESCRIPTION
## Summary
- map `SearchResult.score` to Elasticsearch `_score` via alias
- serialize search results using field aliases
- cover `_score` presence in search result tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab5a0467cc832094a3e320c67b6cea