### PR TITLE
Expose AutoGen prompts for entity extraction and team orchestration

### DIFF
--- a/conversation_service/prompts/autogen/__init__.py
+++ b/conversation_service/prompts/autogen/__init__.py
@@ -1,9 +1,17 @@
-"""Prompts AutoGen."""
+"""Utilitaires de prompts pour l'intégration avec AutoGen.
 
-from .entity_extraction_prompts import ENTITY_EXTRACTION_SYSTEM_MESSAGE
-from .intent_classification_prompts import AUTOGEN_INTENT_SYSTEM_MESSAGE
+Ce module rassemble les différents messages système et fonctions d'aide
+nécessaires aux agents AutoGen.
+"""
+
+from .entity_extraction_prompts import (
+    AUTOGEN_ENTITY_EXTRACTION_SYSTEM_MESSAGE,
+    get_entity_extraction_prompt_for_autogen,
+)
+from .team_orchestration_prompts import TEAM_ORCHESTRATION_PHASE2_MESSAGE
 
 __all__ = [
-    "ENTITY_EXTRACTION_SYSTEM_MESSAGE",
-    "AUTOGEN_INTENT_SYSTEM_MESSAGE",
+    "get_entity_extraction_prompt_for_autogen",
+    "AUTOGEN_ENTITY_EXTRACTION_SYSTEM_MESSAGE",
+    "TEAM_ORCHESTRATION_PHASE2_MESSAGE",
 ]

--- a/conversation_service/prompts/autogen/entity_extraction_prompts.py
+++ b/conversation_service/prompts/autogen/entity_extraction_prompts.py
@@ -1,6 +1,7 @@
 """Prompts système pour l'agent d'extraction d'entités financières AutoGen."""
 
-ENTITY_EXTRACTION_SYSTEM_MESSAGE = """Tu es un agent AutoGen spécialisé en extraction d'entités financières.
+# Message système utilisé par l'agent d'extraction.
+AUTOGEN_ENTITY_EXTRACTION_SYSTEM_MESSAGE = """Tu es un agent AutoGen spécialisé en extraction d'entités financières.
 
 Analyse chaque message utilisateur et identifie les montants, dates, marchands, catégories et types de transactions.
 
@@ -70,3 +71,28 @@ Exemples :
   \"team_context\": {}
 }
 """
+
+
+def get_entity_extraction_prompt_for_autogen(
+    user_message: str, intent_type: str
+) -> str:
+    """Construit le prompt d'extraction pour l'agent AutoGen.
+
+    Parameters
+    ----------
+    user_message:
+        Message fourni par l'utilisateur.
+    intent_type:
+        Intention détectée par l'agent de classification.
+
+    Returns
+    -------
+    str
+        Prompt formaté à transmettre à l'agent d'extraction.
+    """
+
+    return f"INTENT: {intent_type}\nUSER_MESSAGE: {user_message}"
+
+
+# Alias conservé pour compatibilité rétroactive
+ENTITY_EXTRACTION_SYSTEM_MESSAGE = AUTOGEN_ENTITY_EXTRACTION_SYSTEM_MESSAGE

--- a/conversation_service/prompts/autogen/team_orchestration_prompts.py
+++ b/conversation_service/prompts/autogen/team_orchestration_prompts.py
@@ -1,0 +1,3 @@
+"""Prompts système pour l'orchestration d'équipe AutoGen."""
+
+TEAM_ORCHESTRATION_PHASE2_MESSAGE = "Tu es l'orchestrateur de la phase 2. Coordonne les agents pour mener à bien la tâche."


### PR DESCRIPTION
## Summary
- document autogen prompt package and re-export key constants
- add entity extraction helper and system message
- add phase 2 team orchestration message

## Testing
- `pytest tests/agents/test_intent_classifier.py::test_classify_for_team_success -q`
- `pytest tests/agents/financial/test_entity_extractor_agent.py::test_amount_extraction -q`


------
https://chatgpt.com/codex/tasks/task_e_68b135fb812883209f303ec4d91b1e12