### PR TITLE
Use unified SECRET_KEY for conversation service token validation

### DIFF
--- a/conversation_service/api/middleware/auth_middleware.py
+++ b/conversation_service/api/middleware/auth_middleware.py
@@ -55,7 +55,8 @@ class JWTValidator:
     
     def __init__(self):
         self.algorithm = getattr(settings, 'JWT_ALGORITHM', 'HS256')
-        self.secret_key = settings.SECRET_KEY  # Shared secret for bearer token verification
+        # Use the unified SECRET_KEY from settings for JWT verification
+        self.secret_key = settings.SECRET_KEY
 
         self.token_cache: Dict[str, Dict[str, Any]] = {}
         self.cache_ttl = 300  # 5 minutes

--- a/conversation_service/main.py
+++ b/conversation_service/main.py
@@ -144,14 +144,6 @@ class ConversationServiceLoader:
             if not getattr(settings, 'SECRET_KEY', None):
                 validation_errors.append("SECRET_KEY manquant")
             else:
-                jwt_secret = settings.SECRET_KEY
-                if len(jwt_secret) < 32:
-                    validation_errors.append("SECRET_KEY trop court (minimum 32 caractères)")
-                if jwt_secret in ['changeme', 'secret', 'test']:
-            # Secret Key
-            if not getattr(settings, 'SECRET_KEY', None):
-                validation_errors.append("SECRET_KEY manquant")
-            else:
                 secret = settings.SECRET_KEY
                 if len(secret) < 32:
                     validation_errors.append("SECRET_KEY trop court (minimum 32 caractères)")


### PR DESCRIPTION
## Summary
- ensure conversation auth middleware relies on `settings.SECRET_KEY`
- validate configuration against `SECRET_KEY` instead of legacy `JWT_SECRET_KEY`

## Testing
- `pytest tests/api/test_conversation_endpoint.py::TestConversationEndpoint::test_conversation_invalid_token -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae2dcaffa4832089f6cf58e4a6647e