### PR TITLE
Add default system message and DeepSeek failure handling

### DIFF
--- a/conversation_service/autogen_core/agent_runtime.py
+++ b/conversation_service/autogen_core/agent_runtime.py
@@ -6,6 +6,9 @@ from typing import Any, Dict
 
 from .agent_factory import AutoGenAgentFactory
 from .conversation_state import ConversationState
+from ..prompts.autogen.entity_extraction_prompts import (
+    ENTITY_EXTRACTION_SYSTEM_MESSAGE,
+)
 
 logger = logging.getLogger("conversation_service.autogen.runtime")
 
@@ -18,20 +21,28 @@ class ConversationServiceRuntime:
         self.assistant = None
         self.user_proxy = None
 
-    async def initialize_team(self, system_message: str) -> None:
+    async def initialize_team(self, system_message: str | None = None) -> None:
         """Initialise les agents principaux."""
+        system_message = system_message or ENTITY_EXTRACTION_SYSTEM_MESSAGE
         self.user_proxy = await self.factory.create_user_proxy("user")
         self.assistant = await self.factory.create_assistant("assistant", system_message)
         logger.info("Equipe AutoGen initialisée")
 
-    async def process_conversation(self, state: ConversationState, user_message: str) -> str:
+    async def process_conversation(
+        self, state: ConversationState, user_message: str
+    ) -> str | Dict[str, str]:
         """Traite une requête utilisateur et retourne la réponse normalisée."""
         if not self.assistant or not self.user_proxy:
-            await self.initialize_team(system_message="")
+            await self.initialize_team()
 
         state.add_user_message(user_message)
         messages = state.to_messages()
-        raw_response = await self.factory.deepseek.chat(messages)
+        try:
+            raw_response = await self.factory.deepseek.chat(messages)
+        except Exception:
+            logger.exception("DeepSeek chat failed")
+            return {"error": "llm_failure"}
+
         content = self._normalize_response(raw_response)
         state.add_agent_message(content)
         return content

--- a/tests/conversation_service/test_agent_runtime.py
+++ b/tests/conversation_service/test_agent_runtime.py
@@ -1,0 +1,36 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from conversation_service.autogen_core.agent_runtime import ConversationServiceRuntime
+from conversation_service.autogen_core.conversation_state import ConversationState
+from conversation_service.prompts.autogen.entity_extraction_prompts import (
+    ENTITY_EXTRACTION_SYSTEM_MESSAGE,
+)
+
+
+class DummyDeepSeek:
+    def __init__(self):
+        self.chat = AsyncMock(side_effect=Exception("boom"))
+
+
+class DummyFactory:
+    def __init__(self):
+        self.create_user_proxy = AsyncMock(return_value=object())
+        self.create_assistant = AsyncMock(return_value=object())
+        self.deepseek = DummyDeepSeek()
+
+
+@pytest.mark.asyncio
+async def test_process_conversation_deepseek_failure():
+    factory = DummyFactory()
+    runtime = ConversationServiceRuntime(factory=factory)
+    state = ConversationState()
+
+    result = await runtime.process_conversation(state, "hello")
+
+    assert result == {"error": "llm_failure"}
+    factory.create_assistant.assert_awaited_once_with(
+        "assistant", ENTITY_EXTRACTION_SYSTEM_MESSAGE
+    )
+    # Failure should not add assistant message to state
+    assert len(state.turns) == 1


### PR DESCRIPTION
## Summary
- default to entity extraction system message when initializing team without one
- handle DeepSeek chat failures and return structured error
- add unit test for DeepSeek failure path

## Testing
- `pytest tests/conversation_service/test_agent_runtime.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af4314c47883208bbba901f783f3fa