### PR TITLE
Use global SECRET_KEY for JWT auth

### DIFF
--- a/config_service/config.py
+++ b/config_service/config.py
@@ -486,8 +486,7 @@ class GlobalSettings(BaseSettings):
     DEEPSEEK_TEMPERATURE: float = float(os.environ.get("DEEPSEEK_TEMPERATURE", "0.1"))
     DEEPSEEK_TIMEOUT: int = int(os.environ.get("DEEPSEEK_TIMEOUT", "30"))
 
-    # Configuration Authentification JWT
-    JWT_SECRET_KEY: str = os.environ.get("JWT_SECRET_KEY", "")
+    # Configuration Authentification JWT (utilise SECRET_KEY global)
     JWT_ALGORITHM: str = os.environ.get("JWT_ALGORITHM", "HS256")
     JWT_ACCESS_TOKEN_EXPIRE_MINUTES: int = int(os.environ.get("JWT_ACCESS_TOKEN_EXPIRE_MINUTES", str(60 * 24)))
 
@@ -559,15 +558,6 @@ class GlobalSettings(BaseSettings):
     def validate_deepseek_key(cls, v, info):
         if not v and info.data.get('CONVERSATION_SERVICE_ENABLED'):
             raise ValueError("DEEPSEEK_API_KEY est requis si CONVERSATION_SERVICE_ENABLED=True")
-        return v
-
-    @field_validator('JWT_SECRET_KEY')
-    @classmethod
-    def validate_jwt_secret(cls, v):
-        if not v:
-            raise ValueError("JWT_SECRET_KEY est requis pour l'authentification")
-        if len(v) < 32:
-            raise ValueError("JWT_SECRET_KEY doit faire au moins 32 caractères")
         return v
 
     @field_validator("SQLALCHEMY_DATABASE_URI", mode="before")

--- a/conversation_service/api/middleware/auth_middleware.py
+++ b/conversation_service/api/middleware/auth_middleware.py
@@ -54,7 +54,7 @@ class JWTValidator:
     
     def __init__(self):
         self.algorithm = getattr(settings, 'JWT_ALGORITHM', 'HS256')
-        self.secret_key = settings.JWT_SECRET_KEY
+        self.secret_key = settings.SECRET_KEY
         self.token_cache: Dict[str, Dict[str, Any]] = {}
         self.cache_ttl = 300  # 5 minutes
         self.blacklisted_tokens: Set[str] = set()

--- a/conversation_service/main.py
+++ b/conversation_service/main.py
@@ -140,15 +140,15 @@ class ConversationServiceLoader:
                 if not api_key.startswith(('sk-', 'test-')):
                     validation_warnings.append("DEEPSEEK_API_KEY format inhabituel")
             
-            # JWT Secret
-            if not getattr(settings, 'JWT_SECRET_KEY', None):
-                validation_errors.append("JWT_SECRET_KEY manquant")
+            # Secret Key
+            if not getattr(settings, 'SECRET_KEY', None):
+                validation_errors.append("SECRET_KEY manquant")
             else:
-                jwt_secret = settings.JWT_SECRET_KEY
-                if len(jwt_secret) < 32:
-                    validation_errors.append("JWT_SECRET_KEY trop court (minimum 32 caractères)")
-                if jwt_secret in ['changeme', 'secret', 'test']:
-                    validation_errors.append("JWT_SECRET_KEY trop simple (sécurité faible)")
+                secret = settings.SECRET_KEY
+                if len(secret) < 32:
+                    validation_errors.append("SECRET_KEY trop court (minimum 32 caractères)")
+                if secret in ['changeme', 'secret', 'test']:
+                    validation_errors.append("SECRET_KEY trop simple (sécurité faible)")
             
             # Configuration DeepSeek
             deepseek_url = getattr(settings, 'DEEPSEEK_BASE_URL', 'https://api.deepseek.com')

--- a/tests/api/test_conversation_endpoint.py
+++ b/tests/api/test_conversation_endpoint.py
@@ -11,7 +11,7 @@ import json
 
 # Configuration environment pour tests
 os.environ["DEEPSEEK_API_KEY"] = "test-deepseek-key-12345"
-os.environ["JWT_SECRET_KEY"] = "super-secret-test-key-with-more-than-32-chars-123456789"
+os.environ["SECRET_KEY"] = "super-secret-test-key-with-more-than-32-chars-123456789"
 os.environ["CONVERSATION_SERVICE_ENABLED"] = "true"
 os.environ["ENVIRONMENT"] = "testing"
 
@@ -207,7 +207,7 @@ def generate_test_jwt(user_id: int = 1, expired: bool = False) -> str:
         "exp": int(time.time()) + (3600 if not expired else -3600)
     }
     
-    return jwt.encode(payload, os.environ["JWT_SECRET_KEY"], algorithm="HS256")
+    return jwt.encode(payload, os.environ["SECRET_KEY"], algorithm="HS256")
 
 
 class TestConversationEndpoint:

--- a/tests/clients/test_deepseek_client.py
+++ b/tests/clients/test_deepseek_client.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock
 
 # Ensure required env vars for config
 os.environ.setdefault("DEEPSEEK_API_KEY", "testkey")
-os.environ.setdefault("JWT_SECRET_KEY", "x" * 33)
+os.environ.setdefault("SECRET_KEY", "x" * 33)
 
 from conversation_service.clients.deepseek_client import DeepSeekClient
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from typing import Any
 from pathlib import Path
 
 # Configure les variables d'environnement nécessaires aux tests JWT
-os.environ.setdefault("JWT_SECRET_KEY", "0123456789abcdef0123456789abcdef")
+os.environ.setdefault("SECRET_KEY", "0123456789abcdef0123456789abcdef")
 os.environ.setdefault("JWT_ALGORITHM", "HS256")
 
 # Ensure local autogen_agentchat stub is importable when the real package is missing


### PR DESCRIPTION
## Summary
- switch JWT middleware to `settings.SECRET_KEY`
- validate `SECRET_KEY` in conversation service startup
- drop `JWT_SECRET_KEY` from configuration and tests

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_68ade93d79f88320af88e9c82ad7b708