### PR TITLE
Add JWT compatibility test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ Les tests peuvent ensuite être exécutés avec `pytest` :
 pytest
 ```
 
+### JWT compatibility check
+
+Verify that the token issued by the user service is accepted by the
+conversation service with:
+
+```bash
+python test_jwt_compatibility.py
+```
+
+The script prints `COMPATIBILITÉ TOTALE` when validation succeeds and exits with
+a non-zero status on failure.
+
 Pour lancer uniquement les tests du *conversation service* :
 
 ```bash

--- a/test_jwt_compatibility.py
+++ b/test_jwt_compatibility.py
@@ -1,0 +1,27 @@
+import os
+from sys import exit
+
+# Ensure required environment variables for settings
+os.environ.setdefault("SECRET_KEY", "a" * 32 + "b" * 32)
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("DEEPSEEK_API_KEY", "dummy")
+
+from user_service.core.security import create_access_token
+from conversation_service.api.middleware.auth_middleware import JWTValidator
+
+
+def main() -> int:
+    token = create_access_token(subject=1)
+    validator = JWTValidator()
+    result = validator.validate_token(token)
+    if result.success:
+        print("COMPATIBILITÉ TOTALE")
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    try:
+        exit(main())
+    except Exception:
+        exit(1)


### PR DESCRIPTION
## Summary
- add standalone test to check JWT generation/validation between user and conversation services
- document running `python test_jwt_compatibility.py`

## Testing
- `python test_jwt_compatibility.py`
- `SECRET_KEY=abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ REDIS_URL=redis://localhost:6379/0 DEEPSEEK_API_KEY=dummy OPENAI_API_KEY=dummy DATABASE_URL=sqlite:///tmp.db pytest -q` *(fails: ModuleNotFoundError: No module named 'redis')*

------
https://chatgpt.com/codex/tasks/task_e_68adf24a2ad48320b00ea5532b33eb7d