### PR TITLE
feat: add normalization utilities

### DIFF
--- a/conversation_service/utils/normalization/__init__.py
+++ b/conversation_service/utils/normalization/__init__.py
@@ -1,0 +1,12 @@
+"""Regroupe les fonctions de normalisation du conversation service."""
+from .amount_normalizer import normalize_amount
+from .autogen_normalizer import normalize_transaction
+from .date_normalizer import normalize_date
+from .merchant_normalizer import normalize_merchant
+
+__all__ = [
+    "normalize_amount",
+    "normalize_date",
+    "normalize_merchant",
+    "normalize_transaction",
+]

--- a/conversation_service/utils/normalization/amount_normalizer.py
+++ b/conversation_service/utils/normalization/amount_normalizer.py
@@ -1,0 +1,36 @@
+"""Normalisation de montants pour le conversation service."""
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+
+def normalize_amount(amount_str: str) -> Optional[float]:
+    """Convertit une chaîne représentant un montant en ``float``.
+
+    La fonction accepte des formats variés (``1 234,56 €``, ``$1,234.56``, etc.) et
+    gère automatiquement les séparateurs de milliers et décimaux.
+
+    Args:
+        amount_str: Chaîne contenant un montant.
+
+    Returns:
+        Montant sous forme ``float`` ou ``None`` si la conversion échoue.
+    """
+    if not isinstance(amount_str, str) or not amount_str.strip():
+        return None
+
+    # Suppression des symboles monétaires et des espaces non nécessaires
+    cleaned = re.sub(r"[^0-9,.-]", "", amount_str.strip())
+
+    # Gestion des formats européens (virgule comme séparateur décimal)
+    if cleaned.count(",") == 1 and cleaned.count(".") == 0:
+        cleaned = cleaned.replace(",", ".")
+    else:
+        # Suppression des virgules utilisées comme séparateur de milliers
+        cleaned = cleaned.replace(",", "")
+
+    try:
+        return float(cleaned)
+    except ValueError:
+        return None

--- a/conversation_service/utils/normalization/autogen_normalizer.py
+++ b/conversation_service/utils/normalization/autogen_normalizer.py
@@ -1,0 +1,28 @@
+"""Normalisation globale des transactions pour le conversation service."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .amount_normalizer import normalize_amount
+from .date_normalizer import normalize_date
+from .merchant_normalizer import normalize_merchant
+
+
+def normalize_transaction(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Applique les normaliseurs aux champs connus d'une transaction.
+
+    Args:
+        data: Dictionnaire contenant potentiellement les clés ``date``, ``amount`` et
+            ``merchant``.
+
+    Returns:
+        ``dict`` enrichi avec les valeurs normalisées.
+    """
+    normalized = dict(data)
+    if "date" in data:
+        normalized["date"] = normalize_date(data["date"])
+    if "amount" in data:
+        normalized["amount"] = normalize_amount(str(data["amount"]))
+    if "merchant" in data:
+        normalized["merchant"] = normalize_merchant(data["merchant"])
+    return normalized

--- a/conversation_service/utils/normalization/date_normalizer.py
+++ b/conversation_service/utils/normalization/date_normalizer.py
@@ -1,0 +1,32 @@
+"""Normalisation de dates pour le conversation service."""
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from typing import Optional
+
+from dateutil import parser
+
+
+def normalize_date(date_str: str) -> Optional[str]:
+    """Normalise une chaîne de date vers le format ISO ``YYYY-MM-DD``.
+
+    Args:
+        date_str: Chaîne représentant une date potentiellement partielle ou au format local.
+
+    Returns:
+        Date normalisée au format ISO ou ``None`` si la date est invalide.
+    """
+    if not isinstance(date_str, str) or not date_str.strip():
+        return None
+
+    # Détection rapide du format ISO pour éviter les inversions jour/mois
+    iso_pattern = r"^\d{4}-\d{2}-\d{2}$"
+    try:
+        if re.match(iso_pattern, date_str.strip()):
+            return datetime.fromisoformat(date_str.strip()).date().isoformat()
+
+        dt: datetime = parser.parse(date_str, dayfirst=True)
+        return dt.date().isoformat()
+    except (parser.ParserError, ValueError, TypeError):
+        return None

--- a/conversation_service/utils/normalization/merchant_normalizer.py
+++ b/conversation_service/utils/normalization/merchant_normalizer.py
@@ -1,0 +1,31 @@
+"""Normalisation des noms de commerçant pour le conversation service."""
+from __future__ import annotations
+
+import re
+import unicodedata
+from typing import Optional
+
+
+def normalize_merchant(name: str) -> Optional[str]:
+    """Nettoie et met en forme le nom d'un commerçant.
+
+    La normalisation supprime la ponctuation et met la chaîne en majuscules afin de
+    faciliter les comparaisons.
+
+    Args:
+        name: Nom du commerçant tel qu'extrait d'une transaction.
+
+    Returns:
+        Nom normalisé en majuscules ou ``None`` si la chaîne est vide.
+    """
+    if not isinstance(name, str) or not name.strip():
+        return None
+
+    cleaned = re.sub(r"[^\w\s]", " ", name.strip())
+    cleaned = re.sub(r"\s+", " ", cleaned)
+
+    # Suppression des accents pour harmoniser les comparaisons
+    normalized = unicodedata.normalize("NFD", cleaned)
+    normalized = normalized.encode("ascii", "ignore").decode("ascii")
+
+    return normalized.upper()

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -1,0 +1,33 @@
+import pytest
+
+from conversation_service.utils.normalization import (
+    normalize_amount,
+    normalize_date,
+    normalize_merchant,
+    normalize_transaction,
+)
+
+
+def test_normalize_date():
+    assert normalize_date("01/02/2024") == "2024-02-01"
+    assert normalize_date("2024-02-01") == "2024-02-01"
+    assert normalize_date("date invalide") is None
+
+
+def test_normalize_amount():
+    assert normalize_amount("1 234,56 €") == pytest.approx(1234.56)
+    assert normalize_amount("$1,234.56") == pytest.approx(1234.56)
+    assert normalize_amount("montant") is None
+
+
+def test_normalize_merchant():
+    assert normalize_merchant("  café-Paris  ") == "CAFE PARIS"
+    assert normalize_merchant("") is None
+
+
+def test_normalize_transaction():
+    data = {"date": "01/02/2024", "amount": "1 234,56 €", "merchant": "café-Paris"}
+    normalized = normalize_transaction(data)
+    assert normalized["date"] == "2024-02-01"
+    assert normalized["amount"] == pytest.approx(1234.56)
+    assert normalized["merchant"] == "CAFE PARIS"


### PR DESCRIPTION
## Summary
- add date, amount and merchant normalizers
- provide global transaction normalizer
- expose utilities and cover with tests

## Testing
- `pytest tests/test_normalization.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af388b72288320870737f687b5424c