### PR TITLE
feat: enhance intent classifier agent

### DIFF
--- a/conversation_service/agents/financial/intent_classifier.py
+++ b/conversation_service/agents/financial/intent_classifier.py
@@ -1,5 +1,14 @@
 """Autogen-based agent for financial intent classification."""
 
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from collections import Counter
+from typing import Any, Dict
+
 from autogen import AssistantAgent
 from conversation_service.prompts.autogen.intent_classification_prompts import (
     AUTOGEN_INTENT_SYSTEM_MESSAGE,
@@ -26,8 +35,17 @@ class IntentClassifierAgent(AssistantAgent):
         if Teachability is not None:
             self.add_capability(Teachability(verbosity=0))
 
+        # Metrics and caching
+        self.success_count = 0
+        self.error_count = 0
+        self.intent_cache: Dict[str, Dict[str, Any]] = {}
+        self.intent_frequency: Counter[str] = Counter()
+
+        # Dedicated logger
+        self.logger = logging.getLogger("IntentClassifierAgent")
+
     @staticmethod
-    def _create_llm_config():
+    def _create_llm_config() -> Dict[str, Any]:
         return {
             "config_list": [
                 {
@@ -39,6 +57,123 @@ class IntentClassifierAgent(AssistantAgent):
                 }
             ]
         }
+
+    async def classify_for_team(self, user_message: str, user_id: int) -> Dict[str, Any]:
+        """Classify an intent and enrich it with team context.
+
+        The method calls the LLM with a timeout, parses the JSON response and
+        augments it with additional metadata useful for downstream teams.
+        In case of timeout or JSON errors, a fallback response is returned.
+        """
+
+        if user_message in self.intent_cache:
+            self.logger.debug("Cache hit for message")
+            self.success_count += 1
+            return self.intent_cache[user_message]
+
+        start_time = time.monotonic()
+        try:
+            raw_reply = await asyncio.wait_for(
+                self.a_generate_reply(user_message), timeout=30
+            )
+            content = raw_reply if isinstance(raw_reply, str) else str(raw_reply)
+            parsed = json.loads(content)
+            intent_type = parsed.get("intent_type", "UNKNOWN")
+            confidence = float(parsed.get("confidence", 0.0))
+
+            team_context = {
+                "original_message": user_message,
+                "user_id": user_id,
+                "ready_for_entity_extraction": confidence >= 0.5,
+                "suggested_entities_focus": self.suggest_entities_focus(
+                    intent_type, confidence
+                ),
+            }
+
+            result = {**parsed, "team_context": team_context}
+            self.intent_cache[user_message] = result
+            self.intent_frequency[intent_type] += 1
+            self.success_count += 1
+
+            elapsed = time.monotonic() - start_time
+            self.logger.info(
+                "Intent classified in %.2fs for user %s", elapsed, user_id
+            )
+            return result
+        except asyncio.TimeoutError:
+            self.error_count += 1
+            self.logger.error("Intent classification timeout for user %s", user_id)
+        except Exception as exc:  # pragma: no cover - unexpected runtime issues
+            self.error_count += 1
+            self.logger.exception(
+                "Intent classification failed for user %s: %s", user_id, exc
+            )
+
+        # Fallback response on error
+        fallback = {
+            "intent_type": "UNKNOWN",
+            "confidence": 0.0,
+            "team_context": {
+                "original_message": user_message,
+                "user_id": user_id,
+                "ready_for_entity_extraction": False,
+                "suggested_entities_focus": self.suggest_entities_focus(
+                    "UNKNOWN", 0.0
+                ),
+            },
+        }
+        return fallback
+
+    def suggest_entities_focus(self, intent_type: str, confidence: float) -> Dict[str, Any]:
+        """Suggest entity extraction focus based on intent and confidence."""
+
+        if confidence < 0.5:
+            return {"priority_entities": [], "strategy": "clarify"}
+
+        intent_type = intent_type.upper()
+        if intent_type.startswith("SEARCH") or intent_type.endswith("TRANSACTION") or intent_type in {
+            "TRANSACTION_SEARCH",
+            "SEARCH_BY_DATE",
+            "SEARCH_BY_AMOUNT",
+            "SEARCH_BY_MERCHANT",
+            "SEARCH_BY_CATEGORY",
+            "SEARCH_BY_AMOUNT_AND_DATE",
+            "SEARCH_BY_OPERATION_TYPE",
+            "SEARCH_BY_TEXT",
+            "COUNT_TRANSACTIONS",
+            "MERCHANT_INQUIRY",
+            "FILTER_REQUEST",
+        }:
+            return {
+                "priority_entities": ["date", "amount", "merchant", "category"],
+                "strategy": "transaction_filters",
+            }
+
+        if intent_type in {
+            "SPENDING_ANALYSIS",
+            "SPENDING_ANALYSIS_BY_CATEGORY",
+            "SPENDING_ANALYSIS_BY_PERIOD",
+            "SPENDING_COMPARISON",
+            "TREND_ANALYSIS",
+            "CATEGORY_ANALYSIS",
+            "COMPARISON_QUERY",
+        }:
+            return {
+                "priority_entities": ["category", "date_range"],
+                "strategy": "spending_analysis",
+            }
+
+        if intent_type in {
+            "BALANCE_INQUIRY",
+            "ACCOUNT_BALANCE_SPECIFIC",
+            "BALANCE_EVOLUTION",
+        }:
+            return {
+                "priority_entities": ["account"],
+                "strategy": "account_lookup",
+            }
+
+        return {"priority_entities": [], "strategy": "generic"}
 
     async def classify_intent(self, *args, **kwargs):  # pragma: no cover
         """Placeholder classification method."""

--- a/tests/agents/test_intent_classifier.py
+++ b/tests/agents/test_intent_classifier.py
@@ -1,5 +1,9 @@
 """Tests for the Autogen-based IntentClassifierAgent."""
 
+import asyncio
+
+import pytest
+
 from conversation_service.agents.financial.intent_classifier import (
     IntentClassifierAgent,
 )
@@ -24,3 +28,54 @@ def test_intent_classifier_agent_configuration():
             }
         ]
     }
+
+
+@pytest.mark.asyncio
+async def test_classify_for_team_success(monkeypatch):
+    agent = IntentClassifierAgent()
+
+    async def fake_reply(message):
+        return '{"intent_type": "TRANSACTION_SEARCH", "confidence": 0.9}'
+
+    monkeypatch.setattr(agent, "a_generate_reply", fake_reply, raising=False)
+
+    result = await agent.classify_for_team("list my transactions", 42)
+
+    assert result["intent_type"] == "TRANSACTION_SEARCH"
+    assert result["team_context"]["original_message"] == "list my transactions"
+    assert result["team_context"]["user_id"] == 42
+    assert result["team_context"]["ready_for_entity_extraction"] is True
+    assert (
+        result["team_context"]["suggested_entities_focus"]
+        == agent.suggest_entities_focus("TRANSACTION_SEARCH", 0.9)
+    )
+    assert agent.success_count == 1
+    assert agent.error_count == 0
+
+    # Subsequent call should use cache
+    cached = await agent.classify_for_team("list my transactions", 42)
+    assert cached == result
+    assert agent.success_count == 2
+
+
+@pytest.mark.asyncio
+async def test_classify_for_team_timeout(monkeypatch):
+    agent = IntentClassifierAgent()
+
+    async def fake_reply(message):  # simulate long processing
+        await asyncio.sleep(35)
+        return '{"intent_type": "TRANSACTION_SEARCH", "confidence": 0.9}'
+
+    monkeypatch.setattr(agent, "a_generate_reply", fake_reply, raising=False)
+
+    result = await agent.classify_for_team("slow request", 1)
+    assert result["intent_type"] == "UNKNOWN"
+    assert result["team_context"]["ready_for_entity_extraction"] is False
+    assert agent.error_count == 1
+
+
+def test_suggest_entities_focus_mapping():
+    agent = IntentClassifierAgent()
+    res = agent.suggest_entities_focus("BALANCE_INQUIRY", 0.9)
+    assert res["priority_entities"] == ["account"]
+    assert res["strategy"] == "account_lookup"


### PR DESCRIPTION
## Summary
- implement classify_for_team with timeout handling, caching, and team context enrichment
- add suggest_entities_focus helper for entity guidance
- add metrics counters and dedicated logging
- cover new behaviors with tests

## Testing
- `pytest tests/agents/test_intent_classifier.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0b6e001c883209026bb3d5e2d1da8