### PR TITLE
Default healthy status for unused conversation service

### DIFF
--- a/conversation_service/api/routes/conversation.py
+++ b/conversation_service/api/routes/conversation.py
@@ -393,12 +393,14 @@ async def conversation_status():
     try:
         health_metrics = metrics_collector.get_health_metrics()
         
+        health_status = health_metrics["status"]
+
         return {
-            "status": health_metrics["status"],
+            "status": health_status,
             "uptime_seconds": health_metrics["uptime_seconds"],
             "version": "1.1.0",
             "phase": 1,
-            "ready": health_metrics["status"] == "healthy",
+            "ready": health_status == "healthy",
             "jwt_compatible": True,
             "timestamp": datetime.now(timezone.utc).isoformat()
         }
@@ -558,7 +560,7 @@ def _safe_get_metric(metrics: Dict[str, Any], path: list, default: Any = None) -
 def _get_health_status_description(status: str) -> str:
     """Description détaillée du statut de santé avec gestion d'erreur"""
     descriptions = {
-        "healthy": "Service opérationnel, performances normales",
+        "healthy": "Service opérationnel, aucune requête traitée ou performances normales",
         "degraded": "Service opérationnel mais performances réduites",
         "unhealthy": "Service en difficulté, performances critiques",
         "unknown": "Statut indéterminable"

--- a/conversation_service/utils/metrics_collector.py
+++ b/conversation_service/utils/metrics_collector.py
@@ -451,12 +451,12 @@ class AdvancedMetricsCollector:
                 health_score -= min(error_rate * 2, 40)
             
             if error_rate > 20.0 or p95_latency > 10000:  # 10s
-                health_status = "unhealthy" 
+                health_status = "unhealthy"
                 health_score = min(health_score, 30)
-            
+
             if total_requests == 0:
-                health_status = "unknown"
-                health_score = 0
+                health_status = "healthy"
+                health_score = 100.0
             
             uptime_seconds = (datetime.now(timezone.utc) - self._session_start).total_seconds()
             


### PR DESCRIPTION
## Summary
- default to `healthy` status when no conversation requests have occurred
- clarify `/conversation/status` readiness logic
- describe `healthy` status as default in health status descriptions

## Testing
- `pytest` *(fails: tests not collected - missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb806744c8320ae2c08b82950a115