### PR TITLE
test: add field existence coverage

### DIFF
--- a/test_search_service.py
+++ b/test_search_service.py
@@ -120,17 +120,18 @@ class SearchServiceTester:
         """Vérifie si un champ existe dans la réponse (support notation pointée)."""
         keys = field_path.split('.')
         current = data
-        
+
         try:
             for key in keys:
                 if isinstance(current, dict):
                     current = current[key]
-                elif isinstance(current, list) and current:
-                    current = current[0][key]
+                elif isinstance(current, list):
+                    index = int(key)
+                    current = current[index]
                 else:
                     return False
             return current is not None
-        except (KeyError, TypeError, IndexError):
+        except (KeyError, TypeError, IndexError, ValueError):
             return False
 
     async def run_all_tests(self):

--- a/tests/test_field_exists.py
+++ b/tests/test_field_exists.py
@@ -1,0 +1,20 @@
+import pytest
+
+from test_search_service import SearchServiceTester
+
+
+def _mock_data():
+    return {"results": [{"_score": 1.0, "highlights": {}}]}
+
+
+def test_field_exists_returns_true_for_existing_fields():
+    tester = SearchServiceTester()
+    data = _mock_data()
+    assert tester._field_exists(data, "results.0._score")
+    assert tester._field_exists(data, "results.0.highlights")
+
+
+def test_field_exists_returns_false_for_out_of_range_index():
+    tester = SearchServiceTester()
+    data = _mock_data()
+    assert not tester._field_exists(data, "results.1._score")


### PR DESCRIPTION
## Summary
- fix nested field lookup to handle list indices
- add tests for `_field_exists` helper

## Testing
- `pytest tests/test_field_exists.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab8bb5a27483209d2c79e0cc64136d