### PR TITLE
Use default_factory for AutoGenTeamResponse

### DIFF
--- a/conversation_service/models/responses/conversation_responses.py
+++ b/conversation_service/models/responses/conversation_responses.py
@@ -1,7 +1,7 @@
 """
 Modèles Pydantic V2 optimisés pour les réponses conversation service
 """
-from pydantic import BaseModel, field_validator, ConfigDict, computed_field
+from pydantic import BaseModel, field_validator, ConfigDict, computed_field, Field
 from typing import Optional, List, Dict, Any, Union
 from datetime import datetime, timezone
 from enum import Enum
@@ -549,8 +549,8 @@ class AutoGenMessage(BaseModel):
 class AutoGenTeamResponse(BaseModel):
     """Container for the AutoGen team output."""
     final_answer: str
-    steps: List[AutoGenMessage] = []
-    context: Dict[str, Any] = {}
+    steps: List[AutoGenMessage] = Field(default_factory=list)
+    context: Dict[str, Any] = Field(default_factory=dict)
 
 
 class ConversationResponsePhase2AutoGen(BaseModel):


### PR DESCRIPTION
## Summary
- use `Field(default_factory=...)` for `AutoGenTeamResponse.steps` and `context`
- import `Field` in conversation response models

## Testing
- `pytest` *(fails: ImportError: cannot import name 'computed_field' from 'pydantic'; ModuleNotFoundError: No module named 'jose'; ModuleNotFoundError: No module named 'sqlalchemy'; ModuleNotFoundError: No module named 'fastapi'; ModuleNotFoundError: No module named 'field_serializer'; ModuleNotFoundError: No module named 'prometheus_client'; ModuleNotFoundError: No module named 'dateutil')*

------
https://chatgpt.com/codex/tasks/task_e_68af42f88290832096fd3dfc3e04e905