### PR TITLE
Add conversation entity models and validation

### DIFF
--- a/conversation_service/models/conversation/__init__.py
+++ b/conversation_service/models/conversation/__init__.py
@@ -1,0 +1,25 @@
+"""Exports for conversation entities and validation utilities."""
+
+from .entities import (
+    AmountEntity,
+    MerchantEntity,
+    DateEntity,
+    ConversationEntities,
+)
+from .entity_validation import (
+    validate_entities_intent,
+    INTENTS_REQUIRING_AMOUNT,
+    INTENTS_REQUIRING_MERCHANT,
+    INTENTS_REQUIRING_DATE,
+)
+
+__all__ = [
+    "AmountEntity",
+    "MerchantEntity",
+    "DateEntity",
+    "ConversationEntities",
+    "validate_entities_intent",
+    "INTENTS_REQUIRING_AMOUNT",
+    "INTENTS_REQUIRING_MERCHANT",
+    "INTENTS_REQUIRING_DATE",
+]

--- a/conversation_service/models/conversation/entities.py
+++ b/conversation_service/models/conversation/entities.py
@@ -1,0 +1,80 @@
+"""Models for entities extracted from user conversations.
+
+These models represent amounts, merchants, dates and optional metadata
+that can be detected in a user request. They are built with Pydantic to
+benefit from validation and serialization utilities.
+"""
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class AmountEntity(BaseModel):
+    """Represents a monetary amount mentioned by the user."""
+
+    model_config = ConfigDict(validate_assignment=True)
+
+    value: float
+    currency: str = "EUR"
+
+    @field_validator("value")
+    @classmethod
+    def validate_value(cls, v: float) -> float:
+        if v <= 0:
+            raise ValueError("Amount value must be positive")
+        return v
+
+    @field_validator("currency")
+    @classmethod
+    def validate_currency(cls, v: str) -> str:
+        if not v or len(v) != 3:
+            raise ValueError("Currency must be a 3-letter code")
+        return v.upper()
+
+
+class MerchantEntity(BaseModel):
+    """Represents a merchant or vendor name."""
+
+    model_config = ConfigDict(str_strip_whitespace=True, validate_assignment=True)
+
+    name: str
+    category: Optional[str] = None
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("Merchant name cannot be empty")
+        return v.strip()
+
+
+class DateEntity(BaseModel):
+    """Represents a date or date range."""
+
+    model_config = ConfigDict(validate_assignment=True)
+
+    start_date: date
+    end_date: Optional[date] = None
+
+    @field_validator("end_date")
+    @classmethod
+    def validate_end_date(cls, v: Optional[date], info):
+        start = info.data.get("start_date")
+        if v and start and v < start:
+            raise ValueError("end_date cannot be before start_date")
+        return v
+
+
+class ConversationEntities(BaseModel):
+    """Container for all entities extracted from a message."""
+
+    model_config = ConfigDict(validate_assignment=True)
+
+    amounts: List[AmountEntity] = Field(default_factory=list)
+    merchants: List[MerchantEntity] = Field(default_factory=list)
+    dates: List[DateEntity] = Field(default_factory=list)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+

--- a/conversation_service/models/conversation/entity_validation.py
+++ b/conversation_service/models/conversation/entity_validation.py
@@ -1,0 +1,49 @@
+"""Utility functions to validate coherence between entities and intents."""
+from __future__ import annotations
+
+from typing import List
+
+from conversation_service.prompts.harena_intents import HarenaIntentType
+
+from .entities import ConversationEntities
+
+# Intents that require specific entity types
+INTENTS_REQUIRING_AMOUNT = {
+    HarenaIntentType.SEARCH_BY_AMOUNT,
+    HarenaIntentType.SEARCH_BY_AMOUNT_AND_DATE,
+}
+
+INTENTS_REQUIRING_MERCHANT = {
+    HarenaIntentType.SEARCH_BY_MERCHANT,
+    HarenaIntentType.MERCHANT_INQUIRY,
+}
+
+INTENTS_REQUIRING_DATE = {
+    HarenaIntentType.SEARCH_BY_DATE,
+    HarenaIntentType.SEARCH_BY_AMOUNT_AND_DATE,
+}
+
+
+def validate_entities_intent(intent: HarenaIntentType, entities: ConversationEntities) -> List[str]:
+    """Validate that provided entities match the expected intent requirements.
+
+    Args:
+        intent: Predicted user intent.
+        entities: Entities extracted from the user message.
+
+    Returns:
+        A list of issues found. The list is empty when validation succeeds.
+    """
+    issues: List[str] = []
+
+    if intent in INTENTS_REQUIRING_AMOUNT and not entities.amounts:
+        issues.append("amounts required for this intent")
+
+    if intent in INTENTS_REQUIRING_MERCHANT and not entities.merchants:
+        issues.append("merchants required for this intent")
+
+    if intent in INTENTS_REQUIRING_DATE and not entities.dates:
+        issues.append("dates required for this intent")
+
+    return issues
+


### PR DESCRIPTION
## Summary
- add Pydantic models for conversation entities (amount, merchant, date, metadata)
- implement entity-intent validation helpers
- expose new models and validators via package exports

## Testing
- `pytest -q` *(fails: test_classify_intent_json_parse_error, test_classify_intent_prompt_construction)*

------
https://chatgpt.com/codex/tasks/task_e_68af388a08c08320baa29b2f49b10ff7