### PR TITLE
Handle invalid filter values by re-raising errors

### DIFF
--- a/search_service/core/query_builder.py
+++ b/search_service/core/query_builder.py
@@ -195,6 +195,9 @@ class QueryBuilder:
                     field_name = self._get_filter_field_name(field)
                     filter_list.append({"term": {field_name: value}})
                     
+            except ValueError as e:
+                logger.error(f"Error processing filter {field}: {e}")
+                raise
             except Exception as e:
                 logger.error(f"Error processing filter {field}: {e}")
                 # Continue avec les autres filtres plutôt que de planter


### PR DESCRIPTION
## Summary
- raise `ValueError` from `_build_additional_filters` after logging
- continue processing filters only for non-critical exceptions

## Testing
- `pytest tests/test_additional_filters.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae2579f16083208007665340e22401