### PR TITLE
Handle string intents in metrics collection

### DIFF
--- a/conversation_service/api/routes/conversation.py
+++ b/conversation_service/api/routes/conversation.py
@@ -317,8 +317,12 @@ async def _collect_comprehensive_metrics(
         metrics_collector.record_rate("conversation.requests")
         
         # Métriques par intention avec détail
-        intent_type = classification_result.intent_type.value
-        metrics_collector.increment_counter(f"conversation.intent.{intent_type}")
+        intent = (
+            classification_result.intent_type.value
+            if isinstance(classification_result.intent_type, HarenaIntentType)
+            else classification_result.intent_type
+        )
+        metrics_collector.increment_counter(f"conversation.intent.{intent}")
         metrics_collector.increment_counter(f"conversation.intent.category.{classification_result.category}")
         
         # Métriques qualité fine
@@ -326,7 +330,7 @@ async def _collect_comprehensive_metrics(
         
         if not classification_result.is_supported:
             metrics_collector.increment_counter("conversation.intent.unsupported")
-            metrics_collector.increment_counter(f"conversation.intent.unsupported.{intent_type}")
+            metrics_collector.increment_counter(f"conversation.intent.unsupported.{intent}")
         
         # Métriques seuil confidence
         confidence_threshold = getattr(settings, 'MIN_CONFIDENCE_THRESHOLD', 0.5)

--- a/tests/api/test_collect_comprehensive_metrics.py
+++ b/tests/api/test_collect_comprehensive_metrics.py
@@ -1,0 +1,29 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from conversation_service.api.routes.conversation import _collect_comprehensive_metrics
+from conversation_service.prompts.harena_intents import HarenaIntentType
+
+
+@pytest.mark.asyncio
+async def test_collect_comprehensive_metrics_handles_enum_and_string_intent():
+    base = {
+        "category": "GENERAL",
+        "confidence": 0.95,
+        "is_supported": True,
+        "alternatives": [],
+    }
+    agent_metrics = SimpleNamespace(cache_hit=True, tokens_consumed=5)
+
+    # Intent provided as enum
+    enum_result = SimpleNamespace(intent_type=HarenaIntentType.GREETING, **base)
+    with patch("conversation_service.api.routes.conversation.metrics_collector") as mock_metrics:
+        await _collect_comprehensive_metrics("req1", enum_result, 100, agent_metrics)
+        mock_metrics.increment_counter.assert_any_call("conversation.intent.GREETING")
+
+    # Intent provided as string
+    str_result = SimpleNamespace(intent_type="GREETING", **base)
+    with patch("conversation_service.api.routes.conversation.metrics_collector") as mock_metrics:
+        await _collect_comprehensive_metrics("req2", str_result, 100, agent_metrics)
+        mock_metrics.increment_counter.assert_any_call("conversation.intent.GREETING")


### PR DESCRIPTION
## Summary
- Normalize intent type to accept both HarenaIntentType enums and strings when collecting metrics
- Add regression test covering metrics collection for enum and string intents

## Testing
- `pytest tests/api/test_collect_comprehensive_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae2a406c988320bf371423dc559385