### PR TITLE
refactor: unify secret key env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ conversation_service/
     message_repository.py
 ```
 
+## Configuration
+
+Définissez la variable d'environnement `SECRET_KEY`, utilisée pour la
+signature et la vérification des jetons Bearer à travers tous les services.
+
 ## Tests unitaires
 
 Avant d'exécuter les tests, installez les dépendances Web de base :

--- a/config_service/config.py
+++ b/config_service/config.py
@@ -19,7 +19,6 @@ class GlobalSettings(BaseSettings):
     # ==========================================
     PROJECT_NAME: str = "Harena Finance Platform"
     API_V1_STR: str = "/api/v1"
-    SECRET_KEY: str = os.environ.get("SECRET_KEY", secrets.token_urlsafe(32))
     ACCESS_TOKEN_EXPIRE_MINUTES: int = int(os.environ.get("ACCESS_TOKEN_EXPIRE_MINUTES", 60 * 24 * 8))  # 8 jours par défaut
     ENVIRONMENT: str = os.environ.get("ENVIRONMENT", "production")
     
@@ -486,8 +485,8 @@ class GlobalSettings(BaseSettings):
     DEEPSEEK_TEMPERATURE: float = float(os.environ.get("DEEPSEEK_TEMPERATURE", "0.1"))
     DEEPSEEK_TIMEOUT: int = int(os.environ.get("DEEPSEEK_TIMEOUT", "30"))
 
-    # Configuration Authentification JWT
-    JWT_SECRET_KEY: str = os.environ.get("JWT_SECRET_KEY", "")
+    # Secret key powering bearer token verification across services
+    SECRET_KEY: str = os.environ.get("SECRET_KEY", "")
     JWT_ALGORITHM: str = os.environ.get("JWT_ALGORITHM", "HS256")
     JWT_ACCESS_TOKEN_EXPIRE_MINUTES: int = int(os.environ.get("JWT_ACCESS_TOKEN_EXPIRE_MINUTES", str(60 * 24)))
 
@@ -561,13 +560,13 @@ class GlobalSettings(BaseSettings):
             raise ValueError("DEEPSEEK_API_KEY est requis si CONVERSATION_SERVICE_ENABLED=True")
         return v
 
-    @field_validator('JWT_SECRET_KEY')
+    @field_validator('SECRET_KEY')
     @classmethod
-    def validate_jwt_secret(cls, v):
+    def validate_secret_key(cls, v):
         if not v:
-            raise ValueError("JWT_SECRET_KEY est requis pour l'authentification")
+            raise ValueError("SECRET_KEY est requis pour l'authentification")
         if len(v) < 32:
-            raise ValueError("JWT_SECRET_KEY doit faire au moins 32 caractères")
+            raise ValueError("SECRET_KEY doit faire au moins 32 caractères")
         return v
 
     @field_validator("SQLALCHEMY_DATABASE_URI", mode="before")
@@ -1095,8 +1094,8 @@ logger.info(f"Bridge API: {'✅ Configuré' if settings.BRIDGE_CLIENT_ID else '�
 
 # Avertissements de sécurité
 if settings.ENVIRONMENT == "production":
-    if settings.SECRET_KEY == secrets.token_urlsafe(32):
-        logger.warning("🔐 SECRET_KEY utilise une valeur par défaut - définir SECRET_KEY en production!")
+    if not settings.SECRET_KEY:
+        logger.warning("🔐 SECRET_KEY non défini - définir SECRET_KEY en production!")
     if not settings.OPENAI_API_KEY:
         logger.warning("🤖 OPENAI_API_KEY manquant - fonctionnalités IA désactivées")
     if not settings.DATABASE_URL:

--- a/conversation_service/api/middleware/auth_middleware.py
+++ b/conversation_service/api/middleware/auth_middleware.py
@@ -54,7 +54,7 @@ class JWTValidator:
     
     def __init__(self):
         self.algorithm = getattr(settings, 'JWT_ALGORITHM', 'HS256')
-        self.secret_key = settings.JWT_SECRET_KEY
+        self.secret_key = settings.SECRET_KEY  # Shared secret for bearer token verification
         self.token_cache: Dict[str, Dict[str, Any]] = {}
         self.cache_ttl = 300  # 5 minutes
         self.blacklisted_tokens: Set[str] = set()

--- a/conversation_service/main.py
+++ b/conversation_service/main.py
@@ -140,15 +140,15 @@ class ConversationServiceLoader:
                 if not api_key.startswith(('sk-', 'test-')):
                     validation_warnings.append("DEEPSEEK_API_KEY format inhabituel")
             
-            # JWT Secret
-            if not getattr(settings, 'JWT_SECRET_KEY', None):
-                validation_errors.append("JWT_SECRET_KEY manquant")
+            # Secret key used for bearer token verification across services
+            if not getattr(settings, 'SECRET_KEY', None):
+                validation_errors.append("SECRET_KEY manquant")
             else:
-                jwt_secret = settings.JWT_SECRET_KEY
+                jwt_secret = settings.SECRET_KEY
                 if len(jwt_secret) < 32:
-                    validation_errors.append("JWT_SECRET_KEY trop court (minimum 32 caractères)")
+                    validation_errors.append("SECRET_KEY trop court (minimum 32 caractères)")
                 if jwt_secret in ['changeme', 'secret', 'test']:
-                    validation_errors.append("JWT_SECRET_KEY trop simple (sécurité faible)")
+                    validation_errors.append("SECRET_KEY trop simple (sécurité faible)")
             
             # Configuration DeepSeek
             deepseek_url = getattr(settings, 'DEEPSEEK_BASE_URL', 'https://api.deepseek.com')

--- a/tests/api/test_conversation_endpoint.py
+++ b/tests/api/test_conversation_endpoint.py
@@ -11,7 +11,7 @@ import json
 
 # Configuration environment pour tests
 os.environ["DEEPSEEK_API_KEY"] = "test-deepseek-key-12345"
-os.environ["JWT_SECRET_KEY"] = "super-secret-test-key-with-more-than-32-chars-123456789"
+os.environ["SECRET_KEY"] = "super-secret-test-key-with-more-than-32-chars-123456789"
 os.environ["CONVERSATION_SERVICE_ENABLED"] = "true"
 os.environ["ENVIRONMENT"] = "testing"
 
@@ -207,7 +207,7 @@ def generate_test_jwt(user_id: int = 1, expired: bool = False) -> str:
         "exp": int(time.time()) + (3600 if not expired else -3600)
     }
     
-    return jwt.encode(payload, os.environ["JWT_SECRET_KEY"], algorithm="HS256")
+    return jwt.encode(payload, os.environ["SECRET_KEY"], algorithm="HS256")
 
 
 class TestConversationEndpoint:

--- a/tests/clients/test_deepseek_client.py
+++ b/tests/clients/test_deepseek_client.py
@@ -2,9 +2,9 @@ import os
 import pytest
 from unittest.mock import AsyncMock
 
-# Ensure required env vars for config
+# Ensure required env vars for config (SECRET_KEY powers bearer token verification)
 os.environ.setdefault("DEEPSEEK_API_KEY", "testkey")
-os.environ.setdefault("JWT_SECRET_KEY", "x" * 33)
+os.environ.setdefault("SECRET_KEY", "x" * 33)
 
 from conversation_service.clients.deepseek_client import DeepSeekClient
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,8 +12,8 @@ from collections import OrderedDict
 from typing import Any
 from pathlib import Path
 
-# Configure les variables d'environnement nécessaires aux tests JWT
-os.environ.setdefault("JWT_SECRET_KEY", "0123456789abcdef0123456789abcdef")
+# Configure les variables d'environnement nécessaires aux tests de vérification des jetons
+os.environ.setdefault("SECRET_KEY", "0123456789abcdef0123456789abcdef")
 os.environ.setdefault("JWT_ALGORITHM", "HS256")
 
 # Ensure local autogen_agentchat stub is importable when the real package is missing


### PR DESCRIPTION
## Summary
- replace JWT_SECRET_KEY with unified SECRET_KEY across services
- document SECRET_KEY as shared bearer token secret

## Testing
- `pytest` *(fails: tests/agents/test_intent_classifier.py: ModuleNotFoundError: No module named 'autogen_agentchat')*

------
https://chatgpt.com/codex/tasks/task_e_68ade96168208320b0fc2c6e4eb3fd40