### PR TITLE
feat: add AutoGen intent classification prompt

### DIFF
--- a/conversation_service/prompts/autogen/__init__.py
+++ b/conversation_service/prompts/autogen/__init__.py
@@ -1,0 +1,1 @@
+"""Prompts AutoGen pour classification."""

--- a/conversation_service/prompts/autogen/intent_classification_prompts.py
+++ b/conversation_service/prompts/autogen/intent_classification_prompts.py
@@ -1,0 +1,16 @@
+"""Prompts système pour l'agent de classification d'intentions AutoGen."""
+
+AUTOGEN_INTENT_SYSTEM_MESSAGE = """Tu es un agent AutoGen dans une équipe.
+
+Analyse chaque message et réponds uniquement avec un objet JSON valide.
+
+Champs requis :
+{
+  "intent": "NOM_INTENTION",
+  "confidence": 0.0-1.0,
+  "reasoning": "Explication de la classification",
+  "team_context": {...}
+}
+
+Le champ "team_context" doit être un objet JSON décrivant le contexte d'équipe pertinent (par exemple {"projet": "harena"}).
+"""


### PR DESCRIPTION
## Summary
- add AutoGen system prompt for intent classification requiring JSON fields including team_context
- scaffold autogen prompts package

## Testing
- `pytest` *(fails: ImportError: cannot import name 'computed_field' from 'pydantic'; ModuleNotFoundError: No module named 'jose', No module named 'sqlalchemy', No module named 'fastapi', No module named 'prometheus_client', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b0aa0054088320b20460519f48d2c4