### PR TITLE
feat: add JWT middleware to local dev app

### DIFF
--- a/conversation_service/main.py
+++ b/conversation_service/main.py
@@ -491,7 +491,7 @@ class ConversationServiceLoader:
         except RuntimeError as e:
             if "Cannot add middleware after an application has started" in str(e):
                 can_add_middleware = False
-                logger.warning("⚠️ Application déjà démarrée - skip middleware (mode intégration)")
+                logger.info("ℹ️ Application déjà démarrée - middleware géré par l'app parent (mode intégration)")
             else:
                 raise e
         

--- a/local_app.py
+++ b/local_app.py
@@ -20,6 +20,7 @@ from dotenv import load_dotenv
 from contextlib import asynccontextmanager
 
 from config_service.config import settings
+from conversation_service.api.middleware.auth_middleware import JWTAuthMiddleware
 
 # Charger le fichier .env en priorité
 load_dotenv()
@@ -412,6 +413,8 @@ def create_app():
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    app.add_middleware(JWTAuthMiddleware)
 
     @app.get("/health")
     async def health():


### PR DESCRIPTION
## Summary
- add JWTAuthMiddleware to local app and enable middleware for token validation
- downgrade conversation service integration warning when middleware handled by parent app

## Testing
- `pytest test_jwt_compatibility.py -q` *(fails: ModuleNotFoundError: No module named 'jose')*
- `pytest -q` *(fails: various ImportError: e.g., cannot import name 'computed_field' from 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68aebe892e608320923cfa43e413b443