### PR TITLE
test: fix conversation endpoint dependency overrides

### DIFF
--- a/tests/api/test_conversation_endpoint.py
+++ b/tests/api/test_conversation_endpoint.py
@@ -1,6 +1,7 @@
 """Tests for conversation endpoint using AutoGen runtime."""
 import os
 import sys
+import json
 from datetime import datetime, timedelta
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
@@ -212,24 +213,29 @@ def test_app(mock_runtime):
     """Create a FastAPI app with dependency overrides for tests."""
     app = create_test_app()
 
+    mock_service_loader = MockConversationServiceLoader()
+    app.state.deepseek_client = mock_service_loader.deepseek_client
+    app.state.cache_manager = mock_service_loader.cache_manager
+
     from conversation_service.api.dependencies import (
         get_conversation_runtime,
         get_conversation_service_status,
+        get_deepseek_client,
+        get_cache_manager,
         validate_path_user_id,
         get_user_context,
         rate_limit_dependency,
-        get_conversation_runtime,
     )
     from conversation_service.api.middleware.auth_middleware import verify_user_id_match
     from fastapi import Request
 
-    def override_get_runtime(request: Request):
-        return mock_runtime
-    
     def override_get_deepseek_client(request: Request):
         return mock_service_loader.deepseek_client
 
-    def override_get_status(request: Request):
+    def override_get_cache_manager(request: Request):
+        return mock_service_loader.cache_manager
+
+    def override_get_service_status(request: Request):
         return {"status": "healthy"}
 
     async def override_validate_user(
@@ -245,14 +251,6 @@ def test_app(mock_runtime):
     def override_rate_limit(request: Request, user_id: int = 1):
         return None
 
-    app.dependency_overrides[get_conversation_runtime] = override_get_runtime
-    app.dependency_overrides[get_conversation_service_status] = override_get_status
-    mock_runtime = MagicMock()
-    mock_runtime.run_financial_team = AsyncMock(return_value={
-        "final_answer": "mock",
-        "intermediate_steps": [],
-        "context": {}
-    })
     app.state.conversation_runtime = mock_runtime
 
     def override_get_conversation_runtime(request: Request):


### PR DESCRIPTION
## Summary
- ensure conversation endpoint tests override cache and DeepSeek dependencies correctly

## Testing
- `pytest tests/api/test_conversation_endpoint.py::TestConversationEndpoint::test_conversation_success -q`


------
https://chatgpt.com/codex/tasks/task_e_68af5cd131d483209b0f2dade2a8120d