### PR TITLE
test: patch metrics collector in conversation tests

### DIFF
--- a/tests/api/test_conversation_endpoint.py
+++ b/tests/api/test_conversation_endpoint.py
@@ -599,7 +599,7 @@ class TestConversationHealthEndpoint:
     def test_conversation_health_success(self, client):
         """Test health check réussi"""
         
-        with patch("conversation_service.utils.metrics_collector.metrics_collector") as mock_metrics:
+        with patch("conversation_service.api.routes.conversation.metrics_collector") as mock_metrics:
             mock_metrics.get_health_metrics.return_value = {
                 "status": "healthy",
                 "total_requests": 100,
@@ -615,13 +615,13 @@ class TestConversationHealthEndpoint:
             
             assert data["service"] == "conversation_service"
             assert data["status"] == "healthy"
-            assert "metrics" in data
+            assert "health_details" in data
             assert "features" in data
 
     def test_conversation_health_error(self, client):
         """Test health check avec erreur"""
         
-        with patch("conversation_service.utils.metrics_collector.metrics_collector") as mock_metrics:
+        with patch("conversation_service.api.routes.conversation.metrics_collector") as mock_metrics:
             mock_metrics.get_health_metrics.side_effect = Exception("Metrics error")
             
             response = client.get("/api/v1/conversation/health")
@@ -639,7 +639,7 @@ class TestConversationMetricsEndpoint:
     def test_conversation_metrics_success(self, client):
         """Test récupération métriques réussie"""
         
-        with patch("conversation_service.utils.metrics_collector.metrics_collector") as mock_metrics:
+        with patch("conversation_service.api.routes.conversation.metrics_collector") as mock_metrics:
             mock_metrics.get_all_metrics.return_value = {
                 "timestamp": "2024-01-01T00:00:00Z",
                 "counters": {"conversation.requests.total": 100},
@@ -659,9 +659,10 @@ class TestConversationMetricsEndpoint:
     def test_conversation_metrics_error(self, client):
         """Test erreur récupération métriques"""
         
-        with patch("conversation_service.utils.metrics_collector.metrics_collector") as mock_metrics:
+        with patch("conversation_service.api.routes.conversation.metrics_collector") as mock_metrics:
             mock_metrics.get_all_metrics.side_effect = Exception("Metrics error")
-            
+
             response = client.get("/api/v1/conversation/metrics")
-            
+
             assert response.status_code == 500
+


### PR DESCRIPTION
## Summary
- patch conversation metrics collector path in health and metrics tests
- assert health endpoint includes health details

## Testing
- `pytest tests/api/test_conversation_endpoint.py::TestConversationHealthEndpoint::test_conversation_health_success -q`
- `pytest tests/api/test_conversation_endpoint.py::TestConversationHealthEndpoint::test_conversation_health_error -q`
- `pytest tests/api/test_conversation_endpoint.py::TestConversationMetricsEndpoint::test_conversation_metrics_success -q`
- `pytest tests/api/test_conversation_endpoint.py::TestConversationMetricsEndpoint::test_conversation_metrics_error -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae2576cef48320b1f34aa797e2b26c