### PR TITLE
feat: allow custom response formats in DeepSeek client

### DIFF
--- a/conversation_service/agents/financial/intent_classifier.py
+++ b/conversation_service/agents/financial/intent_classifier.py
@@ -83,7 +83,8 @@ class IntentClassifierAgent(BaseAgent):
                     {"role": "user", "content": prompt}
                 ],
                 max_tokens=300,
-                temperature=0.1
+                temperature=0.1,
+                response_format={"type": "json_object"}
             )
             
             # Parsing et validation réponse

--- a/conversation_service/clients/deepseek_client.py
+++ b/conversation_service/clients/deepseek_client.py
@@ -87,7 +87,8 @@ class DeepSeekClient:
         messages: List[Dict[str, str]],
         max_tokens: Optional[int] = None,
         temperature: Optional[float] = None,
-        model: Optional[str] = None
+        model: Optional[str] = None,
+        response_format: Dict[str, Any] | None = None
     ) -> Dict[str, Any]:
         """Appel API chat completion avec retry automatique"""
         
@@ -104,6 +105,9 @@ class DeepSeekClient:
             "temperature": temperature or self.temperature,
             "stream": False
         }
+
+        if response_format is not None:
+            payload["response_format"] = response_format
         
         # Retry avec backoff exponentiel
         max_retries = 3

--- a/tests/agents/test_intent_classifier.py
+++ b/tests/agents/test_intent_classifier.py
@@ -38,6 +38,7 @@ async def test_classify_intent_success() -> None:
 
     deepseek_client.chat_completion.assert_called_once()
     cache_manager.set_semantic_cache.assert_called_once()
+    assert deepseek_client.chat_completion.call_args.kwargs.get("response_format") == {"type": "json_object"}
 
 
 @pytest.mark.asyncio

--- a/tests/clients/test_deepseek_client.py
+++ b/tests/clients/test_deepseek_client.py
@@ -1,0 +1,52 @@
+import os
+import pytest
+from unittest.mock import AsyncMock
+
+# Ensure required env vars for config
+os.environ.setdefault("DEEPSEEK_API_KEY", "testkey")
+os.environ.setdefault("JWT_SECRET_KEY", "x" * 33)
+
+from conversation_service.clients.deepseek_client import DeepSeekClient
+
+
+class DummyResponse:
+    def __init__(self, status=200):
+        self.status = status
+        self.headers = {}
+
+    async def json(self):
+        return {}
+
+    async def text(self):
+        return ""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_includes_response_format():
+    client = DeepSeekClient()
+    client._initialized = True
+
+    captured = {}
+
+    class MockSession:
+        closed = False
+
+        def post(self, url, json):
+            captured["payload"] = json
+            return DummyResponse()
+
+    client._session = MockSession()
+
+    resp_format = {"type": "json_object"}
+    await client.chat_completion(
+        messages=[{"role": "user", "content": "Hello"}],
+        response_format=resp_format,
+    )
+
+    assert captured["payload"].get("response_format") == resp_format


### PR DESCRIPTION
## Summary
- allow passing `response_format` to DeepSeek `chat_completion`
- use JSON object response format in intent classifier
- test that DeepSeek client sends `response_format`

## Testing
- `pytest tests/clients/test_deepseek_client.py tests/agents/test_intent_classifier.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*


------
https://chatgpt.com/codex/tasks/task_e_68ada650b4b48320aae9f97d96d87e59