### PR TITLE
Fix indentation for test function

### DIFF
--- a/tests/api/test_conversation_endpoint.py
+++ b/tests/api/test_conversation_endpoint.py
@@ -327,10 +327,12 @@ class TestJWTCompatibility:
 # ---------------------------------------------------------------------------
 class TestConversationEndpoint:
     def test_conversation_success(self, client, mock_runtime):
-    """Tests complets pour l'endpoint de conversation"""
+        """Tests complets pour l'endpoint de conversation"""
+        pass
 
     def test_conversation_success(self, client, runtime):
         """Test conversation réussie avec réponse d'équipe AutoGen"""
+
     def test_conversation_success_greeting(self, client):
         """Test conversation réussie avec salutation"""
         


### PR DESCRIPTION
## Summary
- fix misindented docstring in `TestConversationEndpoint.test_conversation_success`
- add placeholder pass for empty test

## Testing
- `pytest tests/api/test_conversation_endpoint.py -q` *(fails: NameError: name 'MagicMock' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68af585c7f288320b5ea3a28ed8a507c