### PR TITLE
Replace PyJWT with python-jose in auth middleware

### DIFF
--- a/tests/api/test_conversation_endpoint.py
+++ b/tests/api/test_conversation_endpoint.py
@@ -4,7 +4,7 @@ Tests complets pour l'endpoint principal de conversation avec mocking avancé
 import os
 import sys
 import pytest
-import jwt
+from jose import jwt
 from unittest.mock import AsyncMock, patch, MagicMock
 from datetime import datetime, timezone
 import json
@@ -203,14 +203,10 @@ def generate_test_jwt(sub: int = 1, expired: bool = False) -> str:
 
     payload = {
         "sub": sub,
-        "exp": int(time.time()) + (3600 if not expired else -3600)
-    }
-
-        "sub": str(user_id),
         "iat": int(time.time()) - (3600 if expired else 0),
         "exp": int(time.time()) + (3600 if not expired else -3600)
     }
-    
+
     return jwt.encode(payload, os.environ["SECRET_KEY"], algorithm="HS256")
 
 


### PR DESCRIPTION
## Summary
- refactor auth middleware to use `python-jose` instead of PyJWT and streamline JWT error handling
- remove duplicate `secret_key` assignment
- update conversation endpoint test helper to generate tokens with `python-jose`

## Testing
- `pytest` *(fails: ImportError: cannot import name 'computed_field' from 'pydantic'; ModuleNotFoundError: No module named 'fastapi'; ModuleNotFoundError: No module named 'sqlalchemy'; and other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68adf244437883208c9546460f97fede