### PR TITLE
test: use passed service loader in app fixture

### DIFF
--- a/tests/api/test_conversation_endpoint.py
+++ b/tests/api/test_conversation_endpoint.py
@@ -220,8 +220,6 @@ def mock_service_loader():
 def test_app(mock_runtime, mock_service_loader):
     """Create a FastAPI app with dependency overrides for tests."""
     app = create_test_app()
-
-    mock_service_loader = MockConversationServiceLoader()
     app.state.deepseek_client = mock_service_loader.deepseek_client
     app.state.cache_manager = mock_service_loader.cache_manager
 
@@ -264,8 +262,6 @@ def test_app(mock_runtime, mock_service_loader):
 
     def override_rate_limit(request: Request, user_id: int = 1):
         return None
-
-    app.dependency_overrides[get_conversation_runtime] = override_get_runtime
     app.dependency_overrides[get_conversation_service_status] = override_get_service_status
     mock_runtime = MagicMock()
     mock_runtime.run_financial_team = AsyncMock(return_value={


### PR DESCRIPTION
## Summary
- ensure test_app uses provided mock service loader directly
- drop stray dependency override to undefined runtime helper

## Testing
- `pytest tests/api/test_conversation_endpoint.py::TestConversationEndpoint -q` *(fails: NameError: name 'IntentClassificationResult' is not defined; assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af63a70b6c8320a591061ac60cf776