### PR TITLE
Add base financial and entity extractor agents

### DIFF
--- a/conversation_service/agents/__init__.py
+++ b/conversation_service/agents/__init__.py
@@ -1,0 +1,6 @@
+"""Interfaces publiques des agents conversationnels."""
+
+from .base_financial_agent import BaseFinancialAgent
+from .entity_extractor_agent import EntityExtractorAgent
+
+__all__ = ["BaseFinancialAgent", "EntityExtractorAgent"]

--- a/conversation_service/agents/base_financial_agent.py
+++ b/conversation_service/agents/base_financial_agent.py
@@ -1,0 +1,88 @@
+"""Base financial agent with shared utilities.
+
+This module provides a light wrapper around :class:`AssistantAgent` with
+helpers common to financial agents, such as currency normalization.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+try:  # pragma: no cover - handled in tests via stub
+    from autogen import AssistantAgent
+except Exception:  # pragma: no cover - fallback when autogen isn't installed
+    class AssistantAgent:  # type: ignore
+        """Minimal stub used when the autogen library is unavailable."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: D401 - simple stub
+            pass
+
+        def add_capability(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover
+            pass
+
+
+class BaseFinancialAgent(AssistantAgent):
+    """Assistant de base pour les opérations financières.
+
+    Parameters
+    ----------
+    name:
+        Nom de l'agent.
+    system_message:
+        Message système envoyé au LLM. Un message par défaut adapté au domaine
+        financier est utilisé si aucun n'est fourni.
+    llm_config:
+        Configuration du modèle sous-jacent.
+    default_currency:
+        Devise par défaut pour la normalisation des montants.
+    """
+
+    def __init__(
+        self,
+        name: str = "base_financial",
+        system_message: Optional[str] = None,
+        llm_config: Optional[Dict[str, Any]] = None,
+        default_currency: str = "EUR",
+        **kwargs: Any,
+    ) -> None:
+        system_message = system_message or (
+            "Tu es un assistant financier aidant les utilisateurs à comprendre"
+            " leurs données monétaires."
+        )
+        super().__init__(
+            name=name,
+            system_message=system_message,
+            llm_config=llm_config,
+            **kwargs,
+        )
+        self.default_currency = default_currency
+
+    # ------------------------------------------------------------------
+    # Helpers financiers
+    # ------------------------------------------------------------------
+    def normalize_amount(self, value: Any, currency: Optional[str] = None) -> Dict[str, Any]:
+        """Normalise un montant en valeur flottante et code devise.
+
+        Parameters
+        ----------
+        value:
+            Valeur brute à normaliser.
+        currency:
+            Code devise (ex: ``"EUR"``). La devise par défaut est utilisée si
+            aucune n'est fournie.
+
+        Returns
+        -------
+        dict
+            Dictionnaire contenant ``amount`` (float) et ``currency`` (str).
+        """
+        try:
+            amount = float(value)
+        except (TypeError, ValueError):  # pragma: no cover - validation simple
+            amount = 0.0
+
+        return {"amount": amount, "currency": (currency or self.default_currency).upper()}
+
+    def format_amount(self, value: Any, currency: Optional[str] = None) -> str:
+        """Formate un montant normalisé pour affichage."""
+        normalized = self.normalize_amount(value, currency)
+        return f"{normalized['amount']:.2f} {normalized['currency']}"

--- a/conversation_service/agents/entity_extractor_agent.py
+++ b/conversation_service/agents/entity_extractor_agent.py
@@ -1,0 +1,70 @@
+"""Entity extraction agent with optional teachability support.
+
+The agent leverages :class:`AssistantAgent` from the autogen library. It can be
+extended with normalizer callables that post-process extracted entities. When
+the :class:`Teachability` capability is available, it is added to the agent so
+that users can teach new entities during runtime.
+"""
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable, List, Optional
+
+try:  # pragma: no cover - resolved in tests via stub
+    from autogen import AssistantAgent
+except Exception:  # pragma: no cover - fallback
+    class AssistantAgent:  # type: ignore
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        def add_capability(self, *args: Any, **kwargs: Any) -> None:  # noqa: D401
+            pass
+
+try:  # pragma: no cover - Teachability may not be installed
+    from autogen.agentchat.contrib.capabilities.teachability import Teachability
+except Exception:  # pragma: no cover - fallback stub when autogen extras absent
+    class Teachability:  # type: ignore
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+
+class EntityExtractorAgent(AssistantAgent):
+    """Agent chargé d'extraire des entités dans un texte."""
+
+    def __init__(
+        self,
+        name: str = "entity_extractor",
+        normalizers: Optional[Iterable[Callable[[str], str]]] = None,
+        enable_teachability: bool = True,
+        system_message: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        system_message = system_message or "Extract financial entities from user messages."
+        super().__init__(name=name, system_message=system_message, **kwargs)
+
+        self.normalizers: List[Callable[[str], str]] = list(normalizers or [])
+        self.teachability: Optional[Teachability] = None
+
+        if enable_teachability:
+            try:
+                self.teachability = Teachability()
+                if hasattr(self, "add_capability"):
+                    self.add_capability(self.teachability)
+            except Exception:  # pragma: no cover - safety if capability not available
+                self.teachability = None
+
+    # ------------------------------------------------------------------
+    # Normalisation des entités
+    # ------------------------------------------------------------------
+    def add_normalizer(self, normalizer: Callable[[str], str]) -> None:
+        """Ajoute une fonction de normalisation d'entité."""
+        self.normalizers.append(normalizer)
+
+    def normalize(self, entity: str) -> str:
+        """Applique tous les normalisateurs configurés à une entité."""
+        for normalizer in self.normalizers:
+            entity = normalizer(entity)
+        return entity
+
+    def normalize_entities(self, entities: Iterable[str]) -> List[str]:
+        """Normalise une collection d'entités."""
+        return [self.normalize(e) for e in entities]


### PR DESCRIPTION
## Summary
- introduce BaseFinancialAgent built on AssistantAgent with helpers for currency normalization
- add EntityExtractorAgent with normalizers and optional Teachability capability
- expose new agents in `conversation_service.agents`

## Testing
- `pytest -q` *(fails: No module named 'jose', 'sqlalchemy', 'fastapi', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68af387d58a88320a9627ff4c27d8468