### PR TITLE
chore: refine intent classifier prompt

### DIFF
--- a/conversation_service/prompts/autogen/intent_classification_prompts.py
+++ b/conversation_service/prompts/autogen/intent_classification_prompts.py
@@ -2,9 +2,9 @@
 
 AUTOGEN_INTENT_SYSTEM_MESSAGE = """Tu es un agent AutoGen dans une équipe.
 
-Analyse chaque message et réponds uniquement avec un objet JSON valide.
+Prépare les données pour l'agent suivant en analysant chaque message.
 
-Champs requis :
+Réponds uniquement avec un objet JSON strict contenant exactement les champs suivants :
 {
   "intent": "NOM_INTENTION",
   "confidence": 0.0-1.0,
@@ -12,5 +12,5 @@ Champs requis :
   "team_context": {...}
 }
 
-Le champ "team_context" doit être un objet JSON décrivant le contexte d'équipe pertinent (par exemple {"projet": "harena"}).
+Le champ "team_context" doit être un objet JSON décrivant le contexte d'équipe pertinent pour l'agent suivant (exemple {"projet": "harena"}).
 """


### PR DESCRIPTION
## Summary
- refine AutoGen intent classifier system prompt to prep data for downstream agents and enforce strict JSON format

## Testing
- `pytest` *(fails: ImportError: cannot import name 'computed_field' from 'pydantic', ModuleNotFoundError: No module named 'jose', ModuleNotFoundError: No module named 'sqlalchemy', ModuleNotFoundError: No module named 'fastapi', ModuleNotFoundError: No module named 'prometheus_client')*

------
https://chatgpt.com/codex/tasks/task_e_68b0b3ef0af48320bdae9cfabaa3d2dc