### PR TITLE
Fix JWT generation in conversation endpoint tests

### DIFF
--- a/tests/api/test_conversation_endpoint.py
+++ b/tests/api/test_conversation_endpoint.py
@@ -4,7 +4,7 @@ Tests complets pour l'endpoint principal de conversation avec mocking avancé
 import os
 import sys
 import pytest
-import jwt
+from jose import jwt
 from unittest.mock import AsyncMock, patch, MagicMock
 from datetime import datetime, timezone
 import json
@@ -203,14 +203,10 @@ def generate_test_jwt(sub: int = 1, expired: bool = False) -> str:
 
     payload = {
         "sub": sub,
-        "exp": int(time.time()) + (3600 if not expired else -3600)
+        "iat": int(time.time()) - (3600 if expired else 0),
+        "exp": int(time.time()) + (3600 if not expired else -3600),
     }
 
-        "sub": str(user_id),
-        "iat": int(time.time()) - (3600 if expired else 0),
-        "exp": int(time.time()) + (3600 if not expired else -3600)
-    }
-    
     return jwt.encode(payload, os.environ["SECRET_KEY"], algorithm="HS256")
 
 


### PR DESCRIPTION
## Summary
- use jose JWT library in tests
- simplify test JWT payload to rely on `sub`, `iat`, and `exp`

## Testing
- `pytest tests/api/test_conversation_endpoint.py::TestConversationEndpoint::test_conversation_success_greeting -q` *(fails: assert 503 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68adf23e05f88320bc7e8629792017a3