### PR TITLE
Expose conversation models at package level

### DIFF
--- a/conversation_service/models/__init__.py
+++ b/conversation_service/models/__init__.py
@@ -1,5 +1,14 @@
 """Expose public models for the conversation service."""
 
 from . import requests, responses, conversation
+from .conversation import EntityExtractionResult
+from .responses import AutogenConversationResponse, TeamRunResult
 
-__all__ = ["requests", "responses", "conversation"]
+__all__ = [
+    "requests",
+    "responses",
+    "conversation",
+    "EntityExtractionResult",
+    "AutogenConversationResponse",
+    "TeamRunResult",
+]


### PR DESCRIPTION
## Summary
- Re-export `EntityExtractionResult`, `AutogenConversationResponse`, and `TeamRunResult` via `conversation_service.models`

## Testing
- `pytest tests/test_team_run_result.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68b155fae2448320aad9f01d10514353