### PR TITLE
feat: add TeamRunResult model

### DIFF
--- a/conversation_service/models/responses/__init__.py
+++ b/conversation_service/models/responses/__init__.py
@@ -1,1 +1,9 @@
+"""Expose public response models."""
+
 from .autogen_conversation_response import AutogenConversationResponse
+from .team_run_result import TeamRunResult
+
+__all__ = [
+    "AutogenConversationResponse",
+    "TeamRunResult",
+]

--- a/conversation_service/models/responses/team_run_result.py
+++ b/conversation_service/models/responses/team_run_result.py
@@ -1,0 +1,56 @@
+"""Model for standardized team execution results."""
+from __future__ import annotations
+
+from typing import List, Optional, TYPE_CHECKING
+from pydantic import BaseModel, Field, ConfigDict, field_validator
+
+if TYPE_CHECKING:  # pragma: no cover - hints uniquement
+    from conversation_service.models.responses.conversation_responses import (
+        IntentClassificationResult,
+    )
+    from conversation_service.models.conversation.entities import (
+        EntityExtractionResult,
+    )
+
+
+class TeamRunResult(BaseModel):
+    """Résultat d'exécution d'une équipe d'agents."""
+
+    workflow_stage: str = Field(..., description="Étape atteinte du workflow")
+    intent_result: Optional[IntentClassificationResult] = Field(
+        default=None, description="Résultat de classification d'intention"
+    )
+    entities_result: Optional[EntityExtractionResult] = Field(
+        default=None, description="Résultat d'extraction d'entités"
+    )
+    workflow_success: bool = Field(
+        ..., description="Succès global du workflow"
+    )
+    coherence_validation: bool = Field(
+        ..., description="Validation de cohérence intention/entités"
+    )
+    agents_sequence: List[str] = Field(
+        default_factory=list, description="Ordre d'exécution des agents"
+    )
+    processing_time_ms: float = Field(
+        ..., ge=0, description="Temps de traitement en millisecondes"
+    )
+
+    @field_validator("workflow_stage")
+    @classmethod
+    def validate_workflow_stage(cls, v: str) -> str:
+        valid_stages = [
+            "intent_classification",
+            "entity_extraction",
+            "completed",
+        ]
+        if v not in valid_stages:
+            raise ValueError(
+                f"workflow_stage must be one of: {valid_stages}"
+            )
+        return v
+
+    model_config = ConfigDict(validate_assignment=True, extra="forbid")
+
+
+__all__ = ["TeamRunResult"]

--- a/tests/test_team_run_result.py
+++ b/tests/test_team_run_result.py
@@ -1,0 +1,43 @@
+import pytest
+import importlib.util
+from pathlib import Path
+from typing import List, Optional
+
+spec = importlib.util.spec_from_file_location(
+    "team_run_result",
+    Path(__file__).resolve().parents[1]
+    / "conversation_service/models/responses/team_run_result.py",
+)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)  # type: ignore[attr-defined]
+TeamRunResult = module.TeamRunResult
+TeamRunResult.model_rebuild(
+    _types_namespace={
+        "IntentClassificationResult": object,
+        "EntityExtractionResult": object,
+        "Optional": Optional,
+        "List": List,
+    }
+)
+
+
+def test_valid_workflow_stage():
+    result = TeamRunResult(
+        workflow_stage="intent_classification",
+        workflow_success=True,
+        coherence_validation=True,
+        agents_sequence=["IntentClassifier"],
+        processing_time_ms=123.4,
+    )
+    assert result.workflow_stage == "intent_classification"
+
+
+def test_invalid_workflow_stage():
+    with pytest.raises(ValueError):
+        TeamRunResult(
+            workflow_stage="unknown",
+            workflow_success=False,
+            coherence_validation=False,
+            agents_sequence=[],
+            processing_time_ms=0.0,
+        )


### PR DESCRIPTION
## Summary
- define `TeamRunResult` pydantic model with workflow stage validator
- expose model in responses package and cover with tests

## Testing
- `pytest tests/test_team_run_result.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi'; No module named 'jose'; No module named 'sqlalchemy'; No module named 'prometheus_client'; PydanticUserError: Error when building FieldInfo from annotated attribute)*

------
https://chatgpt.com/codex/tasks/task_e_68b154c611348320b219b6ce1e16d315