### PR TITLE
Add conversation entity models

### DIFF
--- a/conversation_service/models/__init__.py
+++ b/conversation_service/models/__init__.py
@@ -1,0 +1,5 @@
+"""Expose public models for the conversation service."""
+
+from . import requests, responses, conversation
+
+__all__ = ["requests", "responses", "conversation"]

--- a/conversation_service/models/conversation/__init__.py
+++ b/conversation_service/models/conversation/__init__.py
@@ -1,0 +1,18 @@
+"""Conversation-related data models."""
+from .entities import (
+    AmountEntity,
+    MerchantEntity,
+    DateEntity,
+    CategoryEntity,
+    TransactionTypeEntity,
+    EntitiesExtractionResult,
+)
+
+__all__ = [
+    "AmountEntity",
+    "MerchantEntity",
+    "DateEntity",
+    "CategoryEntity",
+    "TransactionTypeEntity",
+    "EntitiesExtractionResult",
+]

--- a/conversation_service/models/conversation/entities.py
+++ b/conversation_service/models/conversation/entities.py
@@ -1,0 +1,59 @@
+"""Entity models used in the conversation service."""
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, Dict, List
+
+from pydantic import BaseModel, Field
+
+
+class AmountEntity(BaseModel):
+    """Represents a monetary amount mentioned in a conversation."""
+
+    value: float
+    currency: str
+
+
+class MerchantEntity(BaseModel):
+    """Represents a merchant extracted from a conversation."""
+
+    name: str
+
+
+class DateEntity(BaseModel):
+    """Represents a date extracted from a conversation."""
+
+    date: date
+
+
+class CategoryEntity(BaseModel):
+    """Represents a transaction category extracted from a conversation."""
+
+    name: str
+
+
+class TransactionTypeEntity(BaseModel):
+    """Represents a transaction type such as credit or debit."""
+
+    transaction_type: str
+
+
+class EntitiesExtractionResult(BaseModel):
+    """Aggregates all entities extracted from a conversation."""
+
+    amounts: List[AmountEntity] = Field(default_factory=list)
+    merchants: List[MerchantEntity] = Field(default_factory=list)
+    dates: List[DateEntity] = Field(default_factory=list)
+    categories: List[CategoryEntity] = Field(default_factory=list)
+    transaction_types: List[TransactionTypeEntity] = Field(default_factory=list)
+    extraction_metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+__all__ = [
+    "AmountEntity",
+    "MerchantEntity",
+    "DateEntity",
+    "CategoryEntity",
+    "TransactionTypeEntity",
+    "EntitiesExtractionResult",
+]


### PR DESCRIPTION
## Summary
- add Pydantic models for conversation entity extraction
- expose conversation package from models via __all__

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jose')*


------
https://chatgpt.com/codex/tasks/task_e_68b125e16ee48320b1020232190a4464