### PR TITLE
feat: expose FinancialAnalysisTeam in teams package

### DIFF
--- a/conversation_service/teams/__init__.py
+++ b/conversation_service/teams/__init__.py
@@ -1,0 +1,15 @@
+"""Package des équipes pour le service de conversation.
+
+Ce module fournit un point d'entrée unique pour accéder aux différentes
+équipes disponibles. Actuellement, seule `FinancialAnalysisTeam` est
+exposée publiquement.
+"""
+
+from __future__ import annotations
+
+try:
+    from .financial_analysis_team import FinancialAnalysisTeam  # pragma: no cover
+except ModuleNotFoundError:  # pragma: no cover - impl optionnelle absente
+    FinancialAnalysisTeam = None  # type: ignore[assignment]
+
+__all__ = ["FinancialAnalysisTeam"]


### PR DESCRIPTION
## Summary
- document conversation_service.teams package
- export `FinancialAnalysisTeam` via `__all__`

## Testing
- `pytest tests/autogen_core/test_runtime.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jose')*


------
https://chatgpt.com/codex/tasks/task_e_68b13cec66d48320b5e96a3c3b7d541b