### PR TITLE
test: override dependencies in conversation endpoint tests

### DIFF
--- a/tests/api/test_conversation_endpoint.py
+++ b/tests/api/test_conversation_endpoint.py
@@ -172,23 +172,48 @@ def mock_service_loader():
 def test_app(mock_service_loader):
     """App FastAPI de test configurée"""
     app = create_test_app()
-    
-    # Mock des dépendances
-    with patch("conversation_service.api.dependencies.get_deepseek_client") as mock_get_client, \
-         patch("conversation_service.api.dependencies.get_cache_manager") as mock_get_cache, \
-         patch("conversation_service.api.dependencies.get_conversation_service_status") as mock_get_status, \
-         patch("conversation_service.api.dependencies.validate_path_user_id") as mock_validate_user, \
-         patch("conversation_service.api.dependencies.get_user_context") as mock_get_context, \
-         patch("conversation_service.api.dependencies.rate_limit_dependency") as mock_rate_limit:
-        
-        mock_get_client.return_value = mock_service_loader.deepseek_client
-        mock_get_cache.return_value = mock_service_loader.cache_manager
-        mock_get_status.return_value = {"status": "healthy"}
-        mock_validate_user.return_value = 1
-        mock_get_context.return_value = {"sub": 1}
-        mock_rate_limit.return_value = None
-        
-        yield app
+
+    from conversation_service.api.dependencies import (
+        get_deepseek_client,
+        get_cache_manager,
+        get_conversation_service_status,
+        validate_path_user_id,
+        get_user_context,
+        rate_limit_dependency,
+    )
+
+    from fastapi import Request
+
+    def override_get_deepseek_client(request: Request):
+        return mock_service_loader.deepseek_client
+
+    def override_get_cache_manager(request: Request):
+        return mock_service_loader.cache_manager
+
+    def override_get_service_status(request: Request):
+        return {"status": "healthy"}
+
+    def override_validate_user(
+        request: Request, path_user_id: int, token_user_id: int = 1
+    ) -> int:
+        return 1
+
+    def override_get_user_context(request: Request, user_id: int = 1):
+        return {"sub": 1}
+
+    def override_rate_limit(request: Request, user_id: int = 1):
+        return None
+
+    app.dependency_overrides[get_deepseek_client] = override_get_deepseek_client
+    app.dependency_overrides[get_cache_manager] = override_get_cache_manager
+    app.dependency_overrides[get_conversation_service_status] = (
+        override_get_service_status
+    )
+    app.dependency_overrides[validate_path_user_id] = override_validate_user
+    app.dependency_overrides[get_user_context] = override_get_user_context
+    app.dependency_overrides[rate_limit_dependency] = override_rate_limit
+
+    yield app
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- switch conversation endpoint tests to use `app.dependency_overrides` instead of monkeypatching dependencies

## Testing
- `pytest tests/api/test_conversation_endpoint.py` (fails: assert 500 == 200, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68ae25703f348320b1c11af881e309ec