### PR TITLE
Ensure intent classification retains enum objects

### DIFF
--- a/conversation_service/agents/financial/intent_classifier.py
+++ b/conversation_service/agents/financial/intent_classifier.py
@@ -375,7 +375,7 @@ JSON:"""
             cache_ttl = getattr(settings, 'CACHE_TTL_INTENT', 300)
             await self.cache_manager.set_semantic_cache(
                 cache_key,
-                result.dict(),
+                result.model_dump(mode="json"),
                 ttl=cache_ttl
             )
             

--- a/conversation_service/api/routes/conversation.py
+++ b/conversation_service/api/routes/conversation.py
@@ -466,7 +466,7 @@ if getattr(settings, 'ENVIRONMENT', 'production') != "production":
             
             return {
                 "input": text,
-                "result": result.dict(),
+                "result": result.model_dump(mode="json"),
                 "timestamp": datetime.now(timezone.utc).isoformat()
             }
             

--- a/conversation_service/models/responses/conversation_responses.py
+++ b/conversation_service/models/responses/conversation_responses.py
@@ -100,7 +100,6 @@ class IntentClassificationResult(BaseModel):
     model_config = ConfigDict(
         str_strip_whitespace=True,
         validate_assignment=True,
-        use_enum_values=True,
         arbitrary_types_allowed=True
     )
     
@@ -126,6 +125,14 @@ class IntentClassificationResult(BaseModel):
     # Qualité et fiabilité
     quality_score: Optional[float] = None
     reliability_indicators: Optional[Dict[str, Any]] = None
+
+    @field_validator('intent_type', mode='before')
+    @classmethod
+    def ensure_intent_enum(cls, v: Any) -> HarenaIntentType:
+        """S'assure que intent_type est bien une instance de HarenaIntentType."""
+        if isinstance(v, HarenaIntentType):
+            return v
+        return HarenaIntentType(v)
     
     @field_validator('confidence')
     @classmethod


### PR DESCRIPTION
## Summary
- keep `HarenaIntentType` instances in `IntentClassificationResult`
- serialize intent classification results explicitly for caching and debugging
- add validator ensuring intent enums are preserved

## Testing
- `pytest tests/agents/test_intent_classifier.py -q`
- `pytest tests/api/test_conversation_endpoint.py::TestConversationEndpoint::test_conversation_success_greeting -q` *(fails: 1 validation error for AgentMetrics)*


------
https://chatgpt.com/codex/tasks/task_e_68ae2a3dec7c8320be23a3bdfaadd235