### PR TITLE
feat: expose features in conversation health

### DIFF
--- a/conversation_service/api/routes/conversation.py
+++ b/conversation_service/api/routes/conversation.py
@@ -182,6 +182,10 @@ async def conversation_health_detailed(request: Request) -> Dict[str, Any]:
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "jwt_compatible": True,
         "modes": {"legacy": True, "autogen": autogen_available},
+        "features": {
+            "intent_classification": True,
+            "entity_extraction": True,
+        },
         "health_details": {
             "total_requests": metrics.get("total_requests", 0),
             "error_rate_percent": metrics.get("error_rate_percent", 0.0),

--- a/tests/api/test_conversation_endpoint.py
+++ b/tests/api/test_conversation_endpoint.py
@@ -659,11 +659,14 @@ class TestMonitoringEndpoints:
             
             assert response.status_code == 200
             data = response.json()
-            
+
             assert data["service"] == "conversation_service"
             assert data["status"] == "healthy"
             assert "health_details" in data
-            assert "features" in data
+            assert data["features"] == {
+                "intent_classification": True,
+                "entity_extraction": True,
+            }
 
     def test_conversation_metrics_success(self, client):
         """Test récupération métriques réussie (sans authentification)"""


### PR DESCRIPTION
## Summary
- return supported features in `/conversation/health`
- test health endpoint for features field

## Testing
- `pytest tests/api/test_conversation_endpoint.py::TestMonitoringEndpoints::test_conversation_health_success`


------
https://chatgpt.com/codex/tasks/task_e_68b17f74938c8320a41354bc71d26f47