### PR TITLE
Handle persistent JSON parse errors

### DIFF
--- a/conversation_service/agents/financial/intent_classifier.py
+++ b/conversation_service/agents/financial/intent_classifier.py
@@ -171,7 +171,11 @@ class IntentClassifierAgent(BaseAgent):
         # Toutes les tentatives ont échoué
         logger.error(f"Toutes les tentatives de classification ont échoué après {self.max_retry_attempts} essais")
         metrics_collector.increment_counter("intent_classifier.retry_exhausted")
-        return self._create_error_intent_result(f"Erreur après {self.max_retry_attempts} tentatives: {str(last_exception)}")
+        if isinstance(last_exception, json.JSONDecodeError):
+            return self._create_error_intent_result("JSON parsing error")
+        return self._create_error_intent_result(
+            f"Erreur après {self.max_retry_attempts} tentatives: {str(last_exception)}"
+        )
     
     def _build_json_classification_prompt(
         self, 


### PR DESCRIPTION
## Summary
- return a standardized error when JSON parsing fails after all retries in the financial intent classifier
- cover JSON parsing failure with a dedicated test verifying retry exhaustion

## Testing
- `python -m pytest tests/agents/test_intent_classifier.py::TestIntentClassifierAgent::test_classify_intent_json_parse_error tests/agents/test_intent_classifier.py::TestIntentClassifierAgent::test_classify_intent_json_parse_error_retry_message -q`


------
https://chatgpt.com/codex/tasks/task_e_68af53b91ac08320ade5ab6f648e9084