### PR TITLE
feat: ajoute integration autogen

### DIFF
--- a/conversation_service/autogen_core/__init__.py
+++ b/conversation_service/autogen_core/__init__.py
@@ -1,0 +1,12 @@
+"""Composants AutoGen pour le service de conversation"""
+from .agent_factory import AutoGenAgentFactory
+from .agent_runtime import ConversationServiceRuntime
+from .conversation_state import ConversationState
+from .deepseek_integration import DeepSeekAutoGenClient
+
+__all__ = [
+    "AutoGenAgentFactory",
+    "ConversationServiceRuntime",
+    "ConversationState",
+    "DeepSeekAutoGenClient",
+]

--- a/conversation_service/autogen_core/agent_factory.py
+++ b/conversation_service/autogen_core/agent_factory.py
@@ -1,0 +1,36 @@
+"""Fabrique d'agents AutoGen"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .deepseek_integration import DeepSeekAutoGenClient
+
+logger = logging.getLogger("conversation_service.autogen.factory")
+
+
+class AutoGenAgentFactory:
+    """Crée des agents AutoGen préconfigurés"""
+
+    def __init__(self, deepseek: DeepSeekAutoGenClient | None = None) -> None:
+        self.deepseek = deepseek or DeepSeekAutoGenClient()
+
+    async def create_assistant(self, name: str, system_message: str) -> Any:
+        """Crée un assistant AutoGen basé sur DeepSeek."""
+        try:
+            from autogen import AssistantAgent
+        except Exception as exc:  # pragma: no cover - dépendance externe
+            raise RuntimeError("Autogen n'est pas installé") from exc
+
+        await self.deepseek.initialize()
+        llm_config = self.deepseek.get_llm_config()
+        return AssistantAgent(name=name, llm_config=llm_config, system_message=system_message)
+
+    async def create_user_proxy(self, name: str) -> Any:
+        """Crée un agent utilisateur proxy."""
+        try:
+            from autogen import UserProxyAgent
+        except Exception as exc:  # pragma: no cover
+            raise RuntimeError("Autogen n'est pas installé") from exc
+
+        return UserProxyAgent(name=name, human_input_mode="NEVER")

--- a/conversation_service/autogen_core/agent_runtime.py
+++ b/conversation_service/autogen_core/agent_runtime.py
@@ -1,0 +1,44 @@
+"""Runtime de conversation utilisant AutoGen"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+from .agent_factory import AutoGenAgentFactory
+from .conversation_state import ConversationState
+
+logger = logging.getLogger("conversation_service.autogen.runtime")
+
+
+class ConversationServiceRuntime:
+    """Gère les équipes AutoGen et le flux de conversation."""
+
+    def __init__(self, factory: AutoGenAgentFactory | None = None) -> None:
+        self.factory = factory or AutoGenAgentFactory()
+        self.assistant = None
+        self.user_proxy = None
+
+    async def initialize_team(self, system_message: str) -> None:
+        """Initialise les agents principaux."""
+        self.user_proxy = await self.factory.create_user_proxy("user")
+        self.assistant = await self.factory.create_assistant("assistant", system_message)
+        logger.info("Equipe AutoGen initialisée")
+
+    async def process_conversation(self, state: ConversationState, user_message: str) -> str:
+        """Traite une requête utilisateur et retourne la réponse normalisée."""
+        if not self.assistant or not self.user_proxy:
+            await self.initialize_team(system_message="")
+
+        state.add_user_message(user_message)
+        messages = state.to_messages()
+        raw_response = await self.factory.deepseek.chat(messages)
+        content = self._normalize_response(raw_response)
+        state.add_agent_message(content)
+        return content
+
+    def _normalize_response(self, response: Dict[str, Any]) -> str:
+        """Extrait proprement le texte de réponse du modèle."""
+        try:
+            return response["choices"][0]["message"]["content"].strip()
+        except Exception:
+            return str(response).strip()

--- a/conversation_service/autogen_core/conversation_state.py
+++ b/conversation_service/autogen_core/conversation_state.py
@@ -1,0 +1,40 @@
+"""Etat de conversation persistant pour gestion multi-tours AutoGen"""
+import json
+from dataclasses import dataclass, field
+from typing import List, Dict, Any
+
+
+@dataclass
+class ConversationTurn:
+    """Représente un échange dans la conversation."""
+    role: str
+    content: str
+
+
+@dataclass
+class ConversationState:
+    """Gère l'historique des messages multi-tours."""
+    turns: List[ConversationTurn] = field(default_factory=list)
+
+    def add_user_message(self, content: str) -> None:
+        self.turns.append(ConversationTurn(role="user", content=content))
+
+    def add_agent_message(self, content: str) -> None:
+        self.turns.append(ConversationTurn(role="assistant", content=content))
+
+    def to_messages(self) -> List[Dict[str, str]]:
+        return [
+            {"role": turn.role, "content": turn.content}
+            for turn in self.turns
+        ]
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_messages(), ensure_ascii=False)
+
+    @classmethod
+    def from_json(cls, data: str) -> "ConversationState":
+        messages = json.loads(data)
+        state = cls()
+        for msg in messages:
+            state.turns.append(ConversationTurn(role=msg["role"], content=msg["content"]))
+        return state

--- a/conversation_service/autogen_core/deepseek_integration.py
+++ b/conversation_service/autogen_core/deepseek_integration.py
@@ -1,0 +1,34 @@
+"""Intégration DeepSeek dédiée à AutoGen"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List
+
+from conversation_service.clients.deepseek_client import DeepSeekClient
+
+logger = logging.getLogger("conversation_service.autogen.deepseek")
+
+
+class DeepSeekAutoGenClient:
+    """Wrapper fournissant la configuration LLM pour AutoGen."""
+
+    def __init__(self, client: DeepSeekClient | None = None) -> None:
+        self.client = client or DeepSeekClient()
+
+    async def initialize(self) -> None:
+        await self.client.initialize()
+
+    async def chat(self, messages: List[Dict[str, str]], **kwargs: Any) -> Dict[str, Any]:
+        return await self.client.chat_completion(messages=messages, **kwargs)
+
+    def get_llm_config(self) -> Dict[str, Any]:
+        """Configuration LLM compatible AutoGen."""
+        return {
+            "config_list": [
+                {
+                    "model": self.client.model_chat,
+                    "api_key": self.client.api_key,
+                    "base_url": self.client.api_url,
+                }
+            ]
+        }


### PR DESCRIPTION
## Summary
- add conversation state persistence for multi-turn flows
- wrap DeepSeek client for AutoGen compatibility
- create AutoGen agent factory and runtime

## Testing
- `python -m py_compile conversation_service/autogen_core/*.py`
- `pytest` *(fails: ImportError from pydantic, jose, sqlalchemy, prometheus_client, fastapi and others)*

------
https://chatgpt.com/codex/tasks/task_e_68af387b7e688320bc2b0706cb764520