### PR TITLE
Fix list indexing in SearchServiceTester._field_exists

### DIFF
--- a/test_search_service.py
+++ b/test_search_service.py
@@ -128,12 +128,9 @@ class SearchServiceTester:
                     key = int(key) if key.isdigit() else key
                     current = current[key]
                 elif isinstance(current, list):
-                    index = int(key)
-                    current = current[index]
-                    # Gérer les indices de liste avec conversion en entier et contrôle des erreurs
                     try:
                         current = current[int(key)]
-                    except (ValueError, IndexError, TypeError):
+                    except (ValueError, IndexError):
                         return False
 
                 else:


### PR DESCRIPTION
## Summary
- Simplify list handling in `SearchServiceTester._field_exists`
- Ensure numeric keys are converted and indexed safely

## Testing
- `pytest tests/test_field_exists.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy' and others)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8e07273083208ae7ae357f65082f