### PR TITLE
Import missing intent classes in conversation endpoint tests

### DIFF
--- a/tests/api/test_conversation_endpoint.py
+++ b/tests/api/test_conversation_endpoint.py
@@ -8,6 +8,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from jose import jwt
+from conversation_service.models.responses.conversation_responses import IntentClassificationResult
+from conversation_service.prompts.harena_intents import HarenaIntentType
 
 # ---------------------------------------------------------------------------
 # Environment configuration for tests


### PR DESCRIPTION
## Summary
- fix NameError in conversation endpoint tests by importing IntentClassificationResult and HarenaIntentType

## Testing
- `pytest tests/api/test_conversation_endpoint.py` *(fails: KeyError 'intent')*

------
https://chatgpt.com/codex/tasks/task_e_68af6868a5dc83209bfc3955528e2b81