### PR TITLE
Ensure highlight parameter validated in search requests

### DIFF
--- a/search_service/models/request.py
+++ b/search_service/models/request.py
@@ -102,7 +102,20 @@ class SearchRequest(BaseModel):
             if field not in allowed_fields:
                 # On log un warning mais on ne bloque pas pour la flexibilité
                 pass
-        
+
+        return v
+
+    @field_validator('highlight')
+    @classmethod
+    def validate_highlight(cls, v: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        """Validation simple de la structure de surlignage"""
+        if v is None:
+            return None
+        if not isinstance(v, dict):
+            raise ValueError("highlight must be a dictionary")
+        fields = v.get('fields')
+        if not isinstance(fields, dict) or not fields:
+            raise ValueError("highlight must contain a non-empty 'fields' mapping")
         return v
     
     model_config = ConfigDict(


### PR DESCRIPTION
## Summary
- validate highlight structure in SearchRequest
- confirm query builder forwards highlight parameter
- include hit highlights in search results and cache key

## Testing
- `pytest tests/test_cache_key.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab5d7029208320bab52177003af472