### PR TITLE
Add entity extraction autogen prompts and examples

### DIFF
--- a/conversation_service/prompts/autogen/__init__.py
+++ b/conversation_service/prompts/autogen/__init__.py
@@ -1,0 +1,8 @@
+from .entity_extraction_prompts import ENTITY_EXTRACTION_SYSTEM_MESSAGE
+from .few_shot_examples import ENTITY_EXTRACTION_FEW_SHOT_EXAMPLES
+
+__all__ = [
+    "ENTITY_EXTRACTION_SYSTEM_MESSAGE",
+    "ENTITY_EXTRACTION_FEW_SHOT_EXAMPLES",
+]
+

--- a/conversation_service/prompts/autogen/entity_extraction_prompts.py
+++ b/conversation_service/prompts/autogen/entity_extraction_prompts.py
@@ -1,0 +1,15 @@
+"""Prompts système pour l'extraction d'entités financières."""
+
+ENTITY_EXTRACTION_SYSTEM_MESSAGE = """Tu es un assistant IA spécialisé dans l'extraction d'entités financières.
+Réponds uniquement avec un objet JSON décrivant les entités détectées.
+
+Structure attendue:
+{
+  "amounts": [{"value": 100.0, "currency": "EUR", "operator": "eq"}],
+  "dates": [{"type": "specific", "value": "2024-01-15", "text": "15 janvier 2024"}],
+  "merchants": ["Carrefour"],
+  "categories": ["alimentaire"],
+  "operation_types": ["carte"],
+  "text_search": ["recherche libre"]
+}
+"""

--- a/conversation_service/prompts/autogen/few_shot_examples.py
+++ b/conversation_service/prompts/autogen/few_shot_examples.py
@@ -1,0 +1,30 @@
+"""Exemples few-shot pour l'extraction d'entités financières."""
+
+ENTITY_EXTRACTION_FEW_SHOT_EXAMPLES = [
+    {
+        "input": "J'ai dépensé 20€ chez Carrefour hier.",
+        "output": {
+            "entities": {
+                "amounts": [{"value": 20, "currency": "EUR", "operator": "eq"}],
+                "dates": [{"type": "relative", "value": "hier", "text": "hier"}],
+                "merchants": ["Carrefour"],
+                "categories": [],
+                "operation_types": [],
+                "text_search": []
+            }
+        }
+    },
+    {
+        "input": "Montre-moi mes paiements supérieurs à 100 euros en juillet.",
+        "output": {
+            "entities": {
+                "amounts": [{"value": 100, "currency": "EUR", "operator": "gt"}],
+                "dates": [{"type": "month", "value": "2024-07", "text": "juillet"}],
+                "merchants": [],
+                "categories": [],
+                "operation_types": ["paiement"],
+                "text_search": []
+            }
+        }
+    }
+]


### PR DESCRIPTION
## Summary
- add system message for entity extraction autogen prompts
- provide few-shot examples for entity extraction
- expose autogen prompts package

## Testing
- `pytest` *(fails: ImportError: cannot import name 'computed_field' from 'pydantic', ModuleNotFoundError: No module named 'jose', ModuleNotFoundError: No module named 'sqlalchemy', ModuleNotFoundError: No module named 'fastapi', ModuleNotFoundError: No module named 'prometheus_client')*

------
https://chatgpt.com/codex/tasks/task_e_68af388ca28883208c728e4e8efcc6a5