### PR TITLE
fix: respect custom sort criteria

### DIFF
--- a/search_service/core/query_builder.py
+++ b/search_service/core/query_builder.py
@@ -88,8 +88,6 @@ class QueryBuilder:
             logger.critical(f"🔥 TRI PERSONNALISÉ UTILISÉ: {sort_criteria}")
         else:
             sort_criteria = self._build_sort_criteria(request)
-
-        sort_criteria = self._build_sort_criteria(request)
         query = {
             "query": {"bool": bool_query},
             "sort": sort_criteria,

--- a/tests/test_custom_sort.py
+++ b/tests/test_custom_sort.py
@@ -8,3 +8,21 @@ def test_custom_sort_is_used_in_query():
     req = SearchRequest(user_id=1, sort=custom_sort)
     query = qb.build_query(req)
     assert query["sort"] == custom_sort
+
+
+def test_custom_sort_skips_default_sort(monkeypatch):
+    qb = QueryBuilder()
+    custom_sort = [{"amount": {"order": "asc"}}]
+    called = False
+
+    def fake_build_sort(request):
+        nonlocal called
+        called = True
+        return []
+
+    monkeypatch.setattr(qb, "_build_sort_criteria", fake_build_sort)
+    req = SearchRequest(user_id=1, sort=custom_sort)
+    query = qb.build_query(req)
+
+    assert query["sort"] == custom_sort
+    assert called is False


### PR DESCRIPTION
## Summary
- avoid overriding provided sort criteria when building search queries
- ensure custom sort bypasses default sort logic
- test that QueryBuilder returns custom sort and skips default sort builder

## Testing
- `pytest tests/test_custom_sort.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab8e0023808320beb8da75d78740ce