### PR TITLE
feat: support AutoGen metadata in conversation responses

### DIFF
--- a/conversation_service/models/responses/autogen_conversation_response.py
+++ b/conversation_service/models/responses/autogen_conversation_response.py
@@ -1,10 +1,21 @@
-from typing import Any, Dict
+from __future__ import annotations
 
+from typing import Any, Dict, Optional, Self
+
+from conversation_service.models.conversation.entities import (
+    EntityExtractionResult,
+)
 from .conversation_responses import ConversationResponse
 
 
 class AutogenConversationResponse(ConversationResponse):
     """Réponse de conversation enrichie pour les agents autogen"""
 
-    entities: Dict[str, Any] = {}
-    autogen_metadata: Dict[str, Any] = {}
+    entities: Optional[EntityExtractionResult] = None
+    autogen_metadata: Optional[Dict[str, Any]] = None
+
+    def apply_team_results(self, team_results: Dict[str, Any]) -> Self:
+        """Applique les résultats d'équipe AutoGen à la réponse."""
+
+        self.autogen_metadata = team_results
+        return self

--- a/tests/test_autogen_conversation_response.py
+++ b/tests/test_autogen_conversation_response.py
@@ -1,0 +1,51 @@
+from datetime import datetime, timezone
+
+from conversation_service.models.responses.autogen_conversation_response import (
+    AutogenConversationResponse,
+)
+from conversation_service.models.responses.conversation_responses import (
+    IntentClassificationResult,
+    AgentMetrics,
+)
+from conversation_service.prompts.harena_intents import HarenaIntentType
+
+
+def _make_intent() -> IntentClassificationResult:
+    return IntentClassificationResult(
+        intent_type=HarenaIntentType.GREETING,
+        confidence=0.9,
+        reasoning="salutation",
+        original_message="salut",
+        category="TEST",
+        is_supported=True,
+    )
+
+
+def _make_metrics() -> AgentMetrics:
+    return AgentMetrics(
+        agent_used="test_agent",
+        model_used="test_model",
+        tokens_consumed=10,
+        processing_time_ms=1,
+        confidence_threshold_met=True,
+        cache_hit=False,
+    )
+
+
+def test_apply_team_results_updates_metadata_and_returns_self():
+    response = AutogenConversationResponse(
+        user_id=1,
+        message="hello",
+        timestamp=datetime.now(timezone.utc),
+        intent=_make_intent(),
+        agent_metrics=_make_metrics(),
+        processing_time_ms=1,
+    )
+
+    assert response.autogen_metadata is None
+
+    team_results = {"foo": "bar"}
+    returned = response.apply_team_results(team_results)
+
+    assert response.autogen_metadata == team_results
+    assert returned is response


### PR DESCRIPTION
## Summary
- extend AutogenConversationResponse with optional entities and autogen_metadata
- allow applying team results to populate metadata
- cover AutogenConversationResponse behavior with unit tests

## Testing
- `pytest tests/test_autogen_conversation_response.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b153f9954883208dfb2bc78661e07e