### PR TITLE
chore: deduplicate test imports

### DIFF
--- a/tests/api/test_conversation_endpoint.py
+++ b/tests/api/test_conversation_endpoint.py
@@ -6,10 +6,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import json
-
 import pytest
-from fastapi.testclient import TestClient
 from jose import jwt
 
 # ---------------------------------------------------------------------------
@@ -27,15 +24,8 @@ if str(current_dir) not in sys.path:
 
 from conversation_service.api.routes.conversation import router as conversation_router
 from conversation_service.api.middleware.auth_middleware import JWTAuthMiddleware
-# Import dynamique avec gestion d'erreur
-try:
-    from fastapi.testclient import TestClient
-    from conversation_service.models.requests.conversation_requests import ConversationRequest
-except ImportError as e:
-    # Fallback si imports directs ne fonctionnent pas
-    sys.path.insert(0, str(Path(__file__).parent.parent))
-    from fastapi.testclient import TestClient
-    from conversation_service.models.requests.conversation_requests import ConversationRequest
+from fastapi.testclient import TestClient
+from conversation_service.models.requests.conversation_requests import ConversationRequest
 
 
 # ---------------------------------------------------------------------------
@@ -226,28 +216,18 @@ def test_app(mock_runtime, mock_service_loader):
     app.state.cache_manager = mock_service_loader.cache_manager
 
     from conversation_service.api.dependencies import (
-        get_cache_manager,
         get_conversation_runtime,
         get_conversation_service_status,
         get_deepseek_client,
         get_user_context,
         rate_limit_dependency,
         validate_path_user_id,
-        get_cache_manager,
-        validate_path_user_id,
-        get_user_context,
-        rate_limit_dependency,
-        get_deepseek_client,
-
     )
     from conversation_service.api.middleware.auth_middleware import verify_user_id_match
     from fastapi import Request
 
     def override_get_deepseek_client(request: Request):
         return mock_service_loader.deepseek_client
-
-    def override_get_cache_manager(request: Request):
-        return mock_service_loader.cache_manager
 
     def override_get_service_status(request: Request):
         return {"status": "healthy"}
@@ -265,7 +245,6 @@ def test_app(mock_runtime, mock_service_loader):
     def override_rate_limit(request: Request, user_id: int = 1):
         return None
 
-    app.dependency_overrides[get_conversation_runtime] = override_get_runtime
     app.dependency_overrides[get_conversation_service_status] = override_get_service_status
     mock_runtime = MagicMock()
     mock_runtime.run_financial_team = AsyncMock(return_value={


### PR DESCRIPTION
## Summary
- streamline imports in conversation endpoint tests
- ensure each dependency is imported once and used within fixture

## Testing
- `pytest tests/api/test_conversation_endpoint.py::TestConversationEndpoint::test_conversation_success -q`

------
https://chatgpt.com/codex/tasks/task_e_68af63ae165483208e6f81b0718a1c1d