### PR TITLE
Add response_format checks and malformed JSON test

### DIFF
--- a/conversation_service/agents/financial/intent_classifier.py
+++ b/conversation_service/agents/financial/intent_classifier.py
@@ -83,7 +83,8 @@ class IntentClassifierAgent(BaseAgent):
                     {"role": "user", "content": prompt}
                 ],
                 max_tokens=300,
-                temperature=0.1
+                temperature=0.1,
+                response_format={"type": "json_object"}
             )
             
             # Parsing et validation réponse

--- a/tests/agents/test_intent_classifier.py
+++ b/tests/agents/test_intent_classifier.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, patch, ANY
 
 from conversation_service.agents.financial.intent_classifier import IntentClassifierAgent
 from conversation_service.prompts.harena_intents import HarenaIntentType
@@ -36,7 +36,12 @@ async def test_classify_intent_success() -> None:
     assert result.category == "ACCOUNT_BALANCE"
     assert result.is_supported is True
 
-    deepseek_client.chat_completion.assert_called_once()
+    deepseek_client.chat_completion.assert_called_once_with(
+        messages=ANY,
+        max_tokens=300,
+        temperature=0.1,
+        response_format={"type": "json_object"},
+    )
     cache_manager.set_semantic_cache.assert_called_once()
 
 
@@ -91,7 +96,42 @@ async def test_classify_intent_deepseek_error() -> None:
         result = await agent.classify_intent("balance")
 
     assert result.intent_type == HarenaIntentType.ERROR
-    deepseek_client.chat_completion.assert_called_once()
+    deepseek_client.chat_completion.assert_called_once_with(
+        messages=ANY,
+        max_tokens=300,
+        temperature=0.1,
+        response_format={"type": "json_object"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_classify_intent_malformed_json_error() -> None:
+    deepseek_client = AsyncMock()
+    deepseek_client.chat_completion = AsyncMock(return_value={
+        "choices": [
+            {"message": {"content": '{"intent": "BALANCE_INQUIRY",}'}}
+        ]
+    })
+
+    cache_manager = AsyncMock()
+    cache_manager.get_semantic_cache = AsyncMock(return_value=None)
+    cache_manager.set_semantic_cache = AsyncMock()
+
+    agent = IntentClassifierAgent(deepseek_client=deepseek_client, cache_manager=cache_manager)
+
+    with patch(
+        "conversation_service.utils.validation_utils.validate_intent_response",
+        AsyncMock(return_value=True),
+    ):
+        result = await agent.classify_intent("balance")
+
+    assert result.intent_type == HarenaIntentType.ERROR
+    deepseek_client.chat_completion.assert_called_once_with(
+        messages=ANY,
+        max_tokens=300,
+        temperature=0.1,
+        response_format={"type": "json_object"},
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Ensure DeepSeek chat completion requests specify `response_format={"type": "json_object"}` in intent classifier
- Validate mocked DeepSeek calls include the JSON response format and add malformed JSON error test

## Testing
- `pytest tests/agents/test_intent_classifier.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ada652d8e88320988c820999551839