### PR TITLE
feat: add entity extraction models

### DIFF
--- a/conversation_service/models/conversation/__init__.py
+++ b/conversation_service/models/conversation/__init__.py
@@ -1,18 +1,18 @@
 """Conversation-related data models."""
 from .entities import (
-    AmountEntity,
-    MerchantEntity,
-    DateEntity,
+    ExtractedAmount,
+    ExtractedMerchant,
+    ExtractedDate,
     CategoryEntity,
     TransactionTypeEntity,
-    EntitiesExtractionResult,
+    EntityExtractionResult,
 )
 
 __all__ = [
-    "AmountEntity",
-    "MerchantEntity",
-    "DateEntity",
+    "ExtractedAmount",
+    "ExtractedMerchant",
+    "ExtractedDate",
     "CategoryEntity",
     "TransactionTypeEntity",
-    "EntitiesExtractionResult",
+    "EntityExtractionResult",
 ]

--- a/conversation_service/models/conversation/entities.py
+++ b/conversation_service/models/conversation/entities.py
@@ -1,29 +1,58 @@
 """Entity models used in the conversation service."""
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime
 from typing import Any, Dict, List
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict, field_validator
 
 
-class AmountEntity(BaseModel):
+class ExtractedAmount(BaseModel):
     """Represents a monetary amount mentioned in a conversation."""
 
-    value: float
-    currency: str
+    value: float = Field(..., description="Montant mentionné")
+    currency: str = Field(..., description="Code devise ISO 4217")
+
+    @field_validator("currency")
+    @classmethod
+    def validate_currency(cls, v: str) -> str:
+        v = v.strip().upper()
+        if len(v) != 3:
+            raise ValueError("currency must be a 3-letter ISO code")
+        return v
+
+    model_config = ConfigDict(validate_assignment=True, extra="forbid")
 
 
-class MerchantEntity(BaseModel):
+class ExtractedMerchant(BaseModel):
     """Represents a merchant extracted from a conversation."""
 
-    name: str
+    name: str = Field(..., description="Nom du commerçant")
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("merchant name cannot be empty")
+        return v
+
+    model_config = ConfigDict(validate_assignment=True, extra="forbid")
 
 
-class DateEntity(BaseModel):
+class ExtractedDate(BaseModel):
     """Represents a date extracted from a conversation."""
 
-    date: date
+    date: date = Field(..., description="Date de la transaction")
+
+    @field_validator("date", mode="before")
+    @classmethod
+    def parse_date(cls, v: Any) -> date:
+        if isinstance(v, str):
+            return date.fromisoformat(v)
+        return v
+
+    model_config = ConfigDict(validate_assignment=True, extra="forbid")
 
 
 class CategoryEntity(BaseModel):
@@ -31,29 +60,42 @@ class CategoryEntity(BaseModel):
 
     name: str
 
+    model_config = ConfigDict(validate_assignment=True, extra="forbid")
+
 
 class TransactionTypeEntity(BaseModel):
     """Represents a transaction type such as credit or debit."""
 
     transaction_type: str
 
+    model_config = ConfigDict(validate_assignment=True, extra="forbid")
 
-class EntitiesExtractionResult(BaseModel):
+
+class EntityExtractionResult(BaseModel):
     """Aggregates all entities extracted from a conversation."""
 
-    amounts: List[AmountEntity] = Field(default_factory=list)
-    merchants: List[MerchantEntity] = Field(default_factory=list)
-    dates: List[DateEntity] = Field(default_factory=list)
+    amounts: List[ExtractedAmount] = Field(default_factory=list)
+    merchants: List[ExtractedMerchant] = Field(default_factory=list)
+    dates: List[ExtractedDate] = Field(default_factory=list)
     categories: List[CategoryEntity] = Field(default_factory=list)
     transaction_types: List[TransactionTypeEntity] = Field(default_factory=list)
     extraction_metadata: Dict[str, Any] = Field(default_factory=dict)
+    team_context: Dict[str, Any] = Field(default_factory=dict)
+    global_confidence: float = Field(0.0, ge=0.0, le=1.0)
+
+    model_config = ConfigDict(
+        json_encoders={datetime: lambda v: v.isoformat()},
+        validate_assignment=True,
+        extra="forbid",
+    )
 
 
 __all__ = [
-    "AmountEntity",
-    "MerchantEntity",
-    "DateEntity",
+    "ExtractedAmount",
+    "ExtractedMerchant",
+    "ExtractedDate",
     "CategoryEntity",
     "TransactionTypeEntity",
-    "EntitiesExtractionResult",
+    "EntityExtractionResult",
 ]
+

--- a/tests/agents/financial/test_entity_extractor_agent.py
+++ b/tests/agents/financial/test_entity_extractor_agent.py
@@ -17,15 +17,15 @@ from conversation_service.agents.financial.intent_classifier import (
 def patch_entity_models(monkeypatch):
     """Provide lightweight stand-ins for Pydantic models used in extraction."""
 
-    class AmountEntity(SimpleNamespace):
+    class ExtractedAmount(SimpleNamespace):
         def __init__(self, value: float, currency: str):
             super().__init__(value=float(value), currency=currency)
 
-    class MerchantEntity(SimpleNamespace):
+    class ExtractedMerchant(SimpleNamespace):
         def __init__(self, name: str):
             super().__init__(name=name)
 
-    class DateEntity(SimpleNamespace):
+    class ExtractedDate(SimpleNamespace):
         def __init__(self, date):
             super().__init__(date=date)
 
@@ -37,21 +37,25 @@ def patch_entity_models(monkeypatch):
         def __init__(self, transaction_type: str):
             super().__init__(transaction_type=transaction_type)
 
-    class EntitiesExtractionResult:
-        def __init__(self, extraction_metadata=None):
+    class EntityExtractionResult:
+        def __init__(
+            self, extraction_metadata=None, team_context=None, global_confidence=0.0
+        ):
             self.amounts = []
             self.merchants = []
             self.dates = []
             self.categories = []
             self.transaction_types = []
             self.extraction_metadata = extraction_metadata or {}
+            self.team_context = team_context or {}
+            self.global_confidence = global_confidence
 
-    monkeypatch.setattr(ee, "AmountEntity", AmountEntity)
-    monkeypatch.setattr(ee, "MerchantEntity", MerchantEntity)
-    monkeypatch.setattr(ee, "DateEntity", DateEntity)
+    monkeypatch.setattr(ee, "ExtractedAmount", ExtractedAmount)
+    monkeypatch.setattr(ee, "ExtractedMerchant", ExtractedMerchant)
+    monkeypatch.setattr(ee, "ExtractedDate", ExtractedDate)
     monkeypatch.setattr(ee, "CategoryEntity", CategoryEntity)
     monkeypatch.setattr(ee, "TransactionTypeEntity", TransactionTypeEntity)
-    monkeypatch.setattr(ee, "EntitiesExtractionResult", EntitiesExtractionResult)
+    monkeypatch.setattr(ee, "EntityExtractionResult", EntityExtractionResult)
 
 
 @pytest.mark.asyncio

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,6 +121,11 @@ def create_pydantic_stub():
         def decorator(func):
             return func
         return decorator
+
+    def _computed_field(*args, **kwargs):
+        def decorator(func):
+            return func
+        return decorator
     
     def _create_model(name, **fields):
         return type(name, (_BaseModel,), fields)
@@ -129,6 +134,7 @@ def create_pydantic_stub():
     pydantic_stub.Field = _Field
     pydantic_stub.field_validator = _field_validator
     pydantic_stub.model_validator = _model_validator
+    pydantic_stub.computed_field = _computed_field
     pydantic_stub.create_model = _create_model
     pydantic_stub.ConfigDict = dict
     pydantic_stub.ValidationError = type("ValidationError", (Exception,), {})


### PR DESCRIPTION
## Summary
- add ExtractedAmount, ExtractedMerchant, ExtractedDate models with validation and strict config
- combine extracted entities into EntityExtractionResult with metadata, team context and confidence
- adapt entity extractor agent and tests to new models

## Testing
- `pytest tests/agents/financial/test_entity_extractor_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b152d7b89083208d28bbfc7694fba4