### PR TITLE
Enable JWT middleware in test app

### DIFF
--- a/tests/api/test_conversation_endpoint.py
+++ b/tests/api/test_conversation_endpoint.py
@@ -152,9 +152,9 @@ def create_test_app():
     from conversation_service.api.middleware.auth_middleware import JWTAuthMiddleware
     
     app = FastAPI(title="Test Conversation Service")
-    
+
     # Middleware auth (simplifié pour tests)
-    # app.add_middleware(JWTAuthMiddleware)  # Désactivé pour simplifier
+    app.add_middleware(JWTAuthMiddleware)
     
     # Routes
     app.include_router(conversation_router, prefix="/api/v1")


### PR DESCRIPTION
## Summary
- enable JWTAuthMiddleware in test FastAPI app for conversation endpoint tests

## Testing
- `pytest tests/api/test_conversation_endpoint.py::TestConversationEndpoint::test_conversation_missing_authorization -vv` *(fails: AssertionError: assert 'Authorization' in 'Authentification requise')*

------
https://chatgpt.com/codex/tasks/task_e_68ae2db78ca08320bc7fbd724581895f