### PR TITLE
test: ensure highlight fragments returned

### DIFF
--- a/tests/test_highlight_results.py
+++ b/tests/test_highlight_results.py
@@ -1,0 +1,50 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from search_service.core.search_engine import SearchEngine
+from search_service.models.request import SearchRequest
+
+
+def _make_hit() -> dict:
+    return {
+        "_source": {
+            "transaction_id": "tx_1",
+            "user_id": 1,
+            "amount": -5.0,
+            "amount_abs": 5.0,
+            "currency_code": "EUR",
+            "transaction_type": "debit",
+            "date": "2024-01-01",
+            "primary_description": "some restaurant",
+        },
+        "_score": 1.0,
+        "highlight": {"primary_description": ["some <em>restaurant</em>"]},
+    }
+
+
+@pytest.mark.asyncio
+async def test_search_returns_highlights():
+    engine = SearchEngine()
+    engine.elasticsearch_client = object()
+    engine.cache_enabled = False
+
+    req = SearchRequest(
+        user_id=1,
+        query="restaurant",
+        highlight={"fields": {"primary_description": {}}},
+    )
+
+    es_response = {
+        "hits": {"hits": [_make_hit()], "total": {"value": 1}},
+        "took": 1,
+    }
+
+    with patch.object(engine, "_execute_search", AsyncMock(return_value=es_response)) as mock_exec:
+        resp = await engine.search(req)
+
+    es_query = mock_exec.await_args.args[0]
+    assert es_query["highlight"] == req.highlight
+    assert resp["results"][0]["highlights"] == {
+        "primary_description": ["some <em>restaurant</em>"]
+    }


### PR DESCRIPTION
## Summary
- add test verifying highlight snippets are returned and included in ES query

## Testing
- `pytest tests/test_highlight_results.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy', No module named 'fastapi', No module named 'prometheus_client')*

------
https://chatgpt.com/codex/tasks/task_e_68ab671014048320af6e0cf66f9ecd11