### PR TITLE
feat: add conversation monitoring endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,17 @@ uvicorn conversation_service.main:app --reload
 The FastAPI app is built by `create_app()` in `conversation_service/main.py`.
 
 
+### Monitoring endpoints
+
+Three lightweight endpoints expose the status of the conversation service:
+
+- `GET /api/v1/conversation/status` returns `{ "status": "ready" }` when the service is up
+- `GET /api/v1/conversation/health` provides basic health metrics
+- `GET /api/v1/conversation/metrics` dumps the metrics collected by the service
+
+All three routes are public and do not require authentication.
+
+
 ## Table `conversation_messages`
 
 La table `conversation_messages` enregistre chaque message individuel échangé dans une conversation.

--- a/conversation_service/api/routes/conversation.py
+++ b/conversation_service/api/routes/conversation.py
@@ -86,3 +86,39 @@ async def analyze_conversation(
         team_response=team_response,
         status=ProcessingStatus.SUCCESS,
     )
+
+
+@router.get("/conversation/status")
+async def conversation_status():
+    """Simple endpoint de disponibilité."""
+    return {
+        "service": "conversation_service",
+        "status": "ready",
+        "ready": True,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+@router.get("/conversation/health")
+async def conversation_health():
+    """Retourne un aperçu de l'état du service."""
+    health_metrics = metrics_collector.get_health_metrics()
+    return {
+        "service": "conversation_service",
+        "status": health_metrics.get("status", "unknown"),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "health_details": health_metrics,
+        "features": [],
+    }
+
+
+@router.get("/conversation/metrics")
+async def conversation_metrics():
+    """Expose les métriques collectées."""
+    metrics_data = metrics_collector.get_all_metrics()
+    return {
+        "timestamp": metrics_data.get("timestamp", datetime.now(timezone.utc).isoformat()),
+        "metrics": metrics_data,
+        "service_info": {"name": "conversation_service", "version": "1.0.0", "phase": 1},
+        "performance_summary": {},
+    }


### PR DESCRIPTION
## Summary
- add public status, health and metrics routes under `/api/v1/conversation`
- document monitoring endpoints in README

## Testing
- `pytest tests/api/test_conversation_endpoint.py::TestMonitoringEndpoints -q`


------
https://chatgpt.com/codex/tasks/task_e_68af53ac05988320a308abc0b493fdb7