### PR TITLE
Ensure default conversation runtime

### DIFF
--- a/conversation_service/api/dependencies.py
+++ b/conversation_service/api/dependencies.py
@@ -1062,7 +1062,8 @@ def get_conversation_runtime(request: Request) -> ConversationServiceRuntime:
     """Retrieve ConversationServiceRuntime from the FastAPI application."""
     runtime = getattr(request.app.state, "conversation_runtime", None)
     if runtime is None:
-        raise HTTPException(status_code=503, detail="Conversation runtime not initialised")
+        runtime = ConversationServiceRuntime()
+        request.app.state.conversation_runtime = runtime
     return runtime
 
 # Export des principales dépendances


### PR DESCRIPTION
## Summary
- provide fallback `ConversationServiceRuntime` when none is present and attach it to FastAPI app state
- add regression test confirming runtime is injected automatically

## Testing
- `pytest tests/api/test_conversation_endpoint.py::TestConversationEndpoint::test_conversation_runtime_injected -q`


------
https://chatgpt.com/codex/tasks/task_e_68af5397dfc08320b1b53171b7c15e05