### PR TITLE
Track agent processing time in conversation metrics

### DIFF
--- a/conversation_service/api/routes/conversation.py
+++ b/conversation_service/api/routes/conversation.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 
 from conversation_service.models.requests.conversation_requests import ConversationRequest
 from conversation_service.models.responses.conversation_responses import ConversationResponse, AgentMetrics
-from conversation_service.agents.financial.intent_classifier import IntentClassifierAgent
+from conversation_service.agents.financial import intent_classifier as intent_classifier_module
 from conversation_service.clients.deepseek_client import DeepSeekClient
 from conversation_service.core.cache_manager import CacheManager
 from conversation_service.prompts.harena_intents import HarenaIntentType
@@ -86,7 +86,7 @@ async def analyze_conversation(
             )
         
         # Initialisation agent intent classifier
-        intent_classifier = IntentClassifierAgent(
+        intent_classifier = intent_classifier_module.IntentClassifierAgent(
             deepseek_client=deepseek_client,
             cache_manager=cache_manager
         )
@@ -100,9 +100,11 @@ async def analyze_conversation(
             user_context=user_context
         )
         classification_time = int((time.time() - classification_start) * 1000)
+        # Gestion flexible du type d'intention (enum ou str)
+        intent_type_value = getattr(classification_result.intent_type, 'value', classification_result.intent_type)
 
         # Validation résultat classification
-        if classification_result.intent_type == HarenaIntentType.ERROR:
+        if intent_type_value == HarenaIntentType.ERROR.value:
             logger.error(f"[{request_id}] Classification échouée - erreur technique")
             metrics_collector.increment_counter("conversation.errors.classification")
             raise HTTPException(
@@ -111,7 +113,7 @@ async def analyze_conversation(
             )
 
         # Calcul temps traitement total
-        processing_time_ms = int((time.time() - start_time) * 1000)
+        processing_time_ms = max(1, int((time.time() - start_time) * 1000))
         
         # Construction métriques agent avec données réelles
         agent_metrics = AgentMetrics(
@@ -119,12 +121,14 @@ async def analyze_conversation(
             cache_hit=classification_time < 100,  # Heuristique cache hit
             model_used=getattr(settings, 'DEEPSEEK_CHAT_MODEL', 'deepseek-chat'),
             tokens_consumed=await _estimate_tokens_consumption(clean_message, classification_result),
+            processing_time_ms=classification_result.processing_time_ms or classification_time,
             confidence_threshold_met=classification_result.confidence >= getattr(settings, 'MIN_CONFIDENCE_THRESHOLD', 0.5)
         )
         
         # Construction réponse Phase 1 avec toutes les données
         response = ConversationResponse(
             user_id=validated_user_id,
+            sub=user_context.get("sub"),
             message=clean_message,
             timestamp=datetime.now(timezone.utc),
             processing_time_ms=processing_time_ms,
@@ -139,7 +143,7 @@ async def analyze_conversation(
         
         # Log succès avec détails
         logger.info(
-            f"[{request_id}] Classification réussie: {classification_result.intent_type.value} "
+            f"[{request_id}] Classification réussie: {intent_type_value} "
             f"(confiance: {classification_result.confidence:.2f}, "
             f"temps: {processing_time_ms}ms, cache: {agent_metrics.cache_hit})"
         )
@@ -317,13 +321,13 @@ async def _collect_comprehensive_metrics(
         metrics_collector.record_rate("conversation.requests")
         
         # Métriques par intention avec détail
-        intent_type = classification_result.intent_type.value
+        intent_type = getattr(classification_result.intent_type, "value", classification_result.intent_type)
         metrics_collector.increment_counter(f"conversation.intent.{intent_type}")
         metrics_collector.increment_counter(f"conversation.intent.category.{classification_result.category}")
-        
+
         # Métriques qualité fine
         metrics_collector.record_gauge("conversation.intent.confidence", classification_result.confidence)
-        
+
         if not classification_result.is_supported:
             metrics_collector.increment_counter("conversation.intent.unsupported")
             metrics_collector.increment_counter(f"conversation.intent.unsupported.{intent_type}")

--- a/conversation_service/models/responses/conversation_responses.py
+++ b/conversation_service/models/responses/conversation_responses.py
@@ -361,6 +361,7 @@ class ConversationResponse(BaseModel):
         json_schema_extra={
             "example": {
                 "user_id": 123,
+                "sub": 123,
                 "message": "Mes achats Amazon",
                 "timestamp": "2024-08-26T14:30:00+00:00",
                 "processing_time_ms": 245,
@@ -393,6 +394,7 @@ class ConversationResponse(BaseModel):
     
     # Identifiants et contexte
     user_id: int
+    sub: Optional[int] = None
     message: str
     timestamp: datetime
     request_id: Optional[str] = None
@@ -417,6 +419,17 @@ class ConversationResponse(BaseModel):
             raise ValueError("User ID doit être positif")
         if v > 1000000:  # Limite raisonnable
             raise ValueError("User ID hors limites")
+        return v
+
+    @field_validator('sub')
+    @classmethod
+    def validate_sub(cls, v: Optional[int]) -> Optional[int]:
+        if v is None:
+            return v
+        if v <= 0:
+            raise ValueError("Sub doit être positif")
+        if v > 1000000:
+            raise ValueError("Sub hors limites")
         return v
     
     @field_validator('message')


### PR DESCRIPTION
## Summary
- pass through classification processing time to AgentMetrics
- include JWT `sub` in conversation responses
- ensure intent type handling works with string or enum values

## Testing
- `pytest tests/api/test_conversation_endpoint.py::TestConversationEndpoint::test_conversation_success_greeting -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae2a3431c883209669d1607f013ac1