### PR TITLE
Add tests for autogen entity models

### DIFF
--- a/conversation_service/models/conversation/entities.py
+++ b/conversation_service/models/conversation/entities.py
@@ -1,7 +1,7 @@
 """Entity models used in the conversation service."""
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date as Date, datetime
 from typing import Any, Dict, List
 
 from pydantic import BaseModel, Field, ConfigDict, field_validator
@@ -43,13 +43,13 @@ class ExtractedMerchant(BaseModel):
 class ExtractedDate(BaseModel):
     """Represents a date extracted from a conversation."""
 
-    date: date = Field(..., description="Date de la transaction")
+    date: Date = Field(..., description="Date de la transaction")
 
     @field_validator("date", mode="before")
     @classmethod
     def parse_date(cls, v: Any) -> date:
         if isinstance(v, str):
-            return date.fromisoformat(v)
+            return Date.fromisoformat(v)
         return v
 
     model_config = ConfigDict(validate_assignment=True, extra="forbid")
@@ -82,6 +82,55 @@ class EntityExtractionResult(BaseModel):
     extraction_metadata: Dict[str, Any] = Field(default_factory=dict)
     team_context: Dict[str, Any] = Field(default_factory=dict)
     global_confidence: float = Field(0.0, ge=0.0, le=1.0)
+
+    @classmethod
+    def from_llm_response(cls, data: Dict[str, Any]) -> "EntityExtractionResult":
+        """Build an extraction result from a raw LLM response."""
+
+        entities_data = data.get("entities", [])
+        if not isinstance(entities_data, list):
+            raise ValueError("entities must be a list")
+
+        result = cls(
+            extraction_metadata=data.get("extraction_metadata", {}),
+            team_context=data.get("team_context", {}),
+            global_confidence=float(data.get("global_confidence", 0.0)),
+        )
+
+        for entity in entities_data:
+            etype = entity.get("type")
+            value = entity.get("value")
+            if etype == "amount":
+                result.amounts.append(
+                    ExtractedAmount(
+                        value=float(value),
+                        currency=entity.get("currency", ""),
+                    )
+                )
+            elif etype == "merchant":
+                result.merchants.append(ExtractedMerchant(name=str(value)))
+            elif etype == "date":
+                result.dates.append(ExtractedDate(date=value))
+            elif etype == "category":
+                result.categories.append(CategoryEntity(name=str(value)))
+            elif etype == "transaction_type":
+                result.transaction_types.append(
+                    TransactionTypeEntity(transaction_type=str(value))
+                )
+
+        return result
+
+    @classmethod
+    def create_fallback_result(
+        cls, error: str, team_context: Dict[str, Any] | None = None
+    ) -> Dict[str, Any]:
+        """Create a standardized fallback extraction result."""
+
+        return {
+            "extraction_success": False,
+            "entities": cls(extraction_metadata={"error": error}),
+            "team_context": team_context or {},
+        }
 
     model_config = ConfigDict(
         json_encoders={datetime: lambda v: v.isoformat()},

--- a/tests/models/test_autogen_models.py
+++ b/tests/models/test_autogen_models.py
@@ -1,0 +1,124 @@
+import pytest
+from datetime import datetime, timezone, date
+
+from conversation_service.models.conversation import (
+    ExtractedAmount,
+    ExtractedMerchant,
+    ExtractedDate,
+    EntityExtractionResult,
+)
+from conversation_service.models.responses.autogen_conversation_response import (
+    AutogenConversationResponse,
+)
+from conversation_service.models.responses.conversation_responses import (
+    IntentClassificationResult,
+    AgentMetrics,
+)
+from conversation_service.prompts.harena_intents import HarenaIntentType
+
+
+def _make_intent() -> IntentClassificationResult:
+    return IntentClassificationResult(
+        intent_type=HarenaIntentType.GREETING,
+        confidence=0.9,
+        reasoning="salutation",
+        original_message="salut",
+        category="TEST",
+        is_supported=True,
+    )
+
+
+def _make_metrics() -> AgentMetrics:
+    return AgentMetrics(
+        agent_used="test_agent",
+        model_used="test_model",
+        tokens_consumed=10,
+        processing_time_ms=1,
+        confidence_threshold_met=True,
+        cache_hit=False,
+    )
+
+
+# --- Entity validations ----------------------------------------------------
+
+def test_extracted_amount_valid_and_invalid_currency():
+    amt = ExtractedAmount(value=10.5, currency="eur")
+    assert amt.currency == "EUR"
+
+    with pytest.raises(ValueError):
+        ExtractedAmount(value=5, currency="EURO")
+
+
+def test_extracted_merchant_validation():
+    merchant = ExtractedMerchant(name="Amazon")
+    assert merchant.name == "Amazon"
+
+    with pytest.raises(ValueError):
+        ExtractedMerchant(name="   ")
+
+
+def test_extracted_date_parsing():
+    d = ExtractedDate(date="2024-05-20")
+    assert d.date == date(2024, 5, 20)
+
+    with pytest.raises(ValueError):
+        ExtractedDate(date="not-a-date")
+
+
+# --- EntityExtractionResult helpers ---------------------------------------
+
+def test_from_llm_response_builds_entities():
+    payload = {
+        "entities": [
+            {"type": "amount", "value": 100, "currency": "EUR"},
+            {"type": "merchant", "value": "Amazon"},
+            {"type": "date", "value": "2024-01-01"},
+            {"type": "category", "value": "Shopping"},
+            {"type": "transaction_type", "value": "DEBIT"},
+        ],
+        "extraction_metadata": {"model": "test"},
+        "team_context": {"intent": "TRANSACTION_SEARCH"},
+        "global_confidence": 0.75,
+    }
+
+    result = EntityExtractionResult.from_llm_response(payload)
+
+    assert [a.value for a in result.amounts] == [100.0]
+    assert result.merchants[0].name == "Amazon"
+    assert result.dates[0].date == date(2024, 1, 1)
+    assert result.categories[0].name == "Shopping"
+    assert result.transaction_types[0].transaction_type == "DEBIT"
+    assert result.extraction_metadata["model"] == "test"
+    assert result.team_context["intent"] == "TRANSACTION_SEARCH"
+    assert result.global_confidence == 0.75
+
+
+def test_create_fallback_result():
+    fb = EntityExtractionResult.create_fallback_result("timeout", {"foo": "bar"})
+
+    assert fb["extraction_success"] is False
+    assert isinstance(fb["entities"], EntityExtractionResult)
+    assert fb["entities"].extraction_metadata["error"] == "timeout"
+    assert fb["team_context"] == {"foo": "bar"}
+
+
+# --- AutogenConversationResponse integration -------------------------------
+
+def test_autogen_conversation_response_accepts_entities():
+    response = AutogenConversationResponse(
+        user_id=1,
+        message="hello",
+        timestamp=datetime.now(timezone.utc),
+        intent=_make_intent(),
+        agent_metrics=_make_metrics(),
+        processing_time_ms=1,
+    )
+
+    assert response.user_id == 1
+    assert response.entities is None
+
+    ent = EntityExtractionResult.from_llm_response({"entities": []})
+    response.entities = ent
+
+    assert response.entities is ent
+    assert response.intent.intent_type == HarenaIntentType.GREETING


### PR DESCRIPTION
## Summary
- add factory helpers to build `EntityExtractionResult` from LLM output or fallback
- test entity model validation and `AutogenConversationResponse` entity integration

## Testing
- `pytest tests/models/test_autogen_models.py`


------
https://chatgpt.com/codex/tasks/task_e_68b15c44aef48320bc0d4063bb84767d