### PR TITLE
Handle IntentExample objects in intent classifier

### DIFF
--- a/conversation_service/agents/financial/intent_classifier.py
+++ b/conversation_service/agents/financial/intent_classifier.py
@@ -99,8 +99,13 @@ class IntentClassifierAgent(BaseAgent):
             await self._cache_classification_result(cache_key, classification_result)
             
             self._update_metrics("classification_success", start_time)
+            intent_display = (
+                classification_result.intent_type.value
+                if hasattr(classification_result.intent_type, "value")
+                else classification_result.intent_type
+            )
             logger.info(
-                f"Classification réussie: {classification_result.intent_type.value} "
+                f"Classification réussie: {intent_display} "
                 f"(conf: {classification_result.confidence:.2f}, temps: {processing_time}ms)"
             )
             
@@ -305,7 +310,7 @@ JSON:"""
         """Vérification dynamique si intention est supportée"""
         try:
             intent_enum = HarenaIntentType(intent_type)
-            unsupported = INTENT_CATEGORIES.get("UNSUPPORTED", [])
+            unsupported = INTENT_CATEGORIES.get("UNSUPPORTED", []) + [HarenaIntentType.UNCLEAR_INTENT]
             return intent_enum not in unsupported
         except ValueError:
             return False
@@ -392,7 +397,7 @@ JSON:"""
             intent_type=HarenaIntentType.UNKNOWN,
             confidence=0.95,
             reasoning=f"Message non interprétable: {reason}",
-            original_message="",
+            original_message=reason,
             category="UNCLEAR_INTENT",
             is_supported=False,
             alternatives=[],
@@ -403,10 +408,10 @@ JSON:"""
         """Résultat pour intention ambiguë"""
         return IntentClassificationResult(
             intent_type=HarenaIntentType.UNCLEAR_INTENT,
-            confidence=0.90,
+            confidence=0.50,
             reasoning=f"Message ambigu: {reason}",
-            original_message="",
-            category="UNCLEAR_INTENT", 
+            original_message=reason,
+            category="UNCLEAR_INTENT",
             is_supported=False,
             alternatives=[],
             processing_time_ms=0
@@ -418,7 +423,7 @@ JSON:"""
             intent_type=HarenaIntentType.ERROR,
             confidence=0.99,
             reasoning=f"Erreur technique: {error}",
-            original_message="",
+            original_message=error,
             category="UNCLEAR_INTENT",
             is_supported=False,
             alternatives=[],

--- a/conversation_service/prompts/few_shot_examples/intent_classification.py
+++ b/conversation_service/prompts/few_shot_examples/intent_classification.py
@@ -538,7 +538,7 @@ def get_few_shot_examples_by_intent(
 def get_balanced_few_shot_examples(
     examples_per_intent: int = 2,
     complexity_mix: bool = True
-) -> List[Dict[str, any]]:
+) -> List[IntentExample]:
     """
     Récupère des exemples équilibrés pour toutes les intentions
     """
@@ -549,15 +549,8 @@ def get_balanced_few_shot_examples(
         balance_intents=True
     )
     
-    # Conversion au format attendu
-    return [
-        {
-            'input': ex.input,
-            'intent': ex.intent,
-            'confidence': ex.confidence
-        }
-        for ex in selected_examples
-    ]
+    # Retourner directement les objets IntentExample pour conserver toutes les métadonnées
+    return selected_examples
 
 def get_contextual_examples(
     user_message: str,


### PR DESCRIPTION
## Summary
- Return `IntentExample` dataclasses from `get_balanced_few_shot_examples`
- Improve `IntentClassifierAgent` logging and result helpers, and treat `UNCLEAR_INTENT` as unsupported
- Update tests to use `IntentExample` instances and patch validation paths

## Testing
- `pytest tests/agents/test_intent_classifier.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae256c1474832098332b39115e8b03