### PR TITLE
feat: update chat payload with metadata and add request model test

### DIFF
--- a/scripts/test_harena_chat_direct.py
+++ b/scripts/test_harena_chat_direct.py
@@ -19,11 +19,16 @@ QUESTIONS = [
 ]
 
 def run_question(
-    session: requests.Session, user_id: int, question: str, conv_id: str
+    session: requests.Session, user_id: int, question: str
 ) -> tuple[dict | None, str, str, float]:
     """Exécute une question de chat et affiche le résultat."""
 
-    chat_payload = {"message": question, "conversation_id": conv_id}
+    chat_payload = {
+        "message": question,
+        "client_info": {"platform": "web", "version": "1.0.0"},
+        "message_type": "text",
+        "priority": "normal",
+    }
     start_time = time.perf_counter()
     intent_type = "N/A"
     confidence = "N/A"
@@ -84,10 +89,9 @@ def main() -> None:
     report = []
     last_chat_data = None
 
-    for i, question in enumerate(QUESTIONS):
-        conversation_id = f"test-chat-analysis-{i}"
+    for question in QUESTIONS:
         chat_data, intent_type, confidence, elapsed_ms = run_question(
-            session, user_id, question, conversation_id
+            session, user_id, question
         )
         report.append(
             {

--- a/tests/api/test_conversation_endpoint.py
+++ b/tests/api/test_conversation_endpoint.py
@@ -619,6 +619,23 @@ class TestDataValidation:
         
         assert response.status_code == 422
 
+
+class TestConversationRequestModel:
+    """Tests pour le modèle ConversationRequest"""
+
+    def test_request_with_optional_fields(self):
+        data = {
+            "message": "Bonjour",
+            "client_info": {"platform": "web", "version": "1.0.0"},
+            "message_type": "text",
+            "priority": "normal",
+        }
+        req = ConversationRequest.model_validate(data)
+        assert req.message == "Bonjour"
+        assert req.client_info == {"platform": "web", "version": "1.0.0"}
+        assert req.message_type == "text"
+        assert req.priority == "normal"
+
 # ============================================================================
 # TESTS ENDPOINTS MONITORING
 # ============================================================================


### PR DESCRIPTION
## Summary
- remove `conversation_id` from chat payload and include client_info, message_type, and priority
- add unit test ensuring `ConversationRequest` accepts optional metadata fields

## Testing
- `pytest tests/api/test_conversation_endpoint.py::TestConversationRequestModel::test_request_with_optional_fields -q`
- `pytest tests/api/test_conversation_endpoint.py::TestConversationEndpoint::test_conversation_success_greeting -q`


------
https://chatgpt.com/codex/tasks/task_e_68aedc463c44832098b002b9af640d02