### PR TITLE
Add MagicMock import for conversation endpoint tests

### DIFF
--- a/tests/api/test_conversation_endpoint.py
+++ b/tests/api/test_conversation_endpoint.py
@@ -3,7 +3,7 @@ import os
 import sys
 from datetime import datetime, timedelta
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi.testclient import TestClient


### PR DESCRIPTION
## Summary
- include MagicMock in conversation endpoint test imports

## Testing
- `pytest tests/api/test_conversation_endpoint.py -q` *(fails: NameError: get_deepseek_client not defined; 4 passed, 11 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af5a283ec483208d189753774ddbb0