### PR TITLE
feat: add AutoGen agent factory

### DIFF
--- a/conversation_service/autogen_core/__init__.py
+++ b/conversation_service/autogen_core/__init__.py
@@ -7,12 +7,7 @@ Ce package expose les composants principaux :
 from __future__ import annotations
 
 from .agent_runtime import ConversationServiceRuntime
-
-
-class AutoGenAgentFactory:
-    """Fabrique d'agents AutoGen."""
-
-    pass
+from .agent_factory import AutoGenAgentFactory
 
 
 __all__ = ["ConversationServiceRuntime", "AutoGenAgentFactory"]

--- a/conversation_service/autogen_core/agent_factory.py
+++ b/conversation_service/autogen_core/agent_factory.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+"""Fabrique centralisée pour les agents AutoGen."""
+
+from typing import Any, Dict
+
+
+class AutoGenAgentFactory:
+    """Fabrique d'agents basés sur AutoGen."""
+
+    @staticmethod
+    def create_standard_llm_config() -> Dict[str, Any]:
+        """Retourne la configuration LLM standard compatible DeepSeek."""
+        return {
+            "model": "deepseek-chat",
+            "temperature": 0.7,
+            "max_tokens": 4096,
+            "top_p": 0.95,
+            "timeout": 30,
+        }
+
+    @staticmethod
+    def create_financial_agent(client: Any):
+        """Crée et retourne l'agent financier en injectant le client DeepSeek."""
+        config = AutoGenAgentFactory.create_standard_llm_config()
+        try:
+            from conversation_service.agents.financial import FinancialAgent
+        except Exception as exc:  # pragma: no cover - agent non implémenté
+            raise NotImplementedError(
+                "La classe FinancialAgent doit être définie dans conversation_service.agents.financial"
+            ) from exc
+
+        return FinancialAgent(deepseek_client=client, llm_config=config)
+
+    @staticmethod
+    def create_sales_agent(client: Any):
+        """Placeholder pour créer un agent commercial."""
+        raise NotImplementedError("Agent commercial non implémenté")
+
+    @staticmethod
+    def create_marketing_agent(client: Any):
+        """Placeholder pour créer un agent marketing."""
+        raise NotImplementedError("Agent marketing non implémenté")


### PR DESCRIPTION
## Summary
- add AutoGenAgentFactory with standard DeepSeek config and financial agent constructor
- expose factory via autogen_core package

## Testing
- `pytest` *(fails: cannot import name 'computed_field' from 'pydantic'; ModuleNotFoundError: No module named 'jose', 'sqlalchemy', 'fastapi', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a531ecb48320a20a8998501c6e1c