### PR TITLE
Ensure DeepSeek uses JSON response format and add error test

### DIFF
--- a/conversation_service/agents/financial/intent_classifier.py
+++ b/conversation_service/agents/financial/intent_classifier.py
@@ -83,7 +83,8 @@ class IntentClassifierAgent(BaseAgent):
                     {"role": "user", "content": prompt}
                 ],
                 max_tokens=300,
-                temperature=0.1
+                temperature=0.1,
+                response_format={"type": "json_object"}
             )
             
             # Parsing et validation réponse

--- a/conversation_service/api/routes/conversation.py
+++ b/conversation_service/api/routes/conversation.py
@@ -12,6 +12,7 @@ from conversation_service.models.responses.conversation_responses import Convers
 from conversation_service.agents.financial.intent_classifier import IntentClassifierAgent
 from conversation_service.clients.deepseek_client import DeepSeekClient
 from conversation_service.core.cache_manager import CacheManager
+from conversation_service.prompts.harena_intents import HarenaIntentType
 from conversation_service.api.dependencies import (
     get_deepseek_client,
     get_cache_manager,
@@ -82,7 +83,10 @@ async def analyze_conversation(
             user_message=request_data.message,
             user_context=user_context
         )
-        
+
+        if classification_result.intent_type == HarenaIntentType.ERROR:
+            raise HTTPException(status_code=500, detail="Erreur classification intention")
+
         # Calcul temps traitement total
         processing_time_ms = int((time.time() - start_time) * 1000)
         

--- a/conversation_service/clients/deepseek_client.py
+++ b/conversation_service/clients/deepseek_client.py
@@ -87,10 +87,11 @@ class DeepSeekClient:
         messages: List[Dict[str, str]],
         max_tokens: Optional[int] = None,
         temperature: Optional[float] = None,
-        model: Optional[str] = None
+        model: Optional[str] = None,
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Appel API chat completion avec retry automatique"""
-        
+
         if not self._initialized:
             await self.initialize()
         
@@ -104,6 +105,9 @@ class DeepSeekClient:
             "temperature": temperature or self.temperature,
             "stream": False
         }
+
+        if response_format is not None:
+            payload["response_format"] = response_format
         
         # Retry avec backoff exponentiel
         max_retries = 3


### PR DESCRIPTION
## Summary
- record DeepSeek client call parameters and verify `response_format={"type": "json_object"}`
- add negative test for invalid JSON response and surface error from API
- pass `response_format` through DeepSeek client and raise on classification errors

## Testing
- `pytest tests/api/test_conversation_endpoint.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ada6541b288320a3e9fac5e440800b