### PR TITLE
feat(conversation): add autogen agent and team configs

### DIFF
--- a/conversation_service/models/autogen_models/__init__.py
+++ b/conversation_service/models/autogen_models/__init__.py
@@ -1,0 +1,6 @@
+"""Modèles de configuration AutoGen"""
+
+from .agent_configs import AgentConfig
+from .team_configs import TeamConfig
+
+__all__ = ["AgentConfig", "TeamConfig"]

--- a/conversation_service/models/autogen_models/agent_configs.py
+++ b/conversation_service/models/autogen_models/agent_configs.py
@@ -1,0 +1,18 @@
+"""Modèles Pydantic pour la configuration des agents AutoGen"""
+from typing import Optional, Dict, Any
+from pydantic import BaseModel, Field, ConfigDict
+
+
+class AgentConfig(BaseModel):
+    """Configuration d'un agent AutoGen"""
+    model_config = ConfigDict(extra="forbid", validate_assignment=True)
+
+    name: str = Field(..., description="Nom unique de l'agent")
+    llm: str = Field(..., description="Modèle LLM utilisé, ex: gpt-4o-mini")
+    temperature: float = Field(0.7, ge=0.0, le=2.0)
+    top_p: float = Field(0.95, ge=0.0, le=1.0)
+    max_tokens: int = Field(256, ge=1)
+    teachable: bool = Field(False, description="L'agent peut-il apprendre ?")
+    memory_enabled: bool = Field(False, description="Mémoire de conversation activée")
+    system_prompt: Optional[str] = Field(default=None, description="Prompt système spécifique")
+    extra: Optional[Dict[str, Any]] = Field(default=None, description="Paramètres additionnels")

--- a/conversation_service/models/autogen_models/team_configs.py
+++ b/conversation_service/models/autogen_models/team_configs.py
@@ -1,0 +1,16 @@
+"""Modèles Pydantic pour la configuration des équipes d'agents AutoGen"""
+from typing import List, Optional
+from pydantic import BaseModel, Field, ConfigDict
+
+from .agent_configs import AgentConfig
+
+
+class TeamConfig(BaseModel):
+    """Configuration d'une équipe d'agents"""
+    model_config = ConfigDict(extra="forbid", validate_assignment=True)
+
+    name: str = Field(..., description="Nom de l'équipe")
+    agents: List[AgentConfig] = Field(..., description="Agents participants")
+    max_rounds: int = Field(5, ge=1, description="Nombre maximal d'itérations")
+    description: Optional[str] = Field(default=None, description="Description de l'équipe")
+    shared_state: bool = Field(False, description="État partagé entre agents")


### PR DESCRIPTION
## Summary
- create `autogen_models` package for conversation service
- add `AgentConfig` and `TeamConfig` Pydantic models

## Testing
- `pytest tests/test_harena_intents.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af388690a08320a4f8605741883180