### PR TITLE
Use JWT sub claim for user authentication

### DIFF
--- a/conversation_service/api/middleware/auth_middleware.py
+++ b/conversation_service/api/middleware/auth_middleware.py
@@ -115,7 +115,7 @@ class JWTValidator:
                     "verify_exp": True,
                     "verify_iat": True,
                     "verify_aud": False,  # Pas d'audience pour Phase 1
-                    "require": ["exp", "iat", "user_id"]
+                    "require": ["exp", "sub"]
                 }
             )
             
@@ -129,7 +129,8 @@ class JWTValidator:
                     processing_time_ms=(time.time() - start_time) * 1000
                 )
             
-            user_id = int(payload["user_id"])
+            raw_user_id = payload.get("sub") or payload.get("user_id")
+            user_id = int(raw_user_id)
             
             # Vérifications de sécurité supplémentaires
             security_check = self._perform_security_checks(payload, token)
@@ -232,16 +233,16 @@ class JWTValidator:
     
     def _validate_payload(self, payload: Dict[str, Any]) -> Optional[str]:
         """Validation contenu payload JWT"""
-        # Vérification user_id
-        if "user_id" not in payload:
-            return "user_id manquant dans le token"
-        
+        # Vérification identifiant utilisateur (claim sub)
+        if "sub" not in payload:
+            return "sub manquant dans le token"
+
         try:
-            user_id = int(payload["user_id"])
+            user_id = int(payload["sub"])
             if user_id <= 0:
-                return "user_id invalide (doit être > 0)"
+                return "sub invalide (doit être > 0)"
         except (ValueError, TypeError):
-            return "user_id doit être un entier valide"
+            return "sub doit être un entier valide"
         
         # Vérification timestamps
         current_time = time.time()
@@ -283,8 +284,12 @@ class JWTValidator:
             if key in payload and payload[key]:
                 logger.warning(f"Token avec clé suspecte: {key}")
         
-        # Vérification user_id raisonnable
-        user_id = payload.get("user_id", 0)
+        # Vérification identifiant utilisateur raisonnable
+        raw_user_id = payload.get("sub") or payload.get("user_id", 0)
+        try:
+            user_id = int(raw_user_id)
+        except (TypeError, ValueError):
+            user_id = 0
         if user_id > 1000000:  # Ajustable selon la base utilisateur
             logger.warning(f"User ID inhabituel: {user_id}")
         

--- a/tests/api/test_conversation_endpoint.py
+++ b/tests/api/test_conversation_endpoint.py
@@ -202,7 +202,7 @@ def generate_test_jwt(user_id: int = 1, expired: bool = False) -> str:
     import time
     
     payload = {
-        "user_id": user_id,
+        "sub": str(user_id),
         "iat": int(time.time()) - (3600 if expired else 0),
         "exp": int(time.time()) + (3600 if not expired else -3600)
     }


### PR DESCRIPTION
## Summary
- require `exp` and `sub` claims during JWT decoding and derive the user ID from `sub`
- validate `sub` claim and adjust security checks to use it
- update tests to generate JWTs with `sub`

## Testing
- `pytest tests/api/test_conversation_endpoint.py` *(fails: assert 503 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68ade950bb2c8320ae8c5f88939479b9