### PR TITLE
Add AutogenConversationResponse model

### DIFF
--- a/conversation_service/models/responses/__init__.py
+++ b/conversation_service/models/responses/__init__.py
@@ -1,0 +1,1 @@
+from .autogen_conversation_response import AutogenConversationResponse

--- a/conversation_service/models/responses/autogen_conversation_response.py
+++ b/conversation_service/models/responses/autogen_conversation_response.py
@@ -1,0 +1,10 @@
+from typing import Any, Dict
+
+from .conversation_responses import ConversationResponse
+
+
+class AutogenConversationResponse(ConversationResponse):
+    """Réponse de conversation enrichie pour les agents autogen"""
+
+    entities: Dict[str, Any] = {}
+    autogen_metadata: Dict[str, Any] = {}


### PR DESCRIPTION
## Summary
- add `AutogenConversationResponse` Pydantic model extending `ConversationResponse`
- expose new model in responses package

## Testing
- `pytest` *(fails: module attribute errors and missing dependencies)*
- `pytest tests/test_harena_intents.py`

------
https://chatgpt.com/codex/tasks/task_e_68b14da31f7c8320b9469296e5aa7400