### PR TITLE
Add autogen core package with runtime and agent factory stubs

### DIFF
--- a/conversation_service/autogen_core/__init__.py
+++ b/conversation_service/autogen_core/__init__.py
@@ -1,0 +1,22 @@
+"""Core Autogen pour le service de conversation.
+
+Ce package expose les composants principaux :
+`ConversationServiceRuntime` et `AutoGenAgentFactory`.
+"""
+
+from __future__ import annotations
+
+
+class ConversationServiceRuntime:
+    """Runtime minimal pour le service de conversation basé sur AutoGen."""
+
+    pass
+
+
+class AutoGenAgentFactory:
+    """Fabrique d'agents AutoGen."""
+
+    pass
+
+
+__all__ = ["ConversationServiceRuntime", "AutoGenAgentFactory"]


### PR DESCRIPTION
## Summary
- add new `conversation_service.autogen_core` package to expose `ConversationServiceRuntime` and `AutoGenAgentFactory`
- provide minimal placeholder implementations and public exports

## Testing
- `pytest` *(fails: 18 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a240c4a8832088322ad8682391ed