### PR TITLE
Fix conversation router prefix and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,11 +197,11 @@ la réponse standardisée. Chaque modèle inclut un exemple complet de payload v
 
 ## Authentication
 
-Most endpoints, including `/conversation/chat`, require an OAuth2 Bearer token.
-Clients must authenticate against `/users/auth/login` and include the returned
-`access_token` in an `Authorization: Bearer <token>` header on their first
-request. The test clients in this repository obtain a token during
-initialization so that every call is properly authenticated.
+Most endpoints, including `POST /api/v1/conversation/{user_id}`, require an
+OAuth2 Bearer token. Clients must authenticate against `/users/auth/login` and
+include the returned `access_token` in an `Authorization: Bearer <token>`
+header on their first request. The test clients in this repository obtain a
+token during initialization so that every call is properly authenticated.
 
 ## Environment Variables
 
@@ -227,9 +227,9 @@ setting an environment variable.
 
 ## `metadata.workflow_data`
 
-The conversation API (`/conversation/chat`) includes a `metadata` object in its
-response. A nested `workflow_data` dictionary exposes details collected during
-the multi‑agent workflow:
+The conversation API (`POST /api/v1/conversation/{user_id}`) includes a
+`metadata` object in its response. A nested `workflow_data` dictionary exposes
+details collected during the multi‑agent workflow:
 
 | Key | Type | Description |
 | --- | --- | --- |

--- a/heroku_app.py
+++ b/heroku_app.py
@@ -356,7 +356,7 @@ def create_app():
             # Ensuite charger les routes
             try:
                 from conversation_service.api.routes.conversation import router as conversation_router
-                app.include_router(conversation_router, prefix="/api/v1/conversation")
+                app.include_router(conversation_router, prefix="/api/v1")
                 routes_count = len(conversation_router.routes) if hasattr(conversation_router, 'routes') else 0
 
                 if conversation_init_success:
@@ -367,7 +367,7 @@ def create_app():
                     loader.services_status["conversation_service"].update({
                         "status": "ok",
                         "routes": routes_count,
-                        "prefix": "/api/v1/conversation",
+                        "prefix": "/api/v1",
                         "initialized": True,
                         "architecture": "llm_intent_agent",
                         "model": "gpt-4o-mini",
@@ -383,7 +383,7 @@ def create_app():
                     loader.services_status["conversation_service"].update({
                         "status": "degraded",
                         "routes": routes_count,
-                        "prefix": "/api/v1/conversation",
+                        "prefix": "/api/v1",
                         "initialized": False,
                         "error": loader.conversation_service_error,
                         "architecture": "llm_intent_agent",

--- a/local_app.py
+++ b/local_app.py
@@ -353,7 +353,7 @@ def create_app():
             conversation_loader = ConversationServiceLoader()
             conversation_initialized = await conversation_loader.initialize_conversation_service(app)
 
-            app.include_router(conversation_router, prefix="/api/v1/conversation", tags=["conversation"])
+            app.include_router(conversation_router, prefix="/api/v1", tags=["conversation"])
             routes_count = len(conversation_router.routes) if hasattr(conversation_router, 'routes') else 0
 
             loader.conversation_service_initialized = conversation_initialized
@@ -363,7 +363,7 @@ def create_app():
             loader.services_status["conversation_service"] = {
                 "status": status,
                 "routes": routes_count,
-                "prefix": "/api/v1/conversation",
+                "prefix": "/api/v1",
                 "initialized": conversation_initialized,
                 "error": conversation_loader.initialization_error,
             }

--- a/scripts/test_harena_chat_direct.py
+++ b/scripts/test_harena_chat_direct.py
@@ -10,6 +10,7 @@ from datetime import datetime
 BASE_URL = "http://localhost:8000/api/v1"
 USERNAME = "test2@example.com"
 PASSWORD = "password123"
+USER_ID = 1
 QUESTIONS = [
     "Combien ai-je fait de virements en mai ?",
     "Combien ai-je dépensé en juin ?",
@@ -17,11 +18,11 @@ QUESTIONS = [
     "Compare mes entrées et sorties d'argent en juin !",
 ]
 
-def run_question(session: requests.Session, question: str, conv_id: str) -> dict:
+def run_question(session: requests.Session, user_id: int, question: str, conv_id: str) -> dict:
     """Exécute une question de chat et affiche le résultat."""
 
     chat_payload = {"message": question, "conversation_id": conv_id}
-    chat_resp = session.post(f"{BASE_URL}/conversation/chat", json=chat_payload)
+    chat_resp = session.post(f"{BASE_URL}/conversation/{user_id}", json=chat_payload)
     chat_resp.raise_for_status()
     chat_data = chat_resp.json()
 
@@ -58,7 +59,7 @@ def main() -> None:
 
     for i, question in enumerate(QUESTIONS):
         conversation_id = f"test-chat-analysis-{i}"
-        chat_data = run_question(session, question, conversation_id)
+        chat_data = run_question(session, USER_ID, question, conversation_id)
 
     # ----- ANALYSE DE L'INTENTION DÉTECTÉE ----------------------------------
     intent_result = chat_data["metadata"]["intent_result"]


### PR DESCRIPTION
## Summary
- mount conversation router under `/api/v1` instead of `/api/v1/conversation`
- align Heroku app and client script with the new path
- document updated `/api/v1/conversation/{user_id}` endpoint

## Testing
- `pytest tests/api/test_conversation_endpoint.py::TestConversationEndpoint::test_conversation_success_greeting -q`

------
https://chatgpt.com/codex/tasks/task_e_68aebe8d4dd48320a232de5d97473ac5