### PR TITLE
refactor: centralize llm config parameters for financial agents

### DIFF
--- a/conversation_service/agents/financial/entity_extractor.py
+++ b/conversation_service/agents/financial/entity_extractor.py
@@ -54,11 +54,11 @@ class EntityExtractorAgent(AssistantAgent):
                 {
                     "model": "deepseek-chat",
                     "response_format": {"type": "json_object"},
-                    "temperature": 0.05,
-                    "max_tokens": 1500,
-                    "cache_seed": 42,
                 }
-            ]
+            ],
+            "temperature": 0.05,
+            "max_tokens": 1500,
+            "cache_seed": 42,
         }
 
     def _build_extraction_prompt(self, user_message: str, intent_type: str) -> str:

--- a/conversation_service/agents/financial/intent_classifier.py
+++ b/conversation_service/agents/financial/intent_classifier.py
@@ -51,11 +51,11 @@ class IntentClassifierAgent(AssistantAgent):
                 {
                     "model": "deepseek-chat",
                     "response_format": {"type": "json_object"},
-                    "temperature": 0.1,
-                    "max_tokens": 800,
-                    "cache_seed": 42,
                 }
-            ]
+            ],
+            "temperature": 0.1,
+            "max_tokens": 800,
+            "cache_seed": 42,
         }
 
     async def classify_for_team(self, user_message: str, user_id: int) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- move common LLM parameters out of `config_list` in financial intent and entity agents
- keep model-specific options inside `config_list`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi', 'jose', 'sqlalchemy', etc.)*
- `OPENAI_API_KEY=fake python - <<'PY' import conversation_service.agents.financial.intent_classifier as ic; import conversation_service.agents.financial.entity_extractor as ee; ic.Teachability=None; print('Instantiating IntentClassifierAgent...'); ic.IntentClassifierAgent(); print('IntentClassifierAgent instantiated.'); print('Instantiating EntityExtractorAgent...'); ee.EntityExtractorAgent(); print('EntityExtractorAgent instantiated.'); PY`

------
https://chatgpt.com/codex/tasks/task_e_68b17e959c888320ac16759a13b3fdf8