### PR TITLE
Include conversation service tests in pytest configuration

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-testpaths = tests
+testpaths = tests conversation_service/tests
 markers =
     slow: marks tests as slow


### PR DESCRIPTION
## Summary
- ensure conversation_service tests are included by default

## Testing
- `pytest -q`
- `pytest conversation_service/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68af53c7508c8320a89a2e13f597a07e