### PR TITLE
Use 50% match for two-term queries and add integration test

### DIFF
--- a/search_service/core/query_builder.py
+++ b/search_service/core/query_builder.py
@@ -81,7 +81,7 @@ class QueryBuilder:
     def _build_text_query(self, query_text: str) -> Dict[str, Any]:
         """Construction de la requête textuelle optimisée"""
         terms_count = len(query_text.split())
-        minimum_should_match = "50%" if terms_count > 2 else "100%"
+        minimum_should_match = "50%" if terms_count >= 2 else "100%"
         return {
             "multi_match": {
                 "query": query_text,

--- a/tests/test_two_word_search.py
+++ b/tests/test_two_word_search.py
@@ -1,0 +1,46 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from search_service.core.search_engine import SearchEngine
+from search_service.models.request import SearchRequest
+
+
+def _make_hit() -> dict:
+    return {
+        "_source": {
+            "transaction_id": "tx_1",
+            "user_id": 1,
+            "amount": -5.0,
+            "amount_abs": 5.0,
+            "currency_code": "EUR",
+            "transaction_type": "debit",
+            "date": "2024-01-01",
+            "primary_description": "coffee shop purchase",
+        },
+        "_score": 1.0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_two_word_search_returns_results():
+    engine = SearchEngine()
+    engine.elasticsearch_client = object()
+    engine.cache_enabled = False
+
+    req = SearchRequest(user_id=1, query="coffee shop")
+
+    es_response = {
+        "hits": {"hits": [_make_hit()], "total": {"value": 1}},
+        "took": 1,
+    }
+
+    with patch.object(engine, "_execute_search", AsyncMock(return_value=es_response)) as mock_exec:
+        resp = await engine.search(req)
+
+    assert len(resp["results"]) >= 1
+    es_query = mock_exec.await_args.args[0]
+    assert (
+        es_query["query"]["bool"]["must"][1]["multi_match"]["minimum_should_match"]
+        == "50%"
+    )


### PR DESCRIPTION
## Summary
- Use `minimum_should_match` of 50% for queries containing at least two terms
- Add integration test validating two-word search returns results and uses 50% match

## Testing
- `pytest tests/test_two_word_search.py tests/test_highlight_results.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab6ad18cd083209495a5eae680a8cc