### PR TITLE
Implement richer GroupChatManager stub and tests for financial analysis team

### DIFF
--- a/tests/agents/test_financial_analysis_team.py
+++ b/tests/agents/test_financial_analysis_team.py
@@ -1,0 +1,11 @@
+import asyncio
+
+from conversation_service.teams import FinancialAnalysisTeamPhase2
+
+
+def test_run_returns_intent_and_entities():
+    team = FinancialAnalysisTeamPhase2()
+    result = asyncio.run(team.run("Analyse AAPL price 100"))
+    assert result["intent"] is not None
+    assert result["entities"] is not None
+    assert isinstance(result["entities"], dict)


### PR DESCRIPTION
## Summary
- Enhance fallback `GroupChatManager` stub with basic intent and entity extraction logic
- Parse manager output in `FinancialAnalysisTeamPhase2.run`
- Add unit test ensuring team returns non-null intent and entities

## Testing
- `python -m pytest tests/agents/test_financial_analysis_team.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af431a88688320a943f84ad4519040