### PR TITLE
feat(search): support highlight in requests and cache

### DIFF
--- a/search_service/core/query_builder.py
+++ b/search_service/core/query_builder.py
@@ -69,6 +69,9 @@ class QueryBuilder:
             "from": request.offset
         }
 
+        if request.highlight:
+            query["highlight"] = request.highlight
+
         logger.info(
             f"Pagination utilisée - page: {page}, page_size: {page_size}, offset: {offset}"
         )

--- a/search_service/core/search_engine.py
+++ b/search_service/core/search_engine.py
@@ -78,6 +78,7 @@ class SearchEngine:
             query=request.query,
             filters=json.dumps(request.filters, sort_keys=True),
             aggregations=json.dumps(request.aggregations, sort_keys=True),
+            highlight=json.dumps(request.highlight, sort_keys=True),
             aggregation_only=request.aggregation_only,
             offset=request.offset,
             page_size=request.page_size,

--- a/search_service/models/request.py
+++ b/search_service/models/request.py
@@ -41,6 +41,10 @@ class SearchRequest(BaseModel):
         default=None, description="Requête d'agrégation optionnelle"
     )
 
+    highlight: Optional[Dict[str, Any]] = Field(
+        default=None, description="Paramètres de surlignage optionnels"
+    )
+
     aggregation_only: bool = Field(
         default=False,
         description="Si vrai, seuls les résultats d'agrégations sont renvoyés",
@@ -117,6 +121,7 @@ class SearchRequest(BaseModel):
                 "aggregations": {
                     "by_category": {"terms": {"field": "category_name"}}
                 },
+                "highlight": {"fields": {"primary_description": {}}},
                 "aggregation_only": False
             }
         }

--- a/tests/test_cache_key.py
+++ b/tests/test_cache_key.py
@@ -21,6 +21,14 @@ def test_cache_key_includes_aggregations_and_flag():
     flag_req = SearchRequest(user_id=1, query="", filters={}, aggregation_only=True)
     assert engine._generate_cache_key(flag_req) != base_key
 
+    highlight_req = SearchRequest(
+        user_id=1,
+        query="",
+        filters={},
+        highlight={"fields": {"primary_description": {}}},
+    )
+    assert engine._generate_cache_key(highlight_req) != base_key
+
 
 @pytest.mark.asyncio
 async def test_cache_get_set_use_generated_key():


### PR DESCRIPTION
## Summary
- add optional highlight to search requests
- include highlight in built queries
- avoid cache collisions by keying on highlight

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab5a0685bc83208a3145c9dcc236de