### PR TITLE
Ensure _score alias present in serialized search results

### DIFF
--- a/search_service/core/search_engine.py
+++ b/search_service/core/search_engine.py
@@ -220,8 +220,15 @@ class SearchEngine:
             total_pages = math.ceil(total_results / page_size) if page_size else 0
             has_more_results = (request.offset + returned_results) < total_results
 
+            serialized_results = []
+            for r in results:
+                data = r.model_dump(by_alias=True)
+                if "_score" not in data and "score" in data:
+                    data["_score"] = data.pop("score")
+                serialized_results.append(data)
+
             response = {
-                "results": [r.model_dump(by_alias=True) for r in results],
+                "results": serialized_results,
                 "aggregations": aggregations,
                 "success": True,
                 "error_message": None,

--- a/tests/test_aggregation_pagination.py
+++ b/tests/test_aggregation_pagination.py
@@ -70,5 +70,7 @@ def test_pagination_with_aggregations_returns_all_hits():
         assert first["account_type"] == "checking"
         assert first["account_balance"] == 2001.0
         assert first["account_currency"] == "EUR"
+        assert first["_score"] == 1.0
+        assert "score" not in first
 
     asyncio.run(_run())

--- a/tests/test_search_account_metadata.py
+++ b/tests/test_search_account_metadata.py
@@ -55,5 +55,7 @@ def test_search_returns_account_metadata():
         assert result["account_type"] == "checking"
         assert result["account_balance"] == 1234.56
         assert result["account_currency"] == "EUR"
+        assert result["_score"] == 1.0
+        assert "score" not in result
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- guarantee each search result serializes via `model_dump(by_alias=True)` and expose `_score`
- add regression tests to confirm `_score` is returned instead of `score`

## Testing
- `pytest tests/test_aggregation_pagination.py tests/test_search_account_metadata.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab5d6a49d0832090620d0ef9b431c9