### PR TITLE
Expose conversation health metrics

### DIFF
--- a/conversation_service/api/routes/conversation.py
+++ b/conversation_service/api/routes/conversation.py
@@ -182,10 +182,11 @@ async def conversation_health_detailed():
         health_metrics = metrics_collector.get_health_metrics()
         
         return {
-            "service": "conversation_service", 
+            "service": "conversation_service",
             "phase": 1,
             "status": health_metrics["status"],
             "timestamp": datetime.now(timezone.utc).isoformat(),
+            "metrics": health_metrics,
             "health_details": {
                 "total_requests": health_metrics["total_requests"],
                 "error_rate_percent": health_metrics["error_rate_percent"],

--- a/tests/api/test_conversation_endpoint.py
+++ b/tests/api/test_conversation_endpoint.py
@@ -599,14 +599,15 @@ class TestConversationHealthEndpoint:
     def test_conversation_health_success(self, client):
         """Test health check réussi"""
         
-        with patch("conversation_service.utils.metrics_collector.metrics_collector") as mock_metrics:
-            mock_metrics.get_health_metrics.return_value = {
+        with patch("conversation_service.api.routes.conversation.metrics_collector") as mock_metrics:
+            expected_metrics = {
                 "status": "healthy",
                 "total_requests": 100,
                 "error_rate_percent": 2.5,
                 "latency_p95_ms": 250,
                 "uptime_seconds": 3600
             }
+            mock_metrics.get_health_metrics.return_value = expected_metrics
             
             response = client.get("/api/v1/conversation/health")
             
@@ -615,13 +616,13 @@ class TestConversationHealthEndpoint:
             
             assert data["service"] == "conversation_service"
             assert data["status"] == "healthy"
-            assert "metrics" in data
+            assert data["metrics"] == expected_metrics
             assert "features" in data
 
     def test_conversation_health_error(self, client):
         """Test health check avec erreur"""
         
-        with patch("conversation_service.utils.metrics_collector.metrics_collector") as mock_metrics:
+        with patch("conversation_service.api.routes.conversation.metrics_collector") as mock_metrics:
             mock_metrics.get_health_metrics.side_effect = Exception("Metrics error")
             
             response = client.get("/api/v1/conversation/health")


### PR DESCRIPTION
## Summary
- Add metrics field to conversation service health endpoint
- Check returned metrics structure in health endpoint tests

## Testing
- `pytest tests/api/test_conversation_endpoint.py::TestConversationHealthEndpoint -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae2582fe448320a1f315eb9d6717d0